### PR TITLE
Add a workaround to support Celery 4.2 on Python 3.7

### DIFF
--- a/cachito/workers/tasks/celery.py
+++ b/cachito/workers/tasks/celery.py
@@ -1,10 +1,19 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from celery import Celery
+import sys
+
+import celery
 from celery.signals import celeryd_init
 
 from cachito.workers.config import configure_celery, validate_celery_config
 
 
-app = Celery(include=['cachito.workers.tasks.general', 'cachito.workers.tasks.golang'])
+# Workaround https://github.com/celery/celery/issues/5416
+if celery.version_info < (4, 3) and sys.version_info >= (3, 7):  # pragma: no cover
+    from re import Pattern
+    from celery.app.routes import re as routes_re
+    routes_re._pattern_type = Pattern
+
+
+app = celery.Celery(include=['cachito.workers.tasks.general', 'cachito.workers.tasks.golang'])
 configure_celery(app)
 celeryd_init.connect(validate_celery_config)


### PR DESCRIPTION
This is needed since Fedora 30 still has Celery 4.2.

See https://bugzilla.redhat.com/show_bug.cgi?id=1733610.