### PR TITLE
WIP: Add a way to develop Cachito using docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.env/
+.git/
+.idea/
+.pytest_cache/
+.tox/
+.vscode/
+build/
+dist/
+htmlcov/
+*.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM fedora:29
+LABEL maintainer="Factory 2.0"
+
+WORKDIR /src
+RUN dnf -y install \
+    --setopt=deltarpm=0 \
+    --setopt=install_weak_deps=false \
+    --setopt=tsflags=nodocs \
+    httpd \
+    mod_ssl \
+    python3-celery \
+    python3-flask \
+    python3-flask-migrate \
+    python3-flask-sqlalchemy \
+    python3-psycopg2 \
+    python3-mod_wsgi \
+    && dnf clean all
+COPY . .
+COPY ./docker/cachito-httpd.conf /etc/httpd/conf/httpd.conf
+RUN pip3 install . --no-deps
+EXPOSE 8080
+CMD ["/usr/sbin/httpd", "-DFOREGROUND"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include cachito/web/templates *
 recursive-include cachito/web/static *
+recursive-include cachito/web/migrations *
 include requirements.txt requirements-workers.txt LICENSE

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -1,10 +1,18 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from flask import Blueprint, jsonify
 
+from cachito.workers import tasks
+
 
 api_v1 = Blueprint('api_v1', __name__)
 
 
 @api_v1.route('/ping', methods=['GET'])
 def ping():
+    return jsonify(True)
+
+
+@api_v1.route('/ping-celery', methods=['GET'])
+def ping_celery():
+    tasks.add.delay(4, 4)
     return jsonify(True)

--- a/cachito/web/app.py
+++ b/cachito/web/app.py
@@ -7,6 +7,7 @@ from flask_migrate import Migrate
 from cachito.web.splash import splash
 from cachito.web.api_v1 import api_v1
 from cachito.web import db
+from cachito.workers.tasks import app as celery_app
 
 
 def load_config(app):
@@ -49,6 +50,10 @@ def create_app(config_obj=None):
     # Initialize the database migrations
     migrations_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'migrations')
     Migrate(app, db, directory=migrations_dir)
+
+    # Configure Celery with the broker URL defined in Flask
+    if app.config.get('CELERY_BROKER_URL'):
+        celery_app.conf.broker_url = app.config['CELERY_BROKER_URL']
 
     app.register_blueprint(splash)
     app.register_blueprint(api_v1, url_prefix='/api/v1')

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -13,6 +13,7 @@ class ProductionConfig(Config):
 
 class DevelopmentConfig(Config):
     """The development Cachito Flask configuration."""
+    SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://cachito:cachito@db:5432/cachito'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -15,6 +15,7 @@ class DevelopmentConfig(Config):
     """The development Cachito Flask configuration."""
     SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://cachito:cachito@db:5432/cachito'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
+    CELERY_BROKER_URL = 'amqp://cachito:cachito@rabbitmq:5672//'
 
 
 class TestingConfig(DevelopmentConfig):

--- a/cachito/web/manage.py
+++ b/cachito/web/manage.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import time
+
+import click
+from flask.cli import FlaskGroup
+from sqlalchemy.exc import OperationalError
+
+from cachito.web.models import db
+from cachito.web.app import create_app
+
+
+@click.group(cls=FlaskGroup, create_app=create_app)
+def cli():
+    """Manage the Cachito Flask application."""
+
+
+@cli.command(name='wait-for-db')
+def wait_for_db():
+    """Wait until database server is reachable."""
+    # The polling interval in seconds
+    poll_interval = 10
+    while True:
+        try:
+            db.engine.connect()
+        except OperationalError as e:
+            click.echo('Failed to connect to database: {}'.format(e), err=True)
+            click.echo('Sleeping for {} seconds...'.format(poll_interval))
+            time.sleep(poll_interval)
+            click.echo('Retrying...')
+        else:
+            break
+
+
+if __name__ == '__main__':
+    cli()

--- a/cachito/web/migrations/versions/initial_migration.py
+++ b/cachito/web/migrations/versions/initial_migration.py
@@ -1,0 +1,27 @@
+"""An initial migration that can be deleted when there is a real migration
+
+Revision ID: 20ed360ce0c8
+Create Date: 2019-03-28 12:48:46.214233
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20ed360ce0c8'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'request',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('request')

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import os
+
+
+class Config(object):
+    """The base Cachito Celery configuration."""
+    # Don't use the default 'celery' queue
+    task_default_queue = 'cachito'
+
+
+class ProductionConfig(Config):
+    """The production Cachito Celery configuration."""
+
+
+class DevelopmentConfig(Config):
+    """The development Cachito Celery configuration."""
+    broker_url = 'amqp://cachito:cachito@rabbitmq:5672//'
+
+
+class TestingConfig(DevelopmentConfig):
+    """The testing Cachito Celery configuration."""
+
+
+def configure_celery(celery_app):
+    """
+    Configure the Celery application instance.
+
+    :param celery.Celery celery: the Celery application instance to configure
+    """
+    config = ProductionConfig
+    prod_config_file_path = '/etc/cachito/celery.py'
+    if os.getenv('CACHITO_DEV', 'false').lower() == 'true':
+        config = DevelopmentConfig
+    elif os.getenv('CACHITO_TESTING', 'false').lower() == 'true':
+        config = TestingConfig
+    elif os.path.isfile(prod_config_file_path):
+        # Celery doesn't support importing config files that aren't part of a Python path. This is
+        # a hack taken from flask.config.from_pyfile.
+        _user_config = {}
+        with open(prod_config_file_path, mode='rb') as config_file:
+            exec(compile(config_file.read(), prod_config_file_path, 'exec'), _user_config)
+
+        # Celery doesn't support configuring from multiple objects, so this is a way for
+        # the configuration in prod_config_file_path to override the defaults in ProductionConfig
+        config = ProductionConfig()
+        for key, value in _user_config.items():
+            # The _user_config dictionary will contain the __builtins__ key, which we need to skip
+            if not key.startswith('__'):
+                setattr(config, key, value)
+
+    celery_app.config_from_object(config)

--- a/cachito/workers/tasks.py
+++ b/cachito/workers/tasks.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from celery import Celery
+
+from cachito.workers.config import configure_celery
+
+app = Celery('tasks')
+configure_celery(app)
+
+
+@app.task
+def add(x, y):
+    """Add two numbers together to prove Celery works"""
+    return x + y

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3'
+services:
+  db:
+    image: postgres:9.6
+    restart: always
+    environment:
+      POSTGRES_USER: cachito
+      POSTGRES_PASSWORD: cachito
+      POSTGRES_DB: cachito
+      POSTGRES_INITDB_ARGS: "--auth='ident' --auth='trust'"
+
+  rabbitmq:
+    image: rabbitmq:3.7-management
+    environment:
+      RABBITMQ_DEFAULT_USER: cachito
+      RABBITMQ_DEFAULT_PASS: cachito
+    ports:
+      # The RabbitMQ management console
+      - 8081:15672
+
+  cachito-api:
+    build: .
+    command:
+    - /bin/sh
+    - -c
+    - >-
+      pip3 uninstall -y cachito &&
+      python3 setup.py develop --no-deps &&
+      cachito wait-for-db &&
+      cachito db upgrade &&
+      flask-3 run --reload --host 0.0.0.0 --port 8080
+    environment:
+      FLASK_ENV: development
+      FLASK_APP: cachito/web/wsgi.py
+    volumes:
+      - ./:/src:z
+    depends_on:
+      - db
+    ports:
+      - 8080:8080
+
+  # TODO: Figure out auto-reloading of Celery workers during development
+  cachito-worker:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile-workers
+    environment:
+      CACHITO_DEV: 'true'
+    volumes:
+      - ./:/src:z
+    depends_on:
+      - cachito-api
+      - rabbitmq

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,0 +1,14 @@
+FROM fedora:29
+LABEL maintainer="Factory 2.0"
+
+WORKDIR /src
+RUN dnf -y install \
+    --setopt=deltarpm=0 \
+    --setopt=install_weak_deps=false \
+    --setopt=tsflags=nodocs \
+    python3-celery \
+    && dnf clean all
+COPY . .
+RUN pip3 install . --no-deps
+EXPOSE 8080
+CMD ["/bin/celery-3", "-A", "cachito.workers.tasks", "worker", "--loglevel=info"]

--- a/docker/cachito-httpd.conf
+++ b/docker/cachito-httpd.conf
@@ -1,0 +1,29 @@
+ServerRoot "/etc/httpd"
+PidFile /tmp/httpd.pid
+Listen 0.0.0.0:8080 http
+User apache
+Group apache
+DocumentRoot "/var/www/html"
+ErrorLog /dev/stderr
+TransferLog /dev/stdout
+LogLevel warn
+TypesConfig /etc/mime.types
+DefaultRuntimeDir /tmp
+Include conf.modules.d/*.conf
+# ServerName cachito.domain.local
+
+WSGISocketPrefix /tmp/wsgi
+WSGIDaemonProcess cachito threads=5 home=/tmp
+WSGIScriptAlias / /src/cachito/web/wsgi.py
+WSGICallableObject app
+
+<Directory /src>
+    AllowOverride None
+</Directory>
+
+<Directory /src/cachito>
+    WSGIProcessGroup cachito
+    WSGIApplicationGroup %{GLOBAL}
+
+    Require all granted
+</Directory>

--- a/requirements-workers.txt
+++ b/requirements-workers.txt
@@ -1,1 +1,1 @@
-# TODO: Add workers requirements here
+celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+celery
 Flask
 Flask-Migrate
 Flask-SQLAlchemy

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
         'web': get_requirements('requirements.txt'),
         'workers': get_requirements('requirements-workers.txt'),
     },
+    entry_points={
+        'console_scripts': ['cachito=cachito.web.manage:cli'],
+    },
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
This mostly works except for a couple issues:
* A permission denied error occurs in the Flask API container when accessing `setup.py` when the Flask API container and the Celery container both mount the source directory
* We need to add a way for Celery to automatically reload when the code changes like Flask does. StackOverflow suggests `watchdog`. This is not a blocker, but it'd be nice to have.

I also need to add unit tests, especially for the `configure_celery` function.