### PR TITLE
Show all active/inactive flags in a request

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -180,7 +180,7 @@ class Request(db.Model):
             'state_history': states,
             'user': user,
             'environment_variables': env_vars_json,
-            'flags': [flag.to_json() for flag in self.flags if flag.active],
+            'flags': [flag.to_json() for flag in self.flags],
         }
         # Show the latest state information in the first level of the JSON
         rv.update(latest_state)

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -96,8 +96,8 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
     assert rv.status_code == 200
     fetched_request = json.loads(rv.data.decode('utf-8'))
 
-    # The flag should be missing because now it is inactive
-    assert fetched_request['flags'] == []
+    # The flag should be present even if it is inactive now
+    assert fetched_request['flags'] == ['valid_flag']
     assert fetched_request['state'] == 'in_progress'
     assert fetched_request['state_reason'] == 'The request was initiated'
 


### PR DESCRIPTION
Currently, if a flag is active when a request is made and then it is made inacitve, it will not show up in the response when the user requests to see his/her past request. This change will show that flag in the response even though it is inactive now.