### PR TITLE
Revert "Document usage of master container registry tag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Cachito container images are automatically built when changes are merged. There 
 an httpd based image with the Cachito API, and a Celery worker image with the Cachito worker code.
 
 [![cachito-api](https://quay.io/repository/factory2/cachito-api/status)](https://quay.io/repository/factory2/cachito-api)
-  `quay.io/factory2/cachito-api:master`
+  `quay.io/factory2/cachito-api:latest`
 
 [![cachito-worker](https://quay.io/repository/factory2/cachito-worker/status)](https://quay.io/repository/factory2/cachito-worker)
-  `quay.io/factory2/cachito-worker:master`
+  `quay.io/factory2/cachito-worker:latest`
 
 ## Prerequisites
 


### PR DESCRIPTION
This reverts commit f8a0f4226b0f01baaedfb124bb8c81a134af7373.