### PR TITLE
Add support for user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,14 @@ Custom configuration for the API:
 * `CACHITO_SHARED_DIR` - the directory for short-term storage of bundled source archives. This
     configuration is required, and the directory must already exist and be writeable. The
     underlying volume must also be available in the workers.
+* `CACHITO_WORKER_USERNAMES` - the list of usernames without the realm that are allowed to
+    use the `/requests/<id>` patch endpoint. The workers use this to update the request
+    state.
+* `LOGIN_DISABLED` - disables authentication requirements.
 * `MAX_PER_PAGE` - the maximum amount of items in a page for paginated results.
+
+
+If you are planning to deploy Cachito with authentication enabled, you'll need to use
+a web server that supplies the `REMOTE_USER` environment variable when the user is
+properly authenticated. A common deployment option is using httpd (Apache web server)
+with the `mod_auth_gssapi` module.

--- a/cachito/web/app.py
+++ b/cachito/web/app.py
@@ -2,9 +2,11 @@
 import os
 
 from flask import Flask
+from flask_login import LoginManager
 from flask_migrate import Migrate
 from werkzeug.exceptions import default_exceptions
 
+from cachito.web.auth import user_loader, load_user_from_request
 from cachito.web.splash import splash
 from cachito.web.api_v1 import api_v1
 from cachito.web import db
@@ -52,6 +54,11 @@ def create_app(config_obj=None):
     # Initialize the database migrations
     migrations_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'migrations')
     Migrate(app, db, directory=migrations_dir)
+    # Initialize Flask Login
+    login_manager = LoginManager()
+    login_manager.init_app(app)
+    login_manager.user_loader(user_loader)
+    login_manager.request_loader(load_user_from_request)
 
     app.register_blueprint(splash)
     app.register_blueprint(api_v1, url_prefix='/api/v1')

--- a/cachito/web/auth.py
+++ b/cachito/web/auth.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+
+from flask import current_app
+
+from cachito.web import db
+from cachito.web.models import User
+
+
+log = logging.getLogger(__name__)
+
+
+def user_loader(username):
+    """
+    Get the user by their username from the database.
+
+    This is used by the Flask-Login library.
+
+    :param str username: the username of the user
+    :return: the User object associated with the username or None
+    :rtype: cachito.web.models.User
+    """
+    return User.query.filter_by(username=username).first()
+
+
+def load_user_from_request(request):
+    """
+    Load the user that authenticated from the current request.
+
+    When authentication is turned on (default in production), this relies on the "REMOTE_USER"
+    environment variable being set. This is usually set by the mod_auth_gssapi Apache authentication
+    module.
+
+    This is used by the Flask-Login library. If the user does not exist in the database, an entry
+    will be created.
+
+    If None is returned, then Flask-Login will set `flask_login.current_user` to an
+    `AnonymousUserMixin` object, which has the `is_authenticated` property set to `False`.
+    Additionally, any route decorated with `@login_required` will raise an `Unauthorized` exception.
+
+    :param flask.Request request: the Flask request
+    :return: the User object associated with the username or None
+    :rtype: cachito.web.models.User
+    """
+    remote_user = request.environ.get('REMOTE_USER')
+    if not remote_user:
+        if current_app.config.get('LOGIN_DISABLED', False) is True:
+            log.info(
+                'The REMOTE_USER environment variable wasn\'t set on the request, but the '
+                'LOGIN_DISABLED configuration is set to True.'
+            )
+        return
+
+    # Convert the username to lower-case for consistency
+    username = remote_user.lower()
+    log.info(f'The user "{username}" was authenticated successfully by httpd')
+
+    user = User.query.filter_by(username=username).first()
+    if not user:
+        user = User(username=username)
+        db.session.add(user)
+        db.session.commit()
+
+    return user

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -9,6 +9,7 @@ class Config(object):
     """The base Cachito Flask configuration."""
     CACHITO_WAIT_TIMEOUT = 120  # Seconds
     MAX_PER_PAGE = 100
+    CACHITO_WORKER_USERNAMES = []
 
 
 class ProductionConfig(Config):
@@ -21,14 +22,17 @@ class DevelopmentConfig(Config):
     SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://cachito:cachito@db:5432/cachito'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
     CACHITO_SHARED_DIR = os.path.join(tempfile.gettempdir(), 'cachito-shared')
+    LOGIN_DISABLED = True
 
 
 class TestingConfig(DevelopmentConfig):
     """The testing Cachito Flask configuration."""
+    CACHITO_WORKER_USERNAMES = ['worker@domain.local']
     # IMPORTANT: don't use in-memory sqlite. Alembic migrations will create a new
     # connection producing a new instance of the database which is deleted immediately
     # after the migration completes...
     #   https://github.com/miguelgrinberg/Flask-Migrate/issues/153
     SQLALCHEMY_DATABASE_URI = f'sqlite:///{TEST_DB_FILE}'
     DEBUG = True
+    LOGIN_DISABLED = False
     TESTING = True

--- a/cachito/web/migrations/versions/initial_migration.py
+++ b/cachito/web/migrations/versions/initial_migration.py
@@ -24,11 +24,21 @@ def upgrade():
     )
 
     op.create_table(
+        'user',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('username', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('username'),
+    )
+
+    op.create_table(
         'request',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('repo', sa.String(), nullable=False),
         sa.Column('ref', sa.String(), nullable=False),
-        sa.PrimaryKeyConstraint('id')
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
     )
 
     op.create_table(

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -81,6 +81,13 @@ class Request(db.Model):
         if missing_params:
             raise ValidationError('Missing required parameter(s): {}'
                                   .format(', '.join(missing_params)))
+
+        # Don't allow the user to set arbitrary columns or relationships
+        invalid_params = set(kwargs.keys() - required_params)
+        if invalid_params:
+            raise ValidationError(
+                'The following parameters are invalid: {}'.format(', '.join(invalid_params)))
+
         kwargs = deepcopy(kwargs)
 
         # Validate package managers are correctly provided
@@ -100,11 +107,7 @@ class Request(db.Model):
 
         kwargs['pkg_managers'] = found_pkg_managers
 
-        try:
-            request = cls(**kwargs)
-        except TypeError as e:
-            # Handle extraneous parameters.
-            raise ValidationError(str(e))
+        request = cls(**kwargs)
         request.add_state('in_progress', 'The request was initiated')
         return request
 

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -7,9 +7,11 @@ RUN dnf -y install \
     --setopt=install_weak_deps=false \
     --setopt=tsflags=nodocs \
     httpd \
+    mod_auth_gssapi \
     mod_ssl \
     python3-celery \
     python3-flask \
+    python3-flask-login \
     python3-flask-migrate \
     python3-flask-sqlalchemy \
     python3-mod_wsgi \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 celery
 Flask
+flask-login
 Flask-Migrate
 Flask-SQLAlchemy
 psycopg2-binary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,11 @@ def app(request):
 
 
 @pytest.fixture(scope='session')
+def auth_env():
+    return {'REMOTE_USER': 'tbrady@DOMAIN.LOCAL'}
+
+
+@pytest.fixture(scope='session')
 def client(app):
     """Return Flask application client for the pytest session."""
     return app.test_client()
@@ -44,3 +49,8 @@ def db(app, tmpdir):
         flask_migrate.upgrade()
 
     return _db
+
+
+@pytest.fixture(scope='session')
+def worker_auth_env():
+    return {'REMOTE_USER': 'worker@DOMAIN.LOCAL'}

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -88,7 +88,7 @@ def test_fetch_paginated_requests(mock_chain, client, db):
         assert request['repo'] == repo_template.format(repo_number)
 
 
-def test_create_and_fetch_request_invalid_ref(client, db):
+def test_create_request_invalid_ref(client, db):
     data = {
         'repo': 'https://github.com/release-engineering/retrodep.git',
         'ref': 'not-a-ref',

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -101,6 +101,20 @@ def test_create_and_fetch_request_invalid_ref(client, db):
     assert error['error'] == 'The "ref" parameter must be a 40 character hex string'
 
 
+def test_create_request_invalid_parameter(client, db):
+    data = {
+        'repo': 'https://github.com/release-engineering/retrodep.git',
+        'ref': 'c50b93a32df1c9d700e3e80996845bc2e13be848',
+        'pkg_managers': ['gomod'],
+        'user': 'uncle_sam',
+    }
+
+    rv = client.post('/api/v1/requests', json=data)
+    assert rv.status_code == 400
+    error = json.loads(rv.data.decode('utf-8'))
+    assert error['error'] == 'The following parameters are invalid: user'
+
+
 def test_missing_request(client, db):
     rv = client.get('/api/v1/requests/1')
     assert rv.status_code == 404
@@ -150,8 +164,7 @@ def test_validate_extraneous_params(client, db):
     rv = client.post('/api/v1/requests', json=data)
     assert rv.status_code == 400
     error_msg = json.loads(rv.data.decode('utf-8'))['error']
-    assert 'invalid keyword argument' in error_msg
-    assert 'spam' in error_msg
+    assert error_msg == 'The following parameters are invalid: spam'
 
 
 @mock.patch('tempfile.TemporaryDirectory')


### PR DESCRIPTION
This implementation relies on a web server that supplies the `REMOTE_USER` environment variable when the user is properly authenticated. A common deployment option is using httpd (Apache web server) with the `mod_auth_gssapi` module.

This also includes a couple commits that are logically separate but related.