### PR TITLE
Set the request state after the async tasks complete

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -126,8 +126,3 @@ def create_request():
     ).delay()
 
     return flask.jsonify(request.to_json()), 201
-
-
-@api_v1.errorhandler(ValidationError)
-def handle_validation_error(e):
-    return flask.jsonify(error=str(e)), 400

--- a/cachito/web/app.py
+++ b/cachito/web/app.py
@@ -3,10 +3,13 @@ import os
 
 from flask import Flask
 from flask_migrate import Migrate
+from werkzeug.exceptions import default_exceptions
 
 from cachito.web.splash import splash
 from cachito.web.api_v1 import api_v1
 from cachito.web import db
+from cachito.web.errors import json_error
+from cachito.errors import ValidationError
 
 
 def load_config(app):
@@ -52,4 +55,9 @@ def create_app(config_obj=None):
 
     app.register_blueprint(splash)
     app.register_blueprint(api_v1, url_prefix='/api/v1')
+
+    for code in default_exceptions.keys():
+        app.register_error_handler(code, json_error)
+    app.register_error_handler(ValidationError, json_error)
+
     return app

--- a/cachito/web/errors.py
+++ b/cachito/web/errors.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from flask import jsonify
+from werkzeug.exceptions import HTTPException
+
+from cachito.errors import ValidationError
+
+
+def json_error(error):
+    """
+    Convert exceptions to JSON responses.
+
+    :param Exception error: an Exception to convert to JSON
+    :return: a Flask JSON response
+    :rtype: flask.Response
+    """
+    if isinstance(error, HTTPException):
+        if error.code == 404:
+            msg = 'The requested resource was not found'
+        else:
+            msg = error.description
+        response = jsonify({'error': msg})
+        response.status_code = error.code
+    else:
+        status_code = 500
+        if isinstance(error, ValidationError):
+            status_code = 400
+
+        response = jsonify({'error': str(error)})
+        response.status_code = status_code
+    return response

--- a/cachito/web/migrations/versions/initial_migration.py
+++ b/cachito/web/migrations/versions/initial_migration.py
@@ -33,8 +33,8 @@ def upgrade():
 
     op.create_table(
         'request_pkg_manager',
-        sa.Column('request_id', sa.Integer(), nullable=True),
-        sa.Column('pkg_manager_id', sa.Integer(), nullable=True),
+        sa.Column('request_id', sa.Integer(), nullable=False),
+        sa.Column('pkg_manager_id', sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(['pkg_manager_id'], ['package_manager.id'], ),
         sa.ForeignKeyConstraint(['request_id'], ['request.id'], )
     )

--- a/cachito/web/migrations/versions/initial_migration.py
+++ b/cachito/web/migrations/versions/initial_migration.py
@@ -44,8 +44,20 @@ def upgrade():
         {'name': 'gomod'},
     ])
 
+    op.create_table(
+        'request_state',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('state', sa.Integer(), nullable=False),
+        sa.Column('state_reason', sa.String(), nullable=False),
+        sa.Column('updated', sa.DateTime(), nullable=False),
+        sa.Column('request_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['request_id'], ['request.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
 
 def downgrade():
     op.drop_table('request_pkg_manager')
     op.drop_table('request')
     op.drop_table('package_manager')
+    op.drop_table('request_state')

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from copy import deepcopy
+from enum import Enum
+
+import sqlalchemy
 
 from cachito.errors import ValidationError
 from cachito.web import db
@@ -12,6 +15,25 @@ request_pkg_manager_table = db.Table(
 )
 
 
+class RequestStateMapping(Enum):
+    """
+    An Enum that represents the request states.
+    """
+    in_progress = 1
+    complete = 2
+    failed = 3
+
+    @classmethod
+    def get_state_names(cls):
+        """
+        Get a sorted list of valid state names.
+
+        :return: a sorted list of valid state names
+        :rtype: list
+        """
+        return sorted([state.name for state in cls])
+
+
 class Request(db.Model):
     """A Cachito user request."""
     id = db.Column(db.Integer, primary_key=True)
@@ -19,18 +41,37 @@ class Request(db.Model):
     ref = db.Column(db.String, nullable=False)
     pkg_managers = db.relationship('PackageManager', secondary=request_pkg_manager_table,
                                    backref='requests')
+    states = db.relationship(
+        'RequestState', back_populates='request', order_by='RequestState.updated')
 
     def __repr__(self):
         return '<Request {0!r}>'.format(self.id)
 
     def to_json(self):
         pkg_managers = [pkg_manager.to_json() for pkg_manager in self.pkg_managers]
-        return {
+        # Use this list comprehension instead of a RequestState.to_json method to avoid including
+        # redundant information about the request itself
+        states = [
+            {
+                'state': RequestStateMapping(state.state).name,
+                'state_reason': state.state_reason,
+                'updated': state.updated.isoformat(),
+            }
+            for state in self.states
+        ]
+        # Reverse the list since the latest states should be first
+        states = list(reversed(states))
+        latest_state = states[0]
+        rv = {
             'id': self.id,
             'repo': self.repo,
             'ref': self.ref,
             'pkg_managers': pkg_managers,
+            'state_history': states,
         }
+        # Show the latest state information in the first level of the JSON
+        rv.update(latest_state)
+        return rv
 
     @classmethod
     def from_json(cls, kwargs):
@@ -64,7 +105,27 @@ class Request(db.Model):
         except TypeError as e:
             # Handle extraneous parameters.
             raise ValidationError(str(e))
+        request.add_state('in_progress', 'The request was initiated')
         return request
+
+    def add_state(self, state, state_reason):
+        """
+        Add a RequestState associated with the current request.
+
+        :param str state: the state name
+        :param str state_reason: the reason explaining the state transition
+        :raises ValidationError: if the state is invalid
+        """
+        try:
+            state_int = RequestStateMapping.__members__[state].value
+        except KeyError:
+            raise ValidationError(
+                'The state "{}" is invalid. It must be one of: {}.'
+                .format(state, ', '.join(RequestStateMapping.get_state_names()))
+            )
+
+        request_state = RequestState(state=state_int, state_reason=state_reason)
+        self.states.append(request_state)
 
 
 class PackageManager(db.Model):
@@ -77,3 +138,16 @@ class PackageManager(db.Model):
     @classmethod
     def from_json(cls, name):
         return cls(name=name)
+
+
+class RequestState(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    state = db.Column(db.Integer, nullable=False)
+    state_reason = db.Column(db.String, nullable=False)
+    updated = db.Column(db.DateTime(), nullable=False, default=sqlalchemy.func.now())
+    request_id = db.Column(db.Integer, db.ForeignKey('request.id'), nullable=False)
+    request = db.relationship('Request', back_populates='states')
+
+    def __repr__(self):
+        return '<RequestState id={} state="{}" request_id={}>'.format(
+            self.id, RequestStateMapping(self.state).name, self.request_id)

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -7,8 +7,8 @@ from cachito.web import db
 
 request_pkg_manager_table = db.Table(
     'request_pkg_manager',
-    db.Column('request_id', db.Integer, db.ForeignKey('request.id')),
-    db.Column('pkg_manager_id', db.Integer, db.ForeignKey('package_manager.id'))
+    db.Column('request_id', db.Integer, db.ForeignKey('request.id'), nullable=False),
+    db.Column('pkg_manager_id', db.Integer, db.ForeignKey('package_manager.id'), nullable=False)
 )
 
 

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -23,6 +23,7 @@ class DevelopmentConfig(Config):
 
     broker_url = 'amqp://cachito:cachito@rabbitmq:5672//'
     athens_url = 'http://athens:3000'
+    cachito_api_url = 'http://cachito-api:8080/api/v1/'
     cachito_archives_dir = os.path.join(tempfile.gettempdir(), 'cachito-archives')
     cachito_shared_dir = os.path.join(tempfile.gettempdir(), 'cachito-shared')
     cachito_log_level = 'DEBUG'
@@ -33,6 +34,7 @@ class DevelopmentConfig(Config):
 
 class TestingConfig(DevelopmentConfig):
     """The testing Cachito Celery configuration."""
+    cachito_api_url = 'http://cachito.domain.local/api/v1/'
 
 
 def configure_celery(celery_app):
@@ -83,6 +85,9 @@ def validate_celery_config(conf, **kwargs):
             raise ConfigError(
                 f'The configuration "{required_dir_conf}" must be set to an existing directory'
             )
+
+    if not conf.get('cachito_api_url'):
+        raise ConfigError('The configuration "cachito_api_url" must be set')
 
 
 def get_worker_config():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,19 @@ from cachito.web.wsgi import create_app
 
 
 @pytest.fixture(scope='session')
-def app():
+def app(request):
     """Return Flask application for the pytest session."""
-    return create_app('cachito.web.config.TestingConfig')
+    app = create_app('cachito.web.config.TestingConfig')
+    # Establish an application context before running the tests. This allows the use of
+    # Flask-SQLAlchemy in the test setup.
+    ctx = app.app_context()
+    ctx.push()
+
+    def teardown():
+        ctx.pop()
+
+    request.addfinalizer(teardown)
+    return app
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -42,6 +42,8 @@ def test_create_and_fetch_request(mock_chain, client, db):
     fetched_request = json.loads(rv.data.decode('utf-8'))
 
     assert created_request == fetched_request
+    assert fetched_request['state'] == 'in_progress'
+    assert fetched_request['state_reason'] == 'The request was initiated'
 
 
 @mock.patch('cachito.web.api_v1.chain')

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -8,7 +8,10 @@ from unittest import mock
 import pytest
 
 from cachito.web.models import Request
-from cachito.workers.tasks import fetch_app_source, fetch_gomod_source, assemble_source_code_archive
+from cachito.workers.tasks import (
+    fetch_app_source, fetch_gomod_source, assemble_source_code_archive, set_request_state,
+    failed_request_callback
+)
 
 
 def test_ping(client):
@@ -30,11 +33,15 @@ def test_create_and_fetch_request(mock_chain, client, db):
     for key, expected_value in data.items():
         assert expected_value == created_request[key]
 
+    error_callback = failed_request_callback.s(1)
     mock_chain.assert_called_once_with(
         fetch_app_source.s(
             'https://github.com/release-engineering/retrodep.git',
-            'c50b93a32df1c9d700e3e80996845bc2e13be848'),
-        fetch_gomod_source.s()
+            'c50b93a32df1c9d700e3e80996845bc2e13be848',
+            request_id_to_update=1,
+        ).on_error(error_callback),
+        fetch_gomod_source.s(request_id_to_update=1).on_error(error_callback),
+        set_request_state.si(1, 'complete', 'Completed successfully'),
     )
 
     request_id = created_request['id']

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -104,6 +104,8 @@ def test_missing_request(client, db):
 def test_malformed_request_id(client, db):
     rv = client.get('/api/v1/requests/spam')
     assert rv.status_code == 404
+    data = json.loads(rv.data.decode('utf-8'))
+    assert data == {'error': 'The requested resource was not found'}
 
 
 @pytest.mark.parametrize('removed_params', (

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -37,6 +37,7 @@ def test_validate_celery_config(mock_isdir):
     celery_app = celery.Celery()
     celery_app.conf.cachito_archives_dir = '/tmp/some-path'
     celery_app.conf.cachito_shared_dir = '/tmp/some-other-path'
+    celery_app.conf.cachito_api_url = 'http://cachito-api/api/v1/'
     validate_celery_config(celery_app.conf)
     assert mock_isdir.call_count == 2
     mock_isdir.assert_any_call(celery_app.conf.cachito_shared_dir)

--- a/tests/test_workers/test_tasks.py
+++ b/tests/test_workers/test_tasks.py
@@ -11,13 +11,20 @@ from cachito.errors import CachitoError
 from cachito.workers import tasks
 
 
+@pytest.mark.parametrize('request_id_to_update', (None, 1))
+@mock.patch('cachito.workers.tasks.set_request_state')
 @mock.patch('cachito.workers.tasks.Git')
-def test_fetch_app_source(mock_git):
+def test_fetch_app_source(mock_git, mock_set_request_state, request_id_to_update):
     url = 'https://github.com/release-engineering/retrodep.git'
     ref = 'c50b93a32df1c9d700e3e80996845bc2e13be848'
-    tasks.fetch_app_source(url, ref)
+    tasks.fetch_app_source(url, ref, request_id_to_update=request_id_to_update)
     mock_git.assert_called_once_with(url, ref)
     mock_git.return_value.fetch_source.assert_called_once_with()
+    if request_id_to_update:
+        mock_set_request_state.assert_called_once_with(
+            1, 'in_progress', 'Fetching the application source')
+    else:
+        mock_set_request_state.assert_not_called()
 
 
 @mock.patch('cachito.workers.tasks.Git')
@@ -27,6 +34,19 @@ def test_fetch_app_source_request_timed_out(mock_git):
     mock_git.return_value.fetch_source.side_effect = Timeout('The request timed out')
     with pytest.raises(CachitoError, match='The connection timed out while downloading the source'):
         tasks.fetch_app_source(url, ref)
+
+
+@pytest.mark.parametrize('request_id_to_update', (None, 1))
+@mock.patch('cachito.workers.tasks.set_request_state')
+@mock.patch('cachito.workers.tasks.resolve_gomod_deps')
+def test_fetch_gomod_source(mock_resolve_gomod_deps, mock_set_request_state, request_id_to_update):
+    app_archive_path = 'path/to/archive.tar.gz'
+    tasks.fetch_gomod_source(app_archive_path, request_id_to_update=request_id_to_update)
+    if request_id_to_update:
+        mock_set_request_state.assert_called_once_with(
+            1, 'in_progress', 'Fetching the golang dependencies')
+    else:
+        mock_set_request_state.assert_not_called()
 
 
 @mock.patch('cachito.workers.tasks.get_worker_config')
@@ -75,3 +95,42 @@ def test_assemble_archive_bundle(mock_get_worker_config, tmpdir):
             bundle_archive.getmember(expected_member)
         for expected_member in list(deps_archive_contents.keys()):
             bundle_archive.getmember(os.path.join('deps', expected_member))
+
+
+@mock.patch('cachito.workers.tasks.requests')
+def test_set_request_state(mock_requests):
+    mock_requests.patch.return_value.ok = True
+    tasks.set_request_state(1, 'complete', 'Completed successfully')
+    expected_payload = {'state': 'complete', 'state_reason': 'Completed successfully'}
+    mock_requests.patch.assert_called_once_with(
+        'http://cachito.domain.local/api/v1/requests/1', json=expected_payload, timeout=30)
+
+
+@mock.patch('cachito.workers.tasks.requests.patch')
+def test_set_request_state_connection_failed(mock_requests_patch):
+    mock_requests_patch.side_effect = Timeout('The request timed out')
+    expected = 'The connection failed when setting the state to "complete" on request 1'
+    with pytest.raises(CachitoError, match=expected):
+        tasks.set_request_state(1, 'complete', 'Completed successfully')
+
+
+@mock.patch('cachito.workers.tasks.requests')
+def test_set_request_state_bad_status_code(mock_requests):
+    mock_requests.patch.return_value.ok = False
+    expected = 'Setting the state to "complete" on request 1 failed'
+    with pytest.raises(CachitoError, match=expected):
+        tasks.set_request_state(1, 'complete', 'Completed successfully')
+
+
+@mock.patch('cachito.workers.tasks.set_request_state')
+def test_failed_request_callback(mock_set_request_state):
+    exc = CachitoError('some error')
+    tasks.failed_request_callback(None, exc, None, 1)
+    mock_set_request_state.assert_called_once_with(1, 'failed', 'some error')
+
+
+@mock.patch('cachito.workers.tasks.set_request_state')
+def test_failed_request_callback_not_cachitoerror(mock_set_request_state):
+    exc = ValueError('some error')
+    tasks.failed_request_callback(None, exc, None, 1)
+    mock_set_request_state.assert_called_once_with(1, 'failed', 'An unknown error occurred')


### PR DESCRIPTION
This also:
* Handles all default Flask HTTP exceptions and returns them as JSON
* Doesn't allow the columns in the request_pkg_manager association table to be null