### PR TITLE
Add support for replacing dependencies

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -126,12 +126,11 @@ def create_request():
     ]
     if 'gomod' in pkg_manager_names or auto_detect:
         chain_tasks.append(
-            tasks.fetch_gomod_source.s(request_id_to_update=request.id, auto_detect=auto_detect)
-                 .on_error(error_callback)
+            tasks.fetch_gomod_source.s(request.id, auto_detect=auto_detect).on_error(error_callback)
         )
 
     chain_tasks.extend([
-        tasks.create_bundle_archive.s(request_id=request.id).on_error(error_callback),
+        tasks.create_bundle_archive.si(request.id).on_error(error_callback),
         tasks.set_request_state.si(request.id, 'complete', 'Completed successfully'),
     ])
 

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -122,8 +122,7 @@ def create_request():
     # Chain tasks
     error_callback = tasks.failed_request_callback.s(request.id)
     chain_tasks = [
-        tasks.fetch_app_source.s(
-            request.repo, request.ref, request_id_to_update=request.id).on_error(error_callback),
+        tasks.fetch_app_source.s(request.repo, request.ref, request.id).on_error(error_callback),
     ]
     if 'gomod' in pkg_manager_names or auto_detect:
         chain_tasks.append(

--- a/cachito/web/migrations/versions/5854e700a35e_dependency_replacements.py
+++ b/cachito/web/migrations/versions/5854e700a35e_dependency_replacements.py
@@ -1,0 +1,53 @@
+"""Add the replaced_dependency_id column and indexes on the request_dependency table
+
+Revision ID: 5854e700a35e
+Revises: a655a299e967
+Create Date: 2019-10-14 16:33:01.601651
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5854e700a35e'
+down_revision = 'a655a299e967'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Must use batch_alter_table to support SQLite
+    with op.batch_alter_table('request_dependency') as b:
+        b.add_column(sa.Column('replaced_dependency_id', sa.Integer(), nullable=True))
+        b.create_foreign_key(
+            'fk_replaced_dependency_id', 'dependency', ['replaced_dependency_id'], ['id']
+        )
+
+    op.create_index(
+        op.f('ix_request_dependency_dependency_id'),
+        'request_dependency',
+        ['dependency_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_request_dependency_replaced_dependency_id'),
+        'request_dependency',
+        ['replaced_dependency_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_request_dependency_request_id'), 'request_dependency', ['request_id'], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f('ix_request_dependency_request_id'), table_name='request_dependency')
+    op.drop_index(
+        op.f('ix_request_dependency_replaced_dependency_id'), table_name='request_dependency'
+    )
+    op.drop_index(op.f('ix_request_dependency_dependency_id'), table_name='request_dependency')
+    # Must use batch_alter_table to support SQLite
+    with op.batch_alter_table('request_dependency') as b:
+        b.drop_constraint('fk_replaced_dependency_id', type_='foreignkey')
+        b.drop_column('replaced_dependency_id')

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -166,7 +166,7 @@ class Request(db.Model):
         return os.path.join(cachito_bundles_dir, 'temp', str(self.id))
 
     @property
-    def number_of_deps(self):
+    def dependencies_count(self):
         """
         Get the total number of dependencies for a request.
 
@@ -212,7 +212,7 @@ class Request(db.Model):
             rv.update({'state_history': states})
             rv.update({'dependencies': [dep.to_json() for dep in self.dependencies]})
         else:
-            rv.update({'dependencies': self.number_of_deps})
+            rv.update({'dependencies': self.dependencies_count})
         return rv
 
     @classmethod

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -155,7 +155,7 @@ class Request(db.Model):
         """
         Get the total number of dependencies for a request.
 
-        :return: count of the number of dependencies
+        :return: the number of dependencies
         :rtype: int
         """
         req_dep_cols = request_dependency_table.c

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -200,17 +200,40 @@ components:
       example:
         name: github.com/op/go-logging
         type: gomod
-        version: "v0.1.0"
+        version: "v0.1.1"
       properties:
         name:
           type: string
-          example: "github.com/op/go-logging"
+          example: github.com/op/go-logging
         type:
           type: string
           example: gomod
         version:
           type: string
-          example: "v0.1.0"
+          example: "v0.1.1"
+    DependencyWithReplaces:
+      allOf:
+      - $ref: "#/components/schemas/Dependency"
+      - type: object
+        properties:
+          replaces:
+            $ref: "#/components/schemas/Dependency"
+        required:
+        - name
+        - type
+        - version
+    DependencyReplacement:
+      allOf:
+      - type: object
+        properties:
+          new_name:
+            type: string
+            example: gitlab.com/op/go-logging
+        required:
+        - name
+        - type
+        - version
+      - $ref: "#/components/schemas/Dependency"
     EnvironmentVariable:
       type: object
       additionalProperties:
@@ -295,6 +318,10 @@ components:
     RequestNew:
       type: object
       properties:
+        dependency_replacements:
+          type: array
+          items:
+            $ref: "#/components/schemas/DependencyReplacement"
         flags:
           type: array
           items:
@@ -317,6 +344,8 @@ components:
     RequestUpdate:
       type: object
       properties:
+        dependencies:
+          $ref: "#/components/schemas/DependencyWithReplaces"
         environment_variables:
           $ref: "#/components/schemas/EnvironmentVariable"
         pkg_managers:
@@ -337,7 +366,7 @@ components:
           dependencies:
             type: array
             items:
-              $ref: "#/components/schemas/Dependency"
+              $ref: "#/components/schemas/DependencyWithReplaces"
           state_history:
             type: array
             items:

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -338,10 +338,6 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/Dependency"
-            example:
-              - name: github.com/op/go-logging
-                type: gomod
-                version: "v0.1.0"
           state_history:
             type: array
             items:

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -128,25 +128,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  dependencies:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Dependency"
-                  environment_variables:
-                    $ref: "#/components/schemas/EnvironmentVariable"
-                  pkg_managers:
-                    type: array
-                    items:
-                      type: string
-                      example: gomod
-                  state:
-                    type: string
-                    example: complete
-                  state_reason:
-                    type: string
-                    example: Completed successfully
+                $ref: '#/components/schemas/RequestVerbose'
         "404":
           description: The request wasn't found
           content:
@@ -173,7 +155,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestNew'
+              $ref: '#/components/schemas/RequestUpdate'
       security:
       - "Kerberos Authentication": []
   "/requests/{id}/download":
@@ -332,6 +314,22 @@ components:
       required:
       - ref
       - repo
+    RequestUpdate:
+      type: object
+      properties:
+        environment_variables:
+          $ref: "#/components/schemas/EnvironmentVariable"
+        pkg_managers:
+          type: array
+          items:
+            type: string
+            example: gomod
+        state:
+          type: string
+          example: complete
+        state_reason:
+          type: string
+          example: Completed successfully
     RequestVerbose:
       allOf:
       - type: object

--- a/cachito/workers/pkg_manager.py
+++ b/cachito/workers/pkg_manager.py
@@ -34,13 +34,12 @@ class GoCacheTemporaryDirectory(tempfile.TemporaryDirectory):
             super().__exit__(exc, value, tb)
 
 
-def resolve_gomod_deps(archive_path, request_id=None):
+def resolve_gomod_deps(archive_path, request_id):
     """
     Resolve and fetch gomod dependencies for given app source archive.
 
     :param str archive_path: the full path to the application source code
-    :param int request_id: the request ID of the bundle to add the gomod deps to; if not set, this
-        step will be skipped
+    :param int request_id: the request ID of the bundle to add the gomod deps to
     :return: a list of dictionaries representing the gomod dependencies
     :rtype: list
     :raises CachitoError: if fetching dependencies fails
@@ -85,11 +84,10 @@ def resolve_gomod_deps(archive_path, request_id=None):
                 log.warning('Unexpected go module output: %s', line)
 
         # Add the gomod cache to the bundle the user will later download
-        if request_id is not None:
-            cache_path = os.path.join('pkg', 'mod', 'cache', 'download')
-            src_cache_path = os.path.join(temp_dir, cache_path)
-            dest_cache_path = os.path.join('gomod', cache_path)
-            add_deps_to_bundle(src_cache_path, dest_cache_path, request_id)
+        cache_path = os.path.join('pkg', 'mod', 'cache', 'download')
+        src_cache_path = os.path.join(temp_dir, cache_path)
+        dest_cache_path = os.path.join('gomod', cache_path)
+        add_deps_to_bundle(src_cache_path, dest_cache_path, request_id)
 
         return deps
 

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -21,18 +21,18 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def fetch_app_source(url, ref, request_id_to_update=None):
+def fetch_app_source(url, ref, request_id):
     """
     Fetch the application source code that was requested and put it in long-term storage.
 
     :param str url: the source control URL to pull the source from
     :param str ref: the source control reference
-    :param int request_id_to_update: the Cachito request ID this is for; if specified, this will
-        update the request's state
+    :param int request_id: the Cachito request ID this is for
+    :return: the downloaded source archive's path
+    :rtype: str
     """
     log.info('Fetching the source from "%s" at reference "%s"', url, ref)
-    if request_id_to_update:
-        set_request_state(request_id_to_update, 'in_progress', 'Fetching the application source')
+    set_request_state(request_id, 'in_progress', 'Fetching the application source')
     try:
         # Default to Git for now
         scm = Git(url, ref)

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -9,6 +9,7 @@ from cachito.errors import CachitoError
 from cachito.workers.config import get_worker_config
 from cachito.workers.scm import Git
 from cachito.workers.tasks.celery import app
+from cachito.workers.utils import extract_app_src, get_request_bundle_dir, get_request_bundle_path
 
 
 __all__ = [
@@ -28,8 +29,6 @@ def fetch_app_source(url, ref, request_id):
     :param str url: the source control URL to pull the source from
     :param str ref: the source control reference
     :param int request_id: the Cachito request ID this is for
-    :return: the downloaded source archive's path
-    :rtype: str
     """
     log.info('Fetching the source from "%s" at reference "%s"', url, ref)
     set_request_state(request_id, 'in_progress', 'Fetching the application source')
@@ -43,7 +42,15 @@ def fetch_app_source(url, ref, request_id):
         log.exception('Failed to fetch the source from the URL "%s" and reference "%s"', url, ref)
         raise
 
-    return scm.archive_path
+    # Extract the archive contents to the temporary directory of where the bundle is being created.
+    # This will eventually end up in the bundle the user downloads. This is extracted now since
+    # some package managers may add dependency replacements, which require edits to source files.
+    request_bundle_dir = get_request_bundle_dir(request_id)
+    if not os.path.exists(request_bundle_dir):
+        log.debug('Creating %s', request_bundle_dir)
+        os.makedirs(request_bundle_dir, exist_ok=True)
+    log.debug('Extracting %s to %s', scm.archive_path, request_bundle_dir)
+    extract_app_src(scm.archive_path, request_bundle_dir)
 
 
 @app.task
@@ -102,35 +109,27 @@ def failed_request_callback(context, exc, traceback, request_id):
 
 
 @app.task
-def create_bundle_archive(app_archive_path, request_id):
+def create_bundle_archive(request_id):
     """
     Create the bundle archive to be downloaded by the user.
 
-    :param str app_archive_path: the path to the source archive; this is used as the base of the
-        bundle archive
     :param int request_id: the request the bundle is for
     """
     set_request_state(request_id, 'in_progress', 'Assembling the bundle archive')
 
-    config = get_worker_config()
-    bundle_archive_path = os.path.join(config.cachito_bundles_dir, f'{request_id}.tar.gz')
-    deps_path = os.path.join(config.cachito_bundles_dir, 'temp', str(request_id), 'deps')
-    log.debug(
-        'Using %s as the source and %s as the deps for creating the bundle for request %d',
-        app_archive_path, deps_path, request_id,
-    )
+    bundle_dir = get_request_bundle_dir(request_id)
+    source_path = os.path.join(bundle_dir, 'app')
+    deps_path = os.path.join(bundle_dir, 'deps')
+    log.debug('Using %s for creating the bundle for request %d', bundle_dir, request_id)
 
     if not os.path.isdir(deps_path):
         log.debug('No deps are present at %s, creating an empty directory', deps_path)
         os.makedirs(deps_path, exist_ok=True)
 
-    # Python can't append to a compressed tar file, so we must copy the contents of the app archive
-    # to create the bundle archive rather than starting with a copy of the app archive
+    bundle_archive_path = get_request_bundle_path(request_id)
     log.info('Creating %s', bundle_archive_path)
     with tarfile.open(bundle_archive_path, mode='w:gz') as bundle_archive:
-        # Copy over the existing app archive
-        with tarfile.open(app_archive_path, mode='r:*') as app_archive:
-            for member in app_archive.getmembers():
-                bundle_archive.addfile(member, app_archive.extractfile(member.name))
+        # Add the source to the bundle
+        bundle_archive.add(source_path, 'app')
         # Add the dependencies to the bundle
         bundle_archive.add(deps_path, 'deps')

--- a/cachito/workers/tasks/golang.py
+++ b/cachito/workers/tasks/golang.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
+import os
 
 from cachito.errors import CachitoError
 from cachito.workers.pkg_manager import (
-    archive_contains_path, resolve_gomod_deps, update_request_with_deps,
+    resolve_gomod_deps, update_request_with_deps,
 )
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.general import set_request_state
+from cachito.workers.utils import get_request_bundle_dir
 
 
 __all__ = ['fetch_gomod_source']
@@ -14,34 +16,32 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def fetch_gomod_source(app_archive_path, request_id, auto_detect=False):
+def fetch_gomod_source(request_id, auto_detect=False, dep_replacements=None):
     """
-    Resolve and fetch gomod dependencies for given app source archive.
+    Resolve and fetch gomod dependencies for a given request.
 
-    :param str app_archive_path: the full path to the application source code
     :param int request_id: the Cachito request ID this is for
     :param bool auto_detect: automatically detect if the archive uses Go modules
-    :return: the full path to the application source code
-    :rtype: str
+    :param list dep_replacements: dependency replacements with the keys "name" and "version"
     """
+    app_source_path = os.path.join(get_request_bundle_dir(request_id), 'app')
     if auto_detect:
         log.debug('Checking if the application source uses Go modules')
-        if not archive_contains_path(app_archive_path, 'app/go.mod'):
+        go_mod_file = os.path.join(app_source_path, 'go.mod')
+        if not os.path.exists(go_mod_file):
             log.info('The application source does not use Go modules')
-            return app_archive_path
+            return
 
-    log.info('Fetching gomod dependencies for "%s"', app_archive_path)
+    log.info('Fetching gomod dependencies for request %d', request_id)
     set_request_state(request_id, 'in_progress', 'Fetching the golang dependencies')
 
     try:
-        deps = resolve_gomod_deps(app_archive_path, request_id)
+        deps = resolve_gomod_deps(app_source_path, request_id, dep_replacements)
     except CachitoError:
-        log.exception('Failed to fetch gomod dependencies for "%s"', app_archive_path)
+        log.exception('Failed to fetch gomod dependencies for request %d', request_id)
         raise
 
     env_vars = {}
     if len(deps):
         env_vars['GOPATH'] = env_vars['GOCACHE'] = 'deps/gomod'
     update_request_with_deps(request_id, deps, env_vars, 'gomod')
-
-    return app_archive_path

--- a/cachito/workers/tasks/golang.py
+++ b/cachito/workers/tasks/golang.py
@@ -14,13 +14,12 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def fetch_gomod_source(app_archive_path, request_id_to_update=None, auto_detect=False):
+def fetch_gomod_source(app_archive_path, request_id, auto_detect=False):
     """
     Resolve and fetch gomod dependencies for given app source archive.
 
     :param str app_archive_path: the full path to the application source code
-    :param int request_id_to_update: the Cachito request ID this is for; if specified, this will
-        update the request's state
+    :param int request_id: the Cachito request ID this is for
     :param bool auto_detect: automatically detect if the archive uses Go modules
     :return: the full path to the application source code
     :rtype: str
@@ -32,19 +31,17 @@ def fetch_gomod_source(app_archive_path, request_id_to_update=None, auto_detect=
             return app_archive_path
 
     log.info('Fetching gomod dependencies for "%s"', app_archive_path)
-    if request_id_to_update:
-        set_request_state(request_id_to_update, 'in_progress', 'Fetching the golang dependencies')
+    set_request_state(request_id, 'in_progress', 'Fetching the golang dependencies')
 
     try:
-        deps = resolve_gomod_deps(app_archive_path, request_id_to_update)
+        deps = resolve_gomod_deps(app_archive_path, request_id)
     except CachitoError:
         log.exception('Failed to fetch gomod dependencies for "%s"', app_archive_path)
         raise
 
-    if request_id_to_update:
-        env_vars = {}
-        if len(deps):
-            env_vars['GOPATH'] = env_vars['GOCACHE'] = 'deps/gomod'
-        update_request_with_deps(request_id_to_update, deps, env_vars, 'gomod')
+    env_vars = {}
+    if len(deps):
+        env_vars['GOPATH'] = env_vars['GOCACHE'] = 'deps/gomod'
+    update_request_with_deps(request_id, deps, env_vars, 'gomod')
 
     return app_archive_path

--- a/cachito/workers/utils.py
+++ b/cachito/workers/utils.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import os
+import tarfile
+
+from cachito.workers.config import get_worker_config
+
+
+def extract_app_src(archive_path, parent_dir):
+    """
+    Extract an application source archive to a directory.
+
+    :param str archive_path: the absolute path to the application source code
+    :param str parent_dir: the absolute path to the extract target directory
+    :returns: the absolute path of the extracted application source code
+    :rtype: str
+    """
+    with tarfile.open(archive_path, 'r:*') as archive:
+        archive.extractall(parent_dir)
+    return os.path.join(parent_dir, 'app')
+
+
+def get_request_bundle_dir(request_id):
+    """
+    Get the path to the directory where the bundle is being created for the request.
+
+    :param int request_id: the request ID to get the directory for
+    :return: the path to the where the bundle is being created
+    :rtype: str
+    """
+    config = get_worker_config()
+    return os.path.join(config.cachito_bundles_dir, 'temp', str(request_id))
+
+
+def get_request_bundle_path(request_id):
+    """
+    Get the path to the request's bundle.
+
+    :param int request_id: the request ID to get the bundle path for
+    :return: the path to the request's bundle
+    :rtype: str
+    """
+    config = get_worker_config()
+    return os.path.join(config.cachito_bundles_dir, f'{request_id}.tar.gz')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 services:
   db:
     image: postgres:9.6
-    restart: always
     environment:
       POSTGRES_USER: cachito
       POSTGRES_PASSWORD: cachito

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def sample_deps():
         {'type': 'gomod', 'name': 'github.com/kr/text', 'version': 'v0.1.0'},
         {'type': 'gomod', 'name': 'github.com/op/go-logging',
          'version': 'v0.0.0-20160315200505-970db520ece7'},
-        {'type': 'gomod', 'name': 'github.com/pkg/errors', 'version': 'v0.8.1'},
+        {'type': 'gomod', 'name': 'github.com/pkg/new_errors', 'version': 'v1.0.0'},
         {'type': 'gomod', 'name': 'golang.org/x/crypto',
          'version': 'v0.0.0-20190308221718-c2843e01d9a2'},
         {'type': 'gomod', 'name': 'golang.org/x/net',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import copy
 import os
 
 import pytest
@@ -54,26 +55,120 @@ def db(app, tmpdir):
 @pytest.fixture()
 def sample_deps():
     return [
-        {'type': 'gomod', 'name': 'github.com/Masterminds/semver', 'version': 'v1.4.2'},
-        {'type': 'gomod', 'name': 'github.com/kr/pretty', 'version': 'v0.1.0'},
-        {'type': 'gomod', 'name': 'github.com/kr/pty', 'version': 'v1.1.1'},
-        {'type': 'gomod', 'name': 'github.com/kr/text', 'version': 'v0.1.0'},
-        {'type': 'gomod', 'name': 'github.com/op/go-logging',
-         'version': 'v0.0.0-20160315200505-970db520ece7'},
-        {'type': 'gomod', 'name': 'github.com/pkg/new_errors', 'version': 'v1.0.0'},
-        {'type': 'gomod', 'name': 'golang.org/x/crypto',
-         'version': 'v0.0.0-20190308221718-c2843e01d9a2'},
-        {'type': 'gomod', 'name': 'golang.org/x/net',
-         'version': 'v0.0.0-20190311183353-d8887717615a'},
-        {'type': 'gomod', 'name': 'golang.org/x/sys',
-         'version': 'v0.0.0-20190215142949-d0b11bdaac8a'},
-        {'type': 'gomod', 'name': 'golang.org/x/text', 'version': 'v0.3.0'},
-        {'type': 'gomod', 'name': 'golang.org/x/tools',
-         'version': 'v0.0.0-20190325161752-5a8dccf5b48a'},
-        {'type': 'gomod', 'name': 'gopkg.in/check.v1',
-         'version': 'v1.0.0-20180628173108-788fd7840127'},
-        {'type': 'gomod', 'name': 'gopkg.in/yaml.v2', 'version': 'v2.2.2'},
+        {
+            'name': 'github.com/Masterminds/semver',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v1.4.2',
+        },
+        {
+            'name': 'github.com/kr/pretty',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.1.0',
+        },
+        {
+            'name': 'github.com/kr/pty',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v1.1.1',
+        },
+        {
+            'name': 'github.com/kr/text',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.1.0',
+        },
+        {
+            'name': 'github.com/op/go-logging',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.0.0-20160315200505-970db520ece7',
+        },
+        {
+            'name': 'github.com/pkg/errors',
+            'type': 'gomod',
+            'version': 'v1.0.0',
+            'replaces': None,
+        },
+        {
+            'name': 'golang.org/x/crypto',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.0.0-20190308221718-c2843e01d9a2',
+        },
+        {
+            'name': 'golang.org/x/net',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.0.0-20190311183353-d8887717615a',
+        },
+        {
+            'name': 'golang.org/x/sys',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.0.0-20190215142949-d0b11bdaac8a',
+        },
+        {
+            'name': 'golang.org/x/text',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.3.0',
+        },
+        {
+            'name': 'golang.org/x/tools',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.0.0-20190325161752-5a8dccf5b48a',
+        },
+        {
+            'name': 'gopkg.in/check.v1',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v1.0.0-20180628173108-788fd7840127',
+        },
+        {
+            'name': 'gopkg.in/yaml.v2',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v2.2.2',
+        },
+        {
+            'name': 'k8s.io/metrics',
+            'type': 'gomod',
+            'replaces': None,
+            'version': 'v0.0.0',
+        },
     ]
+
+
+@pytest.fixture()
+def sample_deps_replace(sample_deps):
+    # Use a copy in case a test uses both this fixture and the sample_deps fixture
+    sample_deps_with_replace = copy.deepcopy(sample_deps)
+    sample_deps_with_replace[5]['replaces'] = {
+        'name': 'github.com/pkg/errors',
+        'type': 'gomod',
+        'version': 'v0.9.0',
+    }
+    return sample_deps_with_replace
+
+
+@pytest.fixture()
+def sample_deps_replace_new_name(sample_deps):
+    # Use a copy in case a test uses both this fixture and the sample_deps fixture
+    sample_deps_with_replace = copy.deepcopy(sample_deps)
+    sample_deps_with_replace[5] = {
+        'name': 'github.com/pkg/new_errors',
+        'type': 'gomod',
+        'replaces': {
+            'name': 'github.com/pkg/errors',
+            'type': 'gomod',
+            'version': 'v0.9.0',
+        },
+        'version': 'v1.0.0',
+    }
+    return sample_deps_with_replace
 
 
 @pytest.fixture()

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -38,8 +38,7 @@ def test_create_and_fetch_request(mock_chain, pkg_managers, app, auth_env, clien
             'c50b93a32df1c9d700e3e80996845bc2e13be848',
             1,
         ).on_error(error_callback),
-        fetch_gomod_source.s(request_id_to_update=1, auto_detect=auto_detect)
-                          .on_error(error_callback),
+        fetch_gomod_source.s(1, auto_detect=auto_detect).on_error(error_callback),
         create_bundle_archive.s(request_id=1).on_error(error_callback),
         set_request_state.si(1, 'complete', 'Completed successfully'),
     ])
@@ -84,7 +83,7 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
             'c50b93a32df1c9d700e3e80996845bc2e13be848',
             1,
         ).on_error(error_callback),
-        fetch_gomod_source.s(request_id_to_update=1, auto_detect=False).on_error(error_callback),
+        fetch_gomod_source.s(1, auto_detect=False).on_error(error_callback),
         create_bundle_archive.s(request_id=1).on_error(error_callback),
         set_request_state.si(1, 'complete', 'Completed successfully'),
     ])

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -36,7 +36,7 @@ def test_create_and_fetch_request(mock_chain, pkg_managers, app, auth_env, clien
         fetch_app_source.s(
             'https://github.com/release-engineering/retrodep.git',
             'c50b93a32df1c9d700e3e80996845bc2e13be848',
-            request_id_to_update=1,
+            1,
         ).on_error(error_callback),
         fetch_gomod_source.s(request_id_to_update=1, auto_detect=auto_detect)
                           .on_error(error_callback),
@@ -82,7 +82,7 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
         fetch_app_source.s(
             'https://github.com/release-engineering/retrodep.git',
             'c50b93a32df1c9d700e3e80996845bc2e13be848',
-            request_id_to_update=1,
+            1,
         ).on_error(error_callback),
         fetch_gomod_source.s(request_id_to_update=1, auto_detect=False).on_error(error_callback),
         create_bundle_archive.s(request_id=1).on_error(error_callback),

--- a/tests/test_workers/test_pkg_manager.py
+++ b/tests/test_workers/test_pkg_manager.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 
 from cachito.workers.pkg_manager import (
-    add_deps_to_bundle, archive_contains_path, resolve_gomod_deps, update_request_with_deps,
+    add_deps_to_bundle, resolve_gomod_deps, update_request_with_deps,
 )
 from cachito.errors import CachitoError
 
@@ -15,63 +15,114 @@ url = 'https://github.com/release-engineering/retrodep.git'
 ref = 'c50b93a32df1c9d700e3e80996845bc2e13be848'
 archive_path = f'/tmp/cachito-archives/release-engineering/retrodep/{ref}.tar.gz'
 
-mock_cmd_output = dedent("""\
-    github.com/release-engineering/retrodep/v2
-    github.com/Masterminds/semver v1.4.2
-    github.com/kr/pretty v0.1.0
-    github.com/kr/pty v1.1.1
-    github.com/kr/text v0.1.0
-    github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-    github.com/pkg/errors v0.8.0 github.com/pkg/new_errors v1.0.0
-    golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
-    golang.org/x/net v0.0.0-20190311183353-d8887717615a
-    golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
-    golang.org/x/text v0.3.0
-    golang.org/x/tools v0.0.0-20190325161752-5a8dccf5b48a
-    gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
-    gopkg.in/yaml.v2 v2.2.2
+
+def _generate_mock_cmd_output(error_pkg='github.com/pkg/errors v1.0.0'):
+    return dedent(f"""\
+        github.com/release-engineering/retrodep/v2
+        github.com/Masterminds/semver v1.4.2
+        github.com/kr/pretty v0.1.0
+        github.com/kr/pty v1.1.1
+        github.com/kr/text v0.1.0
+        github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
+        {error_pkg}
+        golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
+        golang.org/x/net v0.0.0-20190311183353-d8887717615a
+        golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
+        golang.org/x/text v0.3.0
+        golang.org/x/tools v0.0.0-20190325161752-5a8dccf5b48a
+        gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+        gopkg.in/yaml.v2 v2.2.2
+        k8s.io/metrics v0.0.0 ./staging/src/k8s.io/metrics
     """)
 
 
+@pytest.mark.parametrize('dep_replacement, go_list_error_pkg, expected_replace', (
+    (None, 'github.com/pkg/errors v1.0.0', None),
+    (
+        {'name': 'github.com/pkg/errors', 'type': 'gomod', 'version': 'v1.0.0'},
+        'github.com/pkg/errors v0.9.0 github.com/pkg/errors v1.0.0',
+        'github.com/pkg/errors=github.com/pkg/errors@v1.0.0',
+    ),
+    (
+        {
+            'name': 'github.com/pkg/errors',
+            'new_name': 'github.com/pkg/new_errors',
+            'type': 'gomod',
+            'version': 'v1.0.0',
+        },
+        'github.com/pkg/errors v0.9.0 github.com/pkg/new_errors v1.0.0',
+        'github.com/pkg/errors=github.com/pkg/new_errors@v1.0.0',
+    )
+))
 @mock.patch('cachito.workers.pkg_manager.add_deps_to_bundle')
 @mock.patch('cachito.workers.pkg_manager.GoCacheTemporaryDirectory')
 @mock.patch('subprocess.run')
-@mock.patch('tarfile.open')
 def test_resolve_gomod_deps(
-    mock_tarfile_open, mock_run, mock_temp_dir, mock_add_deps, tmpdir, sample_deps,
+    mock_run, mock_temp_dir, mock_add_deps, dep_replacement, go_list_error_pkg, expected_replace,
+    tmpdir, sample_deps, sample_deps_replace, sample_deps_replace_new_name,
 ):
-    archive_path = '/this/is/path/to/archive.tar.gz'
+    mock_cmd_output = _generate_mock_cmd_output(go_list_error_pkg)
     # Mock the tempfile.TemporaryDirectory context manager
     mock_temp_dir.return_value.__enter__.return_value = str(tmpdir)
 
     # Mock the "subprocess.run" calls
-    mock_run.side_effect = [
+    run_side_effects = []
+    if dep_replacement:
+        run_side_effects.append(
+            mock.Mock(returncode=0, stdout=None),  # go mod edit -replace
+        )
+    run_side_effects.extend([
         mock.Mock(returncode=0, stdout=None),   # go mod download
-        mock.Mock(returncode=0, stdout=mock_cmd_output)  # go list -m all
-    ]
+        mock.Mock(returncode=0, stdout=mock_cmd_output),  # go list -m all
+    ])
+    mock_run.side_effect = run_side_effects
 
-    # Mock the opening of the tar file containing application source code
-    mock_final_tarfile = mock.Mock()
-    mock_final_tarfile.extractall.return_value = None
-    mock_tarfile_open.return_value.__enter__.side_effect = [
-        mock_final_tarfile,
-    ]
+    archive_path = '/this/is/path/to/archive.tar.gz'
+    if dep_replacement is None:
+        resolved_deps = resolve_gomod_deps(archive_path, 3)
+        expected_deps = sample_deps
+    else:
+        resolved_deps = resolve_gomod_deps(archive_path, 3, [dep_replacement])
+        if dep_replacement.get('new_name'):
+            expected_deps = sample_deps_replace_new_name
+        else:
+            expected_deps = sample_deps_replace
 
-    resolved_deps = resolve_gomod_deps(archive_path, 3)
+    if expected_replace:
+        assert mock_run.call_args_list[0][0][0] == \
+            ('go', 'mod', 'edit', '-replace', expected_replace)
 
-    assert resolved_deps == sample_deps
+    assert resolved_deps == expected_deps
     mock_add_deps.assert_called_once()
     assert mock_add_deps.call_args[0][0].endswith('pkg/mod/cache/download')
     assert mock_add_deps.call_args[0][1] == 'gomod/pkg/mod/cache/download'
     assert mock_add_deps.call_args[0][2] == 3
 
 
+@mock.patch('cachito.workers.pkg_manager.GoCacheTemporaryDirectory')
+@mock.patch('subprocess.run')
+def test_resolve_gomod_deps_unused_dep(mock_run, mock_temp_dir, tmpdir):
+    # Mock the tempfile.TemporaryDirectory context manager
+    mock_temp_dir.return_value.__enter__.return_value = str(tmpdir)
+
+    # Mock the "subprocess.run" calls
+    mock_run.side_effect = [
+        mock.Mock(returncode=0, stdout=None),  # go mod edit -replace
+        mock.Mock(returncode=0, stdout=None),   # go mod download
+        mock.Mock(returncode=0, stdout=_generate_mock_cmd_output()),  # go list -m all
+    ]
+
+    expected_error = 'The following gomod dependency replacements don\'t apply: pizza'
+    with pytest.raises(CachitoError, match=expected_error):
+        resolve_gomod_deps(
+            '/path/archive.tar.gz', 3, [{'name': 'pizza', 'type': 'gomod', 'version': 'v1.0.0'}])
+
+
 @pytest.mark.parametrize(('go_mod_rc', 'go_list_rc'), ((0, 1), (1, 0)))
 @mock.patch('cachito.workers.pkg_manager.GoCacheTemporaryDirectory')
 @mock.patch('subprocess.run')
-@mock.patch('tarfile.open')
 def test_go_list_cmd_failure(
-    mock_tarfile_open, mock_run, mock_temp_dir, tmpdir, go_mod_rc, go_list_rc
+    mock_run, mock_temp_dir, tmpdir, go_mod_rc, go_list_rc
 ):
     archive_path = '/this/is/path/to/archive.tar.gz'
     # Mock the tempfile.TemporaryDirectory context manager
@@ -80,14 +131,7 @@ def test_go_list_cmd_failure(
     # Mock the "subprocess.run" calls
     mock_run.side_effect = [
         mock.Mock(returncode=go_mod_rc, stdout=None),   # go mod download
-        mock.Mock(returncode=go_list_rc, stdout=mock_cmd_output)  # go list -m all
-    ]
-
-    # Mock the opening of the tar file containing application source code
-    mock_final_tarfile = mock.Mock()
-    mock_final_tarfile.extractall.return_value = None
-    mock_tarfile_open.return_value.__enter__.side_effect = [
-        mock_final_tarfile,
+        mock.Mock(returncode=go_list_rc, stdout=_generate_mock_cmd_output())  # go list -m all
     ]
 
     with pytest.raises(CachitoError) as exc_info:
@@ -97,20 +141,20 @@ def test_go_list_cmd_failure(
 
 @mock.patch('cachito.workers.config.Config.cachito_deps_patch_batch_size', 5)
 @mock.patch('cachito.workers.requests.requests_auth_session')
-def test_update_request_with_deps(mock_requests, sample_deps):
+def test_update_request_with_deps(mock_requests, sample_deps_replace):
     mock_requests.patch.return_value.ok = True
-    update_request_with_deps(1, sample_deps)
+    update_request_with_deps(1, sample_deps_replace)
     url = 'http://cachito.domain.local/api/v1/requests/1'
     calls = [
-        mock.call(url, json={'dependencies': sample_deps[:5]}, timeout=60),
-        mock.call(url, json={'dependencies': sample_deps[5:10]}, timeout=60),
-        mock.call(url, json={'dependencies': sample_deps[10:]}, timeout=60),
+        mock.call(url, json={'dependencies': sample_deps_replace[:5]}, timeout=60),
+        mock.call(url, json={'dependencies': sample_deps_replace[5:10]}, timeout=60),
+        mock.call(url, json={'dependencies': sample_deps_replace[10:]}, timeout=60),
     ]
     assert mock_requests.patch.call_count == 3
     mock_requests.patch.assert_has_calls(calls)
 
 
-@mock.patch('cachito.workers.pkg_manager.get_worker_config')
+@mock.patch('cachito.workers.utils.get_worker_config')
 def test_add_deps_to_bundle(mock_get_worker_config, tmpdir):
     # Make the bundles and sources dir configs point to under the pytest managed temp dir
     bundles_dir = tmpdir.mkdir('bundles')
@@ -143,18 +187,3 @@ def test_add_deps_to_bundle(mock_get_worker_config, tmpdir):
     for expected in list(deps_contents.keys()):
         expected_path = str(bundles_dir.join('temp', str(request_id), 'deps', 'gomod', expected))
         assert os.path.exists(expected_path) is True
-
-
-@pytest.mark.parametrize('names, expected', (
-    (('app/go.mod', 'app/something'), True),
-    (('app/pizza', 'app/something'), False),
-))
-@mock.patch('tarfile.open')
-def test_archive_contains_path(mock_tarfile_open, names, expected):
-    # Mock the opening of the tar file containing application source code
-    mock_tarfile = mock.Mock()
-    mock_tarfile.getnames.return_value = names
-    mock_tarfile_open.return_value.__enter__.return_value = mock_tarfile
-
-    archive_path = '/some/path/file.tar.gz'
-    assert archive_contains_path(archive_path, 'app/go.mod') is expected

--- a/tests/test_workers/test_pkg_manager.py
+++ b/tests/test_workers/test_pkg_manager.py
@@ -33,13 +33,12 @@ mock_cmd_output = dedent("""\
     """)
 
 
-@pytest.mark.parametrize('request_id', (None, 3))
 @mock.patch('cachito.workers.pkg_manager.add_deps_to_bundle')
 @mock.patch('cachito.workers.pkg_manager.GoCacheTemporaryDirectory')
 @mock.patch('subprocess.run')
 @mock.patch('tarfile.open')
 def test_resolve_gomod_deps(
-    mock_tarfile_open, mock_run, mock_temp_dir, mock_add_deps, request_id, tmpdir, sample_deps,
+    mock_tarfile_open, mock_run, mock_temp_dir, mock_add_deps, tmpdir, sample_deps,
 ):
     archive_path = '/this/is/path/to/archive.tar.gz'
     # Mock the tempfile.TemporaryDirectory context manager
@@ -58,16 +57,13 @@ def test_resolve_gomod_deps(
         mock_final_tarfile,
     ]
 
-    resolved_deps = resolve_gomod_deps(archive_path, request_id)
+    resolved_deps = resolve_gomod_deps(archive_path, 3)
 
     assert resolved_deps == sample_deps
-    if request_id:
-        mock_add_deps.assert_called_once()
-        assert mock_add_deps.call_args[0][0].endswith('pkg/mod/cache/download')
-        assert mock_add_deps.call_args[0][1] == 'gomod/pkg/mod/cache/download'
-        assert mock_add_deps.call_args[0][2] == 3
-    else:
-        mock_add_deps.assert_not_called()
+    mock_add_deps.assert_called_once()
+    assert mock_add_deps.call_args[0][0].endswith('pkg/mod/cache/download')
+    assert mock_add_deps.call_args[0][1] == 'gomod/pkg/mod/cache/download'
+    assert mock_add_deps.call_args[0][2] == 3
 
 
 @pytest.mark.parametrize(('go_mod_rc', 'go_list_rc'), ((0, 1), (1, 0)))
@@ -95,7 +91,7 @@ def test_go_list_cmd_failure(
     ]
 
     with pytest.raises(CachitoError) as exc_info:
-        resolve_gomod_deps(archive_path)
+        resolve_gomod_deps(archive_path, 1)
     assert str(exc_info.value) == 'Processing gomod dependencies failed'
 
 

--- a/tests/test_workers/test_pkg_manager.py
+++ b/tests/test_workers/test_pkg_manager.py
@@ -22,7 +22,7 @@ mock_cmd_output = dedent("""\
     github.com/kr/pty v1.1.1
     github.com/kr/text v0.1.0
     github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-    github.com/pkg/errors v0.8.1
+    github.com/pkg/errors v0.8.0 github.com/pkg/new_errors v1.0.0
     golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
     golang.org/x/net v0.0.0-20190311183353-d8887717615a
     golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a

--- a/tests/test_workers/test_tasks.py
+++ b/tests/test_workers/test_tasks.py
@@ -34,11 +34,10 @@ def test_fetch_app_source_request_timed_out(mock_git, mock_set_request_state):
         tasks.fetch_app_source(url, ref, 1)
 
 
-@pytest.mark.parametrize('request_id_to_update, auto_detect, contains_go_mod', (
-    (None, False, False),
-    (1, False, False),
-    (None, True, True),
-    (None, True, False),
+@pytest.mark.parametrize('auto_detect, contains_go_mod', (
+    (False, False),
+    (True, True),
+    (True, False),
 ))
 @mock.patch('cachito.workers.tasks.golang.archive_contains_path')
 @mock.patch('cachito.workers.tasks.golang.update_request_with_deps')
@@ -46,22 +45,17 @@ def test_fetch_app_source_request_timed_out(mock_git, mock_set_request_state):
 @mock.patch('cachito.workers.tasks.golang.resolve_gomod_deps')
 def test_fetch_gomod_source(
     mock_resolve_gomod_deps, mock_set_request_state, mock_update_request_with_deps,
-    mock_archive_contains_path, request_id_to_update, auto_detect, contains_go_mod, sample_deps,
-    sample_env_vars,
+    mock_archive_contains_path, auto_detect, contains_go_mod, sample_deps, sample_env_vars,
 ):
     mock_archive_contains_path.return_value = contains_go_mod
     app_archive_path = 'path/to/archive.tar.gz'
     mock_resolve_gomod_deps.return_value = sample_deps
-    tasks.fetch_gomod_source(
-        app_archive_path, request_id_to_update=request_id_to_update, auto_detect=auto_detect,
-    )
-    if request_id_to_update:
+    tasks.fetch_gomod_source(app_archive_path, 1, auto_detect=auto_detect)
+    if not auto_detect or contains_go_mod:
         mock_set_request_state.assert_called_once_with(
             1, 'in_progress', 'Fetching the golang dependencies')
         mock_update_request_with_deps.assert_called_once_with(
             1, sample_deps, sample_env_vars, 'gomod')
-    else:
-        mock_set_request_state.assert_not_called()
 
     if auto_detect:
         mock_archive_contains_path.assert_called_once_with(app_archive_path, 'app/go.mod')

--- a/tests/test_workers/test_utils.py
+++ b/tests/test_workers/test_utils.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from unittest.mock import Mock, patch
+
+from cachito.workers import utils
+
+
+@patch('cachito.workers.utils.tarfile.open')
+def test_extract_app_src(mock_tarfile_open):
+    # Mock the opening of the tar file containing application source code
+    mock_final_tarfile = Mock()
+    mock_final_tarfile.extractall.return_value = None
+    mock_tarfile_open.return_value.__enter__.side_effect = [mock_final_tarfile]
+
+    rv = utils.extract_app_src('/tmp/test.tar.gz', '/tmp/bundles')
+
+    assert rv == '/tmp/bundles/app'
+
+
+@patch('cachito.workers.utils.get_worker_config')
+def test_get_request_bundle_dir(mock_gwc):
+    mock_gwc.return_value.cachito_bundles_dir = '/tmp/some/path'
+    rv = utils.get_request_bundle_dir(3)
+    assert rv == '/tmp/some/path/temp/3'
+
+
+@patch('cachito.workers.utils.get_worker_config')
+def test_get_request_bundle_path(mock_gwc):
+    mock_gwc.return_value.cachito_bundles_dir = '/tmp/some/path'
+    rv = utils.get_request_bundle_path(3)
+    assert rv == '/tmp/some/path/3.tar.gz'


### PR DESCRIPTION
To accomplish this, fetch_app_source now extracts the application
source code archive to the `<bundle_dir>/temp/<request_id>/app`
directory. This can then be used by the package manager tasks to
modify the source for dependency overrides. For Golang, this ends
up being the go.mod and go.sum files.

The create_bundle_archive task then creates an archive from the
contents from `<bundle_dir>/temp/<request_id>/app` and
`<bundle_dir>/temp/<request_id>/deps`.

The dependencies in a request's JSON now has a new key called
"replaces". If this is set, a JSON object representing the
dependency that was replaced is shown.