### PR TITLE
Make the HTTP timeouts configurable and increase the timeout when adding the dependencies to a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Custom configuration for the Celery workers are listed below:
   [broker_url](https://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url)
   configuration documentation.
 * `cachito_api_url` - the URL to the Cachito API (e.g. `https://cachito-api.domain.local/api/v1/`).
+* `cachito_api_timeout` - the timeout when making a Cachito API request. The default is `60`
+  seconds.
 * `cachito_athens_url` - the URL to the Athens instance to use for caching golang dependencies. This
   is only necessary for workers that process golang requests.
 * `cachito_auth_type` - the authentication type to use when accessing protected Cachito API
@@ -84,6 +86,8 @@ Custom configuration for the Celery workers are listed below:
 * `cachito_bundles_dir` - the directory for storing bundle archives which include the source archive
   and dependencies. This configuration is required, and the directory must already exist and be
   writeable.
+* `cachito_download_timeout` - the timeout when downloading application source archives from sources
+  such as GitHub. The default is `120` seconds.
 * `cachito_log_level` - the log level to configure the workers with (e.g. `DEBUG`, `INFO`, etc.).
 * `cachito_sources_dir` - the directory for long-term storage of app source archives. This
     configuration is required, and the directory must already exist and be writeable.

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -19,6 +19,10 @@ class Config(object):
     }
     cachito_auth_type = None
     cachito_log_level = 'INFO'
+    # The timeout when downloading application source archives from sources such as GitHub
+    cachito_download_timeout = 120
+    # The timeout when making a Cachito API request
+    cachito_api_timeout = 60
     # The task messages will be acknowledged after the task has been executed,
     # instead of just before
     task_acks_late = True

--- a/cachito/workers/pkg_manager.py
+++ b/cachito/workers/pkg_manager.py
@@ -101,7 +101,7 @@ def update_request_with_deps(request_id, deps):
     log.info('Adding %d dependencies to request %d', len(deps), request_id)
     payload = {'dependencies': deps}
     try:
-        rv = requests_auth_session.patch(request_url, json=payload, timeout=30)
+        rv = requests_auth_session.patch(request_url, json=payload, timeout=60)
     except requests.RequestException:
         msg = f'The connection failed when setting the dependencies on request {request_id}'
         log.exception(msg)

--- a/cachito/workers/pkg_manager.py
+++ b/cachito/workers/pkg_manager.py
@@ -101,7 +101,8 @@ def update_request_with_deps(request_id, deps):
     log.info('Adding %d dependencies to request %d', len(deps), request_id)
     payload = {'dependencies': deps}
     try:
-        rv = requests_auth_session.patch(request_url, json=payload, timeout=60)
+        rv = requests_auth_session.patch(
+            request_url, json=payload, timeout=config.cachito_api_timeout)
     except requests.RequestException:
         msg = f'The connection failed when setting the dependencies on request {request_id}'
         log.exception(msg)

--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -86,10 +86,13 @@ class SCM(ABC):
         """
         # Import this here to avoid a circular import
         from cachito.workers.requests import requests_session
+        config = get_worker_config()
 
         with tempfile.TemporaryDirectory(prefix='cachito-') as temp_dir:
             log.debug('Downloading the archive "%s"', url)
-            with requests_session.get(url, stream=True, timeout=120) as response:
+            with requests_session.get(
+                url, stream=True, timeout=config.cachito_download_timeout,
+            ) as response:
                 if not response.ok:
                     log.error('The request to download "%s" failed with: %s', url, response.text)
                     if response.status_code == 404:

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -68,7 +68,8 @@ def set_request_state(request_id, state, state_reason):
     )
     payload = {'state': state, 'state_reason': state_reason}
     try:
-        rv = requests_auth_session.patch(request_url, json=payload, timeout=30)
+        rv = requests_auth_session.patch(
+            request_url, json=payload, timeout=config.cachito_api_timeout)
     except requests.RequestException:
         msg = f'The connection failed when setting the state to "{state}" on request {request_id}'
         log.exception(msg)

--- a/tests/test_workers/test_pkg_manager.py
+++ b/tests/test_workers/test_pkg_manager.py
@@ -105,7 +105,7 @@ def test_update_request_with_deps(mock_requests, sample_deps):
     update_request_with_deps(1, sample_deps)
     url = 'http://cachito.domain.local/api/v1/requests/1'
     expected_payload = {'dependencies': sample_deps}
-    mock_requests.patch.assert_called_once_with(url, json=expected_payload, timeout=30)
+    mock_requests.patch.assert_called_once_with(url, json=expected_payload, timeout=60)
 
 
 @mock.patch('cachito.workers.pkg_manager.get_worker_config')

--- a/tests/test_workers/test_tasks.py
+++ b/tests/test_workers/test_tasks.py
@@ -62,7 +62,7 @@ def test_set_request_state(mock_requests):
     tasks.set_request_state(1, 'complete', 'Completed successfully')
     expected_payload = {'state': 'complete', 'state_reason': 'Completed successfully'}
     mock_requests.patch.assert_called_once_with(
-        'http://cachito.domain.local/api/v1/requests/1', json=expected_payload, timeout=30)
+        'http://cachito.domain.local/api/v1/requests/1', json=expected_payload, timeout=60)
 
 
 @mock.patch('cachito.workers.requests.requests_auth_session.patch')


### PR DESCRIPTION
The timeout increase is a workaround until we resolve the issue by batching the dependencies sent in the PATCH API request in the future. This happens when the database is on the slow side and the number of dependencies is high.