### PR TITLE
Create the bundle in the archives dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,14 @@ Custom configuration for the Celery workers are listed below:
   endpoints. If this value is `None`, authentication will not be used. This defaults to `kerberos`
   in production.
 * `cachito_log_level` - the log level to configure the workers with (e.g. `DEBUG`, `INFO`, etc.).
-* `cachito_shared_dir` - the directory for short-term storage of bundled source archives. This
-    configuration is required, and the directory must already exist and be writeable. The
-    underlying volume must also be available in the API.
 
 ## Configuring the API
 
 Custom configuration for the API:
 
+* `CACHITO_ARCHIVES_DIR` - the root of the archives directory that is also accessible by the
+  workers. This is used to download the bundle archives created by the workers.
 * `CACHITO_MAX_PER_PAGE` - the maximum amount of items in a page for paginated results.
-* `CACHITO_SHARED_DIR` - the directory for short-term storage of bundled source archives. This
-    configuration is required, and the directory must already exist and be writeable. The
-    underlying volume must also be available in the workers.
-* `CACHITO_WAIT_TIMEOUT` - the timeout used for waiting for a synchronous task to complete.
 * `CACHITO_WORKER_USERNAMES` - the list of usernames without the realm that are allowed to
     use the `/requests/<id>` patch endpoint. The workers use this to update the request
     state.

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -7,7 +7,6 @@ TEST_DB_FILE = os.path.join(tempfile.gettempdir(), 'cachito.db')
 
 class Config(object):
     """The base Cachito Flask configuration."""
-    CACHITO_WAIT_TIMEOUT = 120  # Seconds
     CACHITO_MAX_PER_PAGE = 100
     CACHITO_WORKER_USERNAMES = []
 
@@ -21,7 +20,7 @@ class DevelopmentConfig(Config):
     """The development Cachito Flask configuration."""
     SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://cachito:cachito@db:5432/cachito'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
-    CACHITO_SHARED_DIR = os.path.join(tempfile.gettempdir(), 'cachito-shared')
+    CACHITO_ARCHIVES_DIR = os.path.join(tempfile.gettempdir(), 'cachito-archives')
     LOGIN_DISABLED = True
 
 

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from copy import deepcopy
 from enum import Enum
+import os
 
+import flask
 from flask_login import UserMixin, current_user
 import sqlalchemy
 
@@ -104,6 +106,17 @@ class Request(db.Model):
 
     def __repr__(self):
         return '<Request {0!r}>'.format(self.id)
+
+    @property
+    def bundle_archive(self):
+        """
+        Get the path to the request's bundle archive.
+
+        :return: the path to the request's bundle archive
+        :rtype: str
+        """
+        cachito_archives_dir = flask.current_app.config['CACHITO_ARCHIVES_DIR']
+        return os.path.join(cachito_archives_dir, 'cachito_bundles', f'{self.id}.tar.gz')
 
     def to_json(self):
         pkg_managers = [pkg_manager.to_json() for pkg_manager in self.pkg_managers]

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -33,6 +33,7 @@ class RequestStateMapping(Enum):
     in_progress = 1
     complete = 2
     failed = 3
+    stale = 4
 
     @classmethod
     def get_state_names(cls):
@@ -200,6 +201,9 @@ class Request(db.Model):
         :param str state_reason: the reason explaining the state transition
         :raises ValidationError: if the state is invalid
         """
+        if self.last_state and self.last_state.state_name == 'stale' and state != 'stale':
+            raise ValidationError('A stale request cannot change states')
+
         try:
             state_int = RequestStateMapping.__members__[state].value
         except KeyError:

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -57,7 +57,6 @@ class DevelopmentConfig(Config):
     cachito_api_url = 'http://cachito-api:8080/api/v1/'
     cachito_archives_dir = os.path.join(tempfile.gettempdir(), 'cachito-archives')
     cachito_athens_url = 'http://athens:3000'
-    cachito_shared_dir = os.path.join(tempfile.gettempdir(), 'cachito-shared')
     cachito_log_level = 'DEBUG'
 
 
@@ -77,9 +76,8 @@ def configure_celery(celery_app):
     if os.getenv('CACHITO_DEV', '').lower() == 'true':
         config = DevelopmentConfig
         # When in development mode, create required directories for the user
-        for dirname in (config.cachito_archives_dir, config.cachito_shared_dir):
-            if not os.path.isdir(dirname):
-                os.mkdir(dirname)
+        if not os.path.isdir(config.cachito_archives_dir):
+            os.mkdir(config.cachito_archives_dir)
     elif os.getenv('CACHITO_TESTING', 'false').lower() == 'true':
         config = TestingConfig
     elif os.path.isfile(prod_config_file_path):
@@ -108,12 +106,11 @@ def validate_celery_config(conf, **kwargs):
     :param celery.app.utils.Settings conf: the Celery application configuration to validate
     :raises ConfigError: if the configuration is invalid
     """
-    for required_dir_conf in ('cachito_archives_dir', 'cachito_shared_dir'):
-        required_dir = conf.get(required_dir_conf)
-        if not required_dir or not os.path.isdir(required_dir):
-            raise ConfigError(
-                f'The configuration "{required_dir_conf}" must be set to an existing directory'
-            )
+    archives_dir = conf.get('cachito_archives_dir')
+    if not archives_dir or not os.path.isdir(archives_dir):
+        raise ConfigError(
+            f'The configuration "cachito_archives_dir" must be set to an existing directory'
+        )
 
     if not conf.get('cachito_api_url'):
         raise ConfigError('The configuration "cachito_api_url" must be set')

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import os
-import tarfile
 
 import requests
 
@@ -12,7 +10,6 @@ from cachito.workers.tasks.celery import app
 
 
 __all__ = [
-    'assemble_source_code_archive',
     'failed_request_callback',
     'fetch_app_source',
     'set_request_state',
@@ -44,30 +41,6 @@ def fetch_app_source(url, ref, request_id_to_update=None):
         raise
 
     return scm.archive_path
-
-
-@app.task
-def assemble_source_code_archive(app_archive_path, deps_path, bundle_archive_path):
-    """
-    Creates an archive with the source code for application and its dependencies.
-
-    :param str app_archive_path: the path to the archive of the application source code
-    :param str deps_path: the path to the directory containing the dependencies source code
-    :param str bundle_archive_path: the destination path of the assembled archive
-    """
-    log.info('Assembling source code archive in "%s"', bundle_archive_path)
-    cachito_shared_dir = get_worker_config().cachito_shared_dir
-    absolute_app_archive_path = os.path.join(cachito_shared_dir, app_archive_path)
-    absolute_deps_path = os.path.join(cachito_shared_dir, deps_path)
-    bundle_archive_path = os.path.join(cachito_shared_dir, bundle_archive_path)
-
-    # Generate a tarball containing the application and dependencies source code
-    with tarfile.open(bundle_archive_path, mode='w:gz') as bundle_archive:
-        with tarfile.open(absolute_app_archive_path, mode='r:*') as app_archive:
-            for member in app_archive.getmembers():
-                bundle_archive.addfile(member, app_archive.extractfile(member.name))
-
-        bundle_archive.add(absolute_deps_path, 'deps')
 
 
 @app.task

--- a/cachito/workers/tasks/golang.py
+++ b/cachito/workers/tasks/golang.py
@@ -12,21 +12,22 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def fetch_gomod_source(app_archive_path, copy_cache_to=None, request_id_to_update=None):
+def fetch_gomod_source(app_archive_path, request_id_to_update=None):
     """
     Resolve and fetch gomod dependencies for given app source archive.
 
     :param str app_archive_path: the full path to the application source code
-    :param str copy_cache_to: path to copy artifacts from gomod cache
     :param int request_id_to_update: the Cachito request ID this is for; if specified, this will
         update the request's state
+    :return: the full path to the application source code
+    :rtype: str
     """
     log.info('Fetching gomod dependencies for "%s"', app_archive_path)
     if request_id_to_update:
         set_request_state(request_id_to_update, 'in_progress', 'Fetching the golang dependencies')
 
     try:
-        deps = resolve_gomod_deps(app_archive_path, copy_cache_to)
+        deps = resolve_gomod_deps(app_archive_path, request_id_to_update)
     except CachitoError:
         log.exception('Failed to fetch gomod dependencies for "%s"', app_archive_path)
         raise

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       CACHITO_DEV: 'true'
     volumes:
       - ./:/src:z
-      - ./tmp/cachito-shared:/tmp/cachito-shared:z
+      - ./tmp/cachito-archives:/tmp/cachito-archives:z
     # This is needed in order to allow cleaning up a temporary tarball
     # which is populated by the worker container. In an OpenShift environment
     # this is not needed.
@@ -74,7 +74,6 @@ services:
     volumes:
       - ./:/src:z
       - ./tmp/cachito-archives:/tmp/cachito-archives:z
-      - ./tmp/cachito-shared:/tmp/cachito-shared:z
     depends_on:
       - cachito-api
       - rabbitmq

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -39,9 +39,7 @@ def test_validate_celery_config(mock_isdir):
     celery_app.conf.cachito_shared_dir = '/tmp/some-other-path'
     celery_app.conf.cachito_api_url = 'http://cachito-api/api/v1/'
     validate_celery_config(celery_app.conf)
-    assert mock_isdir.call_count == 2
-    mock_isdir.assert_any_call(celery_app.conf.cachito_shared_dir)
-    mock_isdir.assert_any_call(celery_app.conf.cachito_archives_dir)
+    mock_isdir.assert_called_once_with(celery_app.conf.cachito_archives_dir)
 
 
 def test_validate_celery_config_failure():

--- a/tests/test_workers/test_pkg_manager.py
+++ b/tests/test_workers/test_pkg_manager.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import io
 import os
+import tarfile
 from textwrap import dedent
 from unittest import mock
 
 import pytest
 
-from cachito.workers.pkg_manager import resolve_gomod_deps, update_request_with_deps
+from cachito.workers.pkg_manager import (
+    resolve_gomod_deps, update_request_with_deps, add_deps_to_bundle_archive,
+)
 from cachito.errors import CachitoError
 
 
@@ -31,11 +35,13 @@ mock_cmd_output = dedent("""\
     """)
 
 
+@pytest.mark.parametrize('request_id', (None, 3))
+@mock.patch('cachito.workers.pkg_manager.add_deps_to_bundle_archive')
 @mock.patch('cachito.workers.pkg_manager.GoCacheTemporaryDirectory')
 @mock.patch('subprocess.run')
 @mock.patch('tarfile.open')
 def test_resolve_gomod_deps(
-    mock_tarfile_open, mock_run, mock_temp_dir, tmpdir, sample_deps
+    mock_tarfile_open, mock_run, mock_temp_dir, mock_add_deps, request_id, tmpdir, sample_deps,
 ):
     archive_path = '/this/is/path/to/archive.tar.gz'
     # Mock the tempfile.TemporaryDirectory context manager
@@ -54,51 +60,17 @@ def test_resolve_gomod_deps(
         mock_final_tarfile,
     ]
 
-    resolved_deps = resolve_gomod_deps(archive_path)
+    resolved_deps = resolve_gomod_deps(archive_path, request_id)
 
     assert resolved_deps == sample_deps
-
-
-@mock.patch('cachito.workers.pkg_manager.GoCacheTemporaryDirectory')
-@mock.patch('subprocess.run')
-@mock.patch('tarfile.open')
-def test_resolve_gomod_deps_with_copy_cache(
-    mock_tarfile_open, mock_run, mock_temp_dir, tmpdir, sample_deps
-):
-    archive_path = '/this/is/path/to/archive.tar.gz'
-    # Mock the tempfile.TemporaryDirectory context manager
-    mock_temp_dir.return_value.__enter__.return_value = str(tmpdir)
-
-    dep_cache_partial_path = os.path.join(
-        'pkg', 'mod', 'cache', 'download', 'server.com', 'dep1', '@v', 'dep1.zip')
-
-    def side_effect(*args, **kwargs):
-        if 'list' not in args[0]:
-            # "go list" command
-            return mock.Mock(returncode=0, stdout=None)
-
-        # "go mod" command - generate dummy dependency cache
-        dep1_path = os.path.join(str(tmpdir), dep_cache_partial_path)
-        os.makedirs(os.path.dirname(dep1_path), exist_ok=True)
-        with open(dep1_path, 'wb') as f:
-            f.write(b'dep1 archive')
-        return mock.Mock(returncode=0, stdout=mock_cmd_output)
-
-    mock_run.side_effect = side_effect
-
-    # Mock the opening of the tar file containing application source code
-    mock_final_tarfile = mock.Mock()
-    mock_final_tarfile.extractall.return_value = None
-    mock_tarfile_open.return_value.__enter__.side_effect = [
-        mock_final_tarfile,
-    ]
-
-    copy_cache_to = os.path.join(str(tmpdir), 'the-cache')
-    resolved_deps = resolve_gomod_deps(archive_path, copy_cache_to=copy_cache_to)
-
-    assert resolved_deps == sample_deps
-    # Verify cache has been copied to the provided copy_cache_to location under the gomod dir
-    assert os.path.exists(os.path.join(copy_cache_to, 'gomod', dep_cache_partial_path))
+    if request_id:
+        mock_add_deps.assert_called_once()
+        assert mock_add_deps.call_args[0][0] == 3
+        assert mock_add_deps.call_args[0][1] == '/this/is/path/to/archive.tar.gz'
+        assert mock_add_deps.call_args[0][2].endswith('pkg/mod/cache/download')
+        assert mock_add_deps.call_args[0][3] == 'gomod/pkg/mod/cache/download'
+    else:
+        mock_add_deps.assert_not_called()
 
 
 @pytest.mark.parametrize(('go_mod_rc', 'go_list_rc'), ((0, 1), (1, 0)))
@@ -137,3 +109,63 @@ def test_update_request_with_deps(mock_requests, sample_deps):
     url = 'http://cachito.domain.local/api/v1/requests/1'
     expected_payload = {'dependencies': sample_deps}
     mock_requests.patch.assert_called_once_with(url, json=expected_payload, timeout=30)
+
+
+@mock.patch('tempfile.TemporaryDirectory')
+@mock.patch('cachito.workers.pkg_manager.get_worker_config')
+def test_add_deps_to_bundle_archive(mock_get_worker_config, mock_temp_dir, tmpdir):
+    # Create a temporary directory for add_deps_to_bundle_archive
+    relative_add_deps_tmpdir = 'add_deps_temp'
+    tmpdir.mkdir(relative_add_deps_tmpdir)
+    mock_temp_dir.return_value.__enter__.return_value = tmpdir.join(relative_add_deps_tmpdir)
+    # Make the cachito_archives_dir config point to the pytest managed temp dir
+    mock_get_worker_config.return_value = mock.Mock(cachito_archives_dir=str(tmpdir))
+    # Create a temporary directory to store the application source and deps. Normally the
+    # application source would be in some nested folders, but for the test, it doesn't matter.
+    relative_tmpdir = 'temp'
+    tmpdir.mkdir(relative_tmpdir)
+    app_archive_path = tmpdir.join(relative_tmpdir, 'app.tar.gz')
+    deps_path = tmpdir.join(relative_tmpdir, 'deps')
+
+    # Create the mocked application source archive (app.tar.gz)
+    app_archive_contents = {
+        'app/spam.go': b'Spam mapS',
+        'app/ham.go': b'Ham maH',
+    }
+
+    with tarfile.open(app_archive_path, mode='w:gz') as app_archive:
+        for name, data in app_archive_contents.items():
+            fileobj = io.BytesIO(data)
+            tarinfo = tarfile.TarInfo(name)
+            tarinfo.size = len(fileobj.getvalue())
+            app_archive.addfile(tarinfo, fileobj=fileobj)
+
+    # Create the dependencies cache that mocks the output of `go mod download`
+    deps_archive_contents = {
+        'pkg/mod/cache/download/server.com/dep1/@v/dep1.zip': b'dep1 archive',
+        'pkg/mod/cache/download/server.com/dep2/@v/dep2.zip': b'dep2 archive',
+    }
+
+    for name, data in deps_archive_contents.items():
+        path = deps_path.join(name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        open(path, 'wb').write(data)
+
+    cache_path = os.path.join('pkg', 'mod', 'cache', 'download')
+    # The path to the part of the gomod cache that should be added to the bundle
+    deps_path_input = os.path.join(deps_path, cache_path)
+    # The path to where the cache should end up in the bundle archive
+    dest_cache_path = os.path.join('gomod', cache_path)
+    request_id = 3
+    add_deps_to_bundle_archive(request_id, app_archive_path, deps_path_input, dest_cache_path)
+
+    # Verify the bundle was created
+    bundle_archive_path = str(tmpdir.join('cachito_bundles', f'{request_id}.tar.gz'))
+    assert os.path.exists(bundle_archive_path)
+
+    # Verify contents of assembled archive
+    with tarfile.open(bundle_archive_path, mode='r:*') as bundle_archive:
+        for expected_member in list(app_archive_contents.keys()):
+            bundle_archive.getmember(expected_member)
+        for expected_member in list(deps_archive_contents.keys()):
+            bundle_archive.getmember(os.path.join('deps', 'gomod', expected_member))

--- a/tests/test_workers/test_tasks.py
+++ b/tests/test_workers/test_tasks.py
@@ -1,7 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import io
-import os
-import tarfile
 from unittest import mock
 
 import pytest
@@ -53,54 +50,6 @@ def test_fetch_gomod_source(
         mock_update_request_with_deps.assert_called_once_with(1, sample_deps)
     else:
         mock_set_request_state.assert_not_called()
-
-
-@mock.patch('cachito.workers.tasks.general.get_worker_config')
-def test_assemble_archive_bundle(mock_get_worker_config, tmpdir):
-    mocked_config = mock.Mock(cachito_shared_dir=str(tmpdir))
-    mock_get_worker_config.return_value = mocked_config
-    relative_tmpdir = 'temp'
-    tmpdir.mkdir(relative_tmpdir)
-    relative_deps_path = os.path.join(relative_tmpdir, 'deps')
-    relative_bundle_archive_path = os.path.join(relative_tmpdir, 'bundle.tar.gz')
-
-    app_archive_path = tmpdir.join(relative_tmpdir, 'app.tar.gz')
-    absolute_deps_path = tmpdir.join(relative_deps_path)
-    absolute_bundle_archive_path = tmpdir.join(relative_bundle_archive_path)
-
-    app_archive_contents = {
-        'app/spam.go': b'Spam mapS',
-        'app/ham.go': b'Ham maH',
-    }
-
-    deps_archive_contents = {
-        'gomod/pkg/mod/cache/download/server.com/dep1/@v/dep1.zip': b'dep1 archive',
-        'gomod/pkg/mod/cache/download/server.com/dep2/@v/dep2.zip': b'dep2 archive',
-    }
-
-    # Create mocked application source archive
-    with tarfile.open(app_archive_path, mode='w:gz') as app_archive:
-        for name, data in app_archive_contents.items():
-            fileobj = io.BytesIO(data)
-            tarinfo = tarfile.TarInfo(name)
-            tarinfo.size = len(fileobj.getvalue())
-            app_archive.addfile(tarinfo, fileobj=fileobj)
-
-    # Create mocked dependencies cache
-    for name, data in deps_archive_contents.items():
-        path = absolute_deps_path.join(name)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        open(path, 'wb').write(data)
-
-    tasks.assemble_source_code_archive(
-        app_archive_path, relative_deps_path, relative_bundle_archive_path)
-
-    # Verify contents of assembled archive
-    with tarfile.open(absolute_bundle_archive_path, mode='r:*') as bundle_archive:
-        for expected_member in list(app_archive_contents.keys()):
-            bundle_archive.getmember(expected_member)
-        for expected_member in list(deps_archive_contents.keys()):
-            bundle_archive.getmember(os.path.join('deps', expected_member))
 
 
 @mock.patch('cachito.workers.requests.requests_auth_session')


### PR DESCRIPTION
This makes it so that the download API endpoint doesn't wait for a worker to assemble the bundle. Instead, once the request is complete, the bundle will be present in the archives directory. This will prevent timeouts on large projects and it will address the unstable behavior seen on NFS volumes.

In another PR, I'll work on being able to mark a request as stale through the API, which will cause it to be deleted.