### PR TITLE
Remove the ping API endpoints

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -15,17 +15,6 @@ from cachito.workers import tasks
 api_v1 = flask.Blueprint('api_v1', __name__)
 
 
-@api_v1.route('/ping', methods=['GET'])
-def ping():
-    return flask.jsonify(True)
-
-
-@api_v1.route('/ping-celery', methods=['GET'])
-def ping_celery():
-    tasks.add.delay(4, 4)
-    return flask.jsonify(True)
-
-
 @api_v1.route('/requests', methods=['GET'])
 def get_requests():
     """

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -14,11 +14,6 @@ from cachito.workers.tasks import (
 )
 
 
-def test_ping(client):
-    rv = client.get('/api/v1/ping')
-    assert json.loads(rv.data.decode('utf-8')) is True
-
-
 @mock.patch('cachito.web.api_v1.chain')
 def test_create_and_fetch_request(mock_chain, client, db):
     data = {


### PR DESCRIPTION
These were originally used to test everything was working in our development environment when the project was first created. We are past this point, and they can be removed now.