### PR TITLE
Update the container images to Fedora 31 to use a newer version of Celery

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM fedora:31
 LABEL maintainer="Factory 2.0"
 
 WORKDIR /src

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM fedora:31
 LABEL maintainer="Factory 2.0"
 
 WORKDIR /src


### PR DESCRIPTION
This is related to https://github.com/celery/celery/issues/4895