### PR TITLE
Assemble the bundle archive after all the package managers complete

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -119,6 +119,17 @@ class Request(db.Model):
         cachito_bundles_dir = flask.current_app.config['CACHITO_BUNDLES_DIR']
         return os.path.join(cachito_bundles_dir, f'{self.id}.tar.gz')
 
+    @property
+    def bundle_temp_files(self):
+        """
+        Get the path to the request's temporary files used to create the bundle archive.
+
+        :return: the path to the temporary files
+        :rtype: str
+        """
+        cachito_bundles_dir = flask.current_app.config['CACHITO_BUNDLES_DIR']
+        return os.path.join(cachito_bundles_dir, 'temp', str(self.id))
+
     def to_json(self):
         pkg_managers = [pkg_manager.to_json() for pkg_manager in self.pkg_managers]
         # Use this list comprehension instead of a RequestState.to_json method to avoid including

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -19,8 +19,6 @@ class Config(object):
     }
     cachito_auth_type = None
     cachito_log_level = 'INFO'
-    result_backend = 'rpc'
-    result_persistent = True
     # The task messages will be acknowledged after the task has been executed,
     # instead of just before
     task_acks_late = True

--- a/tests/test_workers/test_tasks.py
+++ b/tests/test_workers/test_tasks.py
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import io
+import os
+import pathlib
+import tarfile
 from unittest import mock
 
 import pytest
 from requests import Timeout
-from cachito.errors import CachitoError
 
+from cachito.errors import CachitoError
 from cachito.workers import tasks
 
 
@@ -89,3 +93,70 @@ def test_failed_request_callback_not_cachitoerror(mock_set_request_state):
     exc = ValueError('some error')
     tasks.failed_request_callback(None, exc, None, 1)
     mock_set_request_state.assert_called_once_with(1, 'failed', 'An unknown error occurred')
+
+
+@pytest.mark.parametrize('deps_present', (True, False))
+@mock.patch('cachito.workers.tasks.general.set_request_state')
+@mock.patch('cachito.workers.tasks.general.get_worker_config')
+def test_create_bundle_archive(mock_get_worker_config, mock_set_request, deps_present, tmpdir):
+    # Make the bundles and sources dir configs point to under the pytest managed temp dir
+    bundles_dir = tmpdir.mkdir('bundles')
+    sources_dir = tmpdir.mkdir('sources')
+    mock_get_worker_config.return_value = mock.Mock(
+        cachito_bundles_dir=str(bundles_dir),
+        cachito_sources_dir=str(sources_dir),
+    )
+
+    # Create the mocked application source archive (app.tar.gz)
+    app_archive_path = (
+        sources_dir.mkdir('release-engineering').mkdir('some_app').join('app.tar.gz')
+    )
+    app_archive_contents = {
+        'app/pizza.go': b'Cheese Pizza',
+        'app/all_systems.go': b'All Systems Go',
+    }
+
+    with tarfile.open(app_archive_path, mode='w:gz') as app_archive:
+        for name, data in app_archive_contents.items():
+            fileobj = io.BytesIO(data)
+            tarinfo = tarfile.TarInfo(name)
+            tarinfo.size = len(fileobj.getvalue())
+            app_archive.addfile(tarinfo, fileobj=fileobj)
+
+    # Create the dependencies cache from the call to add_deps_to_bundle call from resolve_gomod_deps
+    deps_archive_contents = {
+        'deps/gomod/pkg/mod/cache/download/server.com/dep1/@v/dep1.zip': b'dep1 archive',
+        'deps/gomod/pkg/mod/cache/download/server.com/dep2/@v/dep2.zip': b'dep2 archive',
+    }
+
+    request_id = 3
+    if deps_present:
+        temp_bundle_path = bundles_dir.mkdir('temp').mkdir(str(request_id))
+        for name, data in deps_archive_contents.items():
+            path = temp_bundle_path.join(name)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            open(path, 'wb').write(data)
+
+    # Test the bundle is created when create_bundle_archive is called
+    tasks.create_bundle_archive(app_archive_path, request_id)
+    bundle_archive_path = str(bundles_dir.join(f'{request_id}.tar.gz'))
+    assert os.path.exists(bundle_archive_path)
+
+    # Verify the contents of the assembled bundle archive
+    with tarfile.open(bundle_archive_path, mode='r:*') as bundle_archive:
+        bundle_contents = set([
+            path for path in bundle_archive.getnames()
+            if pathlib.Path(path).suffix in ('.go', '.zip')
+        ])
+
+        # Always make sure there is a deps directory. This will be empty if no deps were present.
+        assert 'deps' in bundle_archive.getnames()
+
+    expected = set(app_archive_contents.keys())
+    if deps_present:
+        expected |= set(deps_archive_contents.keys())
+
+    assert bundle_contents == expected
+
+    mock_set_request.assert_called_once_with(
+        request_id, 'in_progress', 'Assembling the bundle archive')


### PR DESCRIPTION
Assemble the bundle archive after all the package managers to allow running the package managers in parallel.

This works by having each package manager add their dependencies to "bundles/temp/<request ID>/deps". Once all the package managers have been completed, a final Celery task assembles the bundle archive.