### PR TITLE
Remove unnecessary database commit

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -113,9 +113,6 @@ def create_request():
     else:
         flask.current_app.logger.info('An anonymous user submitted request %d', request.id)
 
-    db.session.add(request)
-    db.session.commit()
-
     # Chain tasks
     error_callback = tasks.failed_request_callback.s(request.id)
     chain(


### PR DESCRIPTION
The code being removed is actually called right before the log message, so the code being removed is not necessary. This may have happened due to a merge/rebase issue in a previous PR.