### PR TITLE
Document usage of master container registry tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Cachito container images are automatically built when changes are merged. There 
 an httpd based image with the Cachito API, and a Celery worker image with the Cachito worker code.
 
 [![cachito-api](https://quay.io/repository/factory2/cachito-api/status)](https://quay.io/repository/factory2/cachito-api)
-  `quay.io/factory2/cachito-api:latest`
+  `quay.io/factory2/cachito-api:master`
 
 [![cachito-worker](https://quay.io/repository/factory2/cachito-worker/status)](https://quay.io/repository/factory2/cachito-worker)
-  `quay.io/factory2/cachito-worker:latest`
+  `quay.io/factory2/cachito-worker:master`
 
 ## Prerequisites
 


### PR DESCRIPTION
Quay is supposed to tag images as latest if it's building from the
default branch, i.e. master. This is currently not happening when a
custom git build trigger is used. A PR has been filed to fix this
behavior. If/when approved and deployed, we should revert this commit.

Quay is currently closed source so not all will have access to its
private repo:
    https://github.com/quay/quay/pull/3530

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>