### PR TITLE
Split up the location where sources and bundles are stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ Custom configuration for the Celery workers are listed below:
   [broker_url](https://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url)
   configuration documentation.
 * `cachito_api_url` - the URL to the Cachito API (e.g. `https://cachito-api.domain.local/api/v1/`).
-* `cachito_archives_dir` - the directory for long-term storage of app source archives. This
-    configuration is required, and the directory must already exist and be writeable.
 * `cachito_athens_url` - the URL to the Athens instance to use for caching golang dependencies. This
   is only necessary for workers that process golang requests.
 * `cachito_auth_type` - the authentication type to use when accessing protected Cachito API
   endpoints. If this value is `None`, authentication will not be used. This defaults to `kerberos`
   in production.
+* `cachito_bundles_dir` - the directory for storing bundle archives which include the source archive
+  and dependencies. This configuration is required, and the directory must already exist and be
+  writeable.
 * `cachito_log_level` - the log level to configure the workers with (e.g. `DEBUG`, `INFO`, etc.).
+* `cachito_sources_dir` - the directory for long-term storage of app source archives. This
+    configuration is required, and the directory must already exist and be writeable.
 
 To configure the workers to use a Kerberos keytab for authentication, set the `KRB5_CLIENT_KTNAME`
 environment variable to the path of the keytab. Additional Kerberos configuration can be made in
@@ -93,9 +96,9 @@ environment variable to the path of the keytab. Additional Kerberos configuratio
 
 Custom configuration for the API:
 
-* `CACHITO_ARCHIVES_DIR` - the root of the archives directory that is also accessible by the
-  workers. This is used to download the bundle archives created by the workers.
 * `CACHITO_MAX_PER_PAGE` - the maximum amount of items in a page for paginated results.
+* `CACHITO_BUNDLES_DIR` - the root of the bundles directory that is also accessible by the
+  workers. This is used to download the bundle archives created by the workers.
 * `CACHITO_WORKER_USERNAMES` - the list of usernames without the realm that are allowed to
     use the `/requests/<id>` patch endpoint. The workers use this to update the request
     state.

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -18,9 +18,9 @@ class ProductionConfig(Config):
 
 class DevelopmentConfig(Config):
     """The development Cachito Flask configuration."""
+    CACHITO_BUNDLES_DIR = os.path.join(tempfile.gettempdir(), 'cachito-archives', 'bundles')
     SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://cachito:cachito@db:5432/cachito'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
-    CACHITO_ARCHIVES_DIR = os.path.join(tempfile.gettempdir(), 'cachito-archives')
     LOGIN_DISABLED = True
 
 

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -116,8 +116,8 @@ class Request(db.Model):
         :return: the path to the request's bundle archive
         :rtype: str
         """
-        cachito_archives_dir = flask.current_app.config['CACHITO_ARCHIVES_DIR']
-        return os.path.join(cachito_archives_dir, 'cachito_bundles', f'{self.id}.tar.gz')
+        cachito_bundles_dir = flask.current_app.config['CACHITO_BUNDLES_DIR']
+        return os.path.join(cachito_bundles_dir, f'{self.id}.tar.gz')
 
     def to_json(self):
         pkg_managers = [pkg_manager.to_json() for pkg_manager in self.pkg_managers]

--- a/cachito/workers/pkg_manager.py
+++ b/cachito/workers/pkg_manager.py
@@ -128,12 +128,11 @@ def add_deps_to_bundle_archive(request_id, app_archive_path, deps_path, dest_cac
         deps_path to
     """
     config = get_worker_config()
-    bundles_path = os.path.join(config.cachito_archives_dir, 'cachito_bundles')
-    if not os.path.exists(bundles_path):
-        log.debug('Creating %s', bundles_path)
-        os.mkdir(bundles_path)
+    if not os.path.exists(config.cachito_bundles_dir):
+        log.debug('Creating %s', config.cachito_bundles_dir)
+        os.mkdir(config.cachito_bundles_dir)
 
-    bundle_archive_path = os.path.join(bundles_path, f'{request_id}.tar.gz')
+    bundle_archive_path = os.path.join(config.cachito_bundles_dir, f'{request_id}.tar.gz')
     if os.path.exists(bundle_archive_path):
         src_archive_path = bundle_archive_path
     else:

--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -68,7 +68,7 @@ class SCM(ABC):
         """
         if not self._archives_dir:
             self._archives_dir = os.path.abspath(
-                get_worker_config().cachito_archives_dir
+                get_worker_config().cachito_sources_dir
             )
             log.debug('Using "%s" as the archives directory', self._archives_dir)
 

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -208,7 +208,7 @@ def test_create_request_connection_error(mock_chain, app, auth_env, client, db):
 @mock.patch('flask.send_file')
 @mock.patch('cachito.web.api_v1.Request')
 def test_download_archive(mock_request, mock_send_file, mock_exists, client, app):
-    bundle_archive_path = '/tmp/cachito-archives/cachito_bundles/1.tar.gz'
+    bundle_archive_path = '/tmp/cachito-archives/bundles/1.tar.gz'
     mock_request.query.get_or_404().last_state.state_name = 'complete'
     mock_request.query.get_or_404().bundle_archive = bundle_archive_path
     mock_exists.return_value = True
@@ -299,7 +299,7 @@ def test_set_state_stale(mock_remove, mock_exists, bundle_exists, app, client, d
     assert fetched_request['state'] == state
     assert fetched_request['state_reason'] == state_reason
     if bundle_exists:
-        mock_remove.assert_called_once_with('/tmp/cachito-archives/cachito_bundles/1.tar.gz')
+        mock_remove.assert_called_once_with('/tmp/cachito-archives/bundles/1.tar.gz')
     else:
         mock_remove.assert_not_called()
 

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -35,16 +35,28 @@ def test_configure_celery_with_classes_and_files(mock_open, mock_isfile, mock_ge
 @patch('os.path.isdir', return_value=True)
 def test_validate_celery_config(mock_isdir):
     celery_app = celery.Celery()
-    celery_app.conf.cachito_archives_dir = '/tmp/some-path'
-    celery_app.conf.cachito_shared_dir = '/tmp/some-other-path'
     celery_app.conf.cachito_api_url = 'http://cachito-api/api/v1/'
+    celery_app.conf.cachito_bundles_dir = '/tmp/some-path/bundles'
+    celery_app.conf.cachito_sources_dir = '/tmp/some-path/sources'
     validate_celery_config(celery_app.conf)
-    mock_isdir.assert_called_once_with(celery_app.conf.cachito_archives_dir)
+    mock_isdir.assert_any_call(celery_app.conf.cachito_bundles_dir)
+    mock_isdir.assert_any_call(celery_app.conf.cachito_sources_dir)
 
 
-def test_validate_celery_config_failure():
+@patch('os.path.isdir', return_value=True)
+@pytest.mark.parametrize('bundles_dir, sources_dir', ((False, True), (True, False)))
+def test_validate_celery_config_failure(mock_isdir, bundles_dir, sources_dir):
     celery_app = celery.Celery()
-    celery_app.conf.cachito_archives_dir = None
-    expected = 'The configuration "cachito_archives_dir" must be set to an existing directory'
+    celery_app.conf.cachito_sources_dir = '/tmp/some-path/sources'
+
+    if bundles_dir:
+        celery_app.conf.cachito_bundles_dir = '/tmp/some-path/bundles'
+        dir_name = 'cachito_sources_dir'
+    elif sources_dir:
+        celery_app.conf.cachito_sources_dir = '/tmp/some-path/sources'
+        dir_name = 'cachito_bundles_dir'
+
+    setattr(celery_app.conf, dir_name, None)
+    expected = f'The configuration "{dir_name}" must be set to an existing directory'
     with pytest.raises(ConfigError, match=expected):
         validate_celery_config(celery_app.conf)

--- a/tests/test_workers/test_pkg_manager.py
+++ b/tests/test_workers/test_pkg_manager.py
@@ -118,8 +118,13 @@ def test_add_deps_to_bundle_archive(mock_get_worker_config, mock_temp_dir, tmpdi
     relative_add_deps_tmpdir = 'add_deps_temp'
     tmpdir.mkdir(relative_add_deps_tmpdir)
     mock_temp_dir.return_value.__enter__.return_value = tmpdir.join(relative_add_deps_tmpdir)
-    # Make the cachito_archives_dir config point to the pytest managed temp dir
-    mock_get_worker_config.return_value = mock.Mock(cachito_archives_dir=str(tmpdir))
+    # Make the bundles and sources dir configs point to under the pytest managed temp dir
+    bundles_dir = tmpdir.join('bundles')
+    sources_dir = tmpdir.join('sources')
+    mock_get_worker_config.return_value = mock.Mock(
+        cachito_bundles_dir=str(bundles_dir),
+        cachito_sources_dir=str(sources_dir),
+    )
     # Create a temporary directory to store the application source and deps. Normally the
     # application source would be in some nested folders, but for the test, it doesn't matter.
     relative_tmpdir = 'temp'
@@ -160,7 +165,7 @@ def test_add_deps_to_bundle_archive(mock_get_worker_config, mock_temp_dir, tmpdi
     add_deps_to_bundle_archive(request_id, app_archive_path, deps_path_input, dest_cache_path)
 
     # Verify the bundle was created
-    bundle_archive_path = str(tmpdir.join('cachito_bundles', f'{request_id}.tar.gz'))
+    bundle_archive_path = str(bundles_dir.join(f'{request_id}.tar.gz'))
     assert os.path.exists(bundle_archive_path)
 
     # Verify contents of assembled archive

--- a/tests/test_workers/test_scm.py
+++ b/tests/test_workers/test_scm.py
@@ -15,7 +15,7 @@ archive_path = f'/tmp/cachito-archives/release-engineering/retrodep/{ref}.tar.gz
 @mock.patch('os.makedirs')
 def test_archive_path(mock_makedirs, mock_celery_app):
     path = '/tmp/cachito-archives'
-    mock_celery_app.conf.cachito_archives_dir = path
+    mock_celery_app.conf.cachito_sources_dir = path
     git = scm.Git(url, ref)
     assert git.archives_dir == path
     assert git.archive_path == archive_path


### PR DESCRIPTION
This will prevent potential conflicts of names and it will keep the volume more organized for future use-cases.