### PR TITLE
Include gomod environment variables in request

### DIFF
--- a/cachito/web/migrations/versions/cdf17fad3edb_request_env_vars.py
+++ b/cachito/web/migrations/versions/cdf17fad3edb_request_env_vars.py
@@ -1,0 +1,40 @@
+"""Add support for environment variables in request
+
+Revision ID: cdf17fad3edb
+Revises: c8b2a3a26191
+Create Date: 2019-09-04 21:07:16.631196
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cdf17fad3edb'
+down_revision = 'c8b2a3a26191'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'environment_variable',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('value', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name', 'value')
+    )
+    op.create_table(
+        'request_environment_variable',
+        sa.Column('request_id', sa.Integer(), nullable=False),
+        sa.Column('env_var_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['env_var_id'], ['environment_variable.id'], ),
+        sa.ForeignKeyConstraint(['request_id'], ['request.id'], ),
+        sa.UniqueConstraint('request_id', 'env_var_id')
+    )
+
+
+def downgrade():
+    op.drop_table('request_environment_variable')
+    op.drop_table('environment_variable')

--- a/cachito/workers/pkg_manager.py
+++ b/cachito/workers/pkg_manager.py
@@ -85,12 +85,13 @@ def resolve_gomod_deps(archive_path, request_id=None):
         return deps
 
 
-def update_request_with_deps(request_id, deps):
+def update_request_with_deps(request_id, deps, env_vars=None):
     """
     Update the Cachito request with the resolved dependencies.
 
     :param int request_id: the ID of the Cachito request
     :param list deps: the list of dependency dictionaries to record
+    :param dict env_vars: mapping of environment variables to record
     :raise CachitoError: if the request to the Cachito API fails
     """
     # Import this here to avoid a circular import
@@ -100,6 +101,9 @@ def update_request_with_deps(request_id, deps):
 
     log.info('Adding %d dependencies to request %d', len(deps), request_id)
     payload = {'dependencies': deps}
+    if env_vars:
+        log.info('Adding environment variables to request %d: %s', request_id, env_vars)
+        payload['environment_variables'] = env_vars
     try:
         rv = requests_auth_session.patch(
             request_url, json=payload, timeout=config.cachito_api_timeout)

--- a/cachito/workers/tasks/golang.py
+++ b/cachito/workers/tasks/golang.py
@@ -33,6 +33,9 @@ def fetch_gomod_source(app_archive_path, request_id_to_update=None):
         raise
 
     if request_id_to_update:
-        update_request_with_deps(request_id_to_update, deps)
+        env_vars = {}
+        if len(deps):
+            env_vars['GOPATH'] = env_vars['GOCACHE'] = 'deps/gomod'
+        update_request_with_deps(request_id_to_update, deps, env_vars)
 
     return app_archive_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,13 @@ def sample_deps():
     ]
 
 
+@pytest.fixture()
+def sample_env_vars():
+    sample = {}
+    sample['GOPATH'] = sample['GOCACHE'] = 'deps/gomod'
+    return sample
+
+
 @pytest.fixture(scope='session')
 def worker_auth_env():
     return {'REMOTE_USER': 'worker@DOMAIN.LOCAL'}

--- a/tests/test_workers/test_tasks.py
+++ b/tests/test_workers/test_tasks.py
@@ -43,7 +43,7 @@ def test_fetch_app_source_request_timed_out(mock_git):
 @mock.patch('cachito.workers.tasks.golang.resolve_gomod_deps')
 def test_fetch_gomod_source(
     mock_resolve_gomod_deps, mock_set_request_state, mock_update_request_with_deps,
-    request_id_to_update, sample_deps,
+    request_id_to_update, sample_deps, sample_env_vars,
 ):
     app_archive_path = 'path/to/archive.tar.gz'
     mock_resolve_gomod_deps.return_value = sample_deps
@@ -51,7 +51,7 @@ def test_fetch_gomod_source(
     if request_id_to_update:
         mock_set_request_state.assert_called_once_with(
             1, 'in_progress', 'Fetching the golang dependencies')
-        mock_update_request_with_deps.assert_called_once_with(1, sample_deps)
+        mock_update_request_with_deps.assert_called_once_with(1, sample_deps, sample_env_vars)
     else:
         mock_set_request_state.assert_not_called()
 


### PR DESCRIPTION
When gomod package manager is used, certain environment variables should
be set to ensure the cached content is used. This change enhances
request objects to include which environment variables, along with their
corresponding values, should be set.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>