### PR TITLE
Fix the log message when upating the last batch of dependencies

### DIFF
--- a/cachito/workers/pkg_manager.py
+++ b/cachito/workers/pkg_manager.py
@@ -108,7 +108,7 @@ def update_request_with_deps(request_id, deps, env_vars=None):
             payload['environment_variables'] = env_vars
         try:
             log.info('Patching deps {} through {} out of {}'.format(
-                index + 1, batch_upper_limit, len(deps)))
+                index + 1, min(batch_upper_limit, len(deps)), len(deps)))
             rv = requests_auth_session.patch(
                 request_url, json=payload, timeout=config.cachito_api_timeout)
         except requests.RequestException:


### PR DESCRIPTION
This fixes log messages such as `Patching deps 1 through 50 out of 14`. With this commit, it'll be `Patching deps 1 through 14 out of 14`.