### PR TITLE
Add indexes to commonly used columns

### DIFF
--- a/cachito/web/migrations/versions/9118b23629ef_add_indexes.py
+++ b/cachito/web/migrations/versions/9118b23629ef_add_indexes.py
@@ -1,0 +1,72 @@
+"""Add indexes to commonly used columns
+
+Revision ID: 9118b23629ef
+Revises: 5854e700a35e
+Create Date: 2019-10-15 16:56:37.362817
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '9118b23629ef'
+down_revision = '5854e700a35e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f('ix_dependency_name'), 'dependency', ['name'], unique=False)
+    op.create_index(op.f('ix_dependency_type'), 'dependency', ['type'], unique=False)
+    op.create_index(op.f('ix_dependency_version'), 'dependency', ['version'], unique=False)
+    op.create_index(
+        op.f('ix_request_environment_variable_env_var_id'),
+        'request_environment_variable',
+        ['env_var_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_request_environment_variable_request_id'),
+        'request_environment_variable',
+        ['request_id'],
+        unique=False,
+    )
+    op.create_index(op.f('ix_request_flag_flag_id'), 'request_flag', ['flag_id'], unique=False)
+    op.create_index(
+        op.f('ix_request_flag_request_id'), 'request_flag', ['request_id'], unique=False
+    )
+    op.create_index(
+        op.f('ix_request_pkg_manager_pkg_manager_id'),
+        'request_pkg_manager',
+        ['pkg_manager_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_request_pkg_manager_request_id'),
+        'request_pkg_manager',
+        ['request_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_request_state_request_id'), 'request_state', ['request_id'], unique=False
+    )
+    op.create_index(op.f('ix_user_username'), 'user', ['username'], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_user_username'), table_name='user')
+    op.drop_index(op.f('ix_request_state_request_id'), table_name='request_state')
+    op.drop_index(op.f('ix_request_pkg_manager_request_id'), table_name='request_pkg_manager')
+    op.drop_index(op.f('ix_request_pkg_manager_pkg_manager_id'), table_name='request_pkg_manager')
+    op.drop_index(op.f('ix_request_flag_request_id'), table_name='request_flag')
+    op.drop_index(op.f('ix_request_flag_flag_id'), table_name='request_flag')
+    op.drop_index(
+        op.f('ix_request_environment_variable_request_id'),
+        table_name='request_environment_variable',
+    )
+    op.drop_index(
+        op.f('ix_request_environment_variable_env_var_id'),
+        table_name='request_environment_variable',
+    )
+    op.drop_index(op.f('ix_dependency_version'), table_name='dependency')
+    op.drop_index(op.f('ix_dependency_type'), table_name='dependency')
+    op.drop_index(op.f('ix_dependency_name'), table_name='dependency')

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -14,22 +14,34 @@ from cachito.web import db
 
 request_pkg_manager_table = db.Table(
     'request_pkg_manager',
-    db.Column('request_id', db.Integer, db.ForeignKey('request.id'), nullable=False),
-    db.Column('pkg_manager_id', db.Integer, db.ForeignKey('package_manager.id'), nullable=False),
+    db.Column('request_id', db.Integer, db.ForeignKey('request.id'), index=True, nullable=False),
+    db.Column(
+        'pkg_manager_id',
+        db.Integer,
+        db.ForeignKey('package_manager.id'),
+        index=True,
+        nullable=False,
+    ),
     db.UniqueConstraint('request_id', 'pkg_manager_id'),
 )
 
 request_environment_variable_table = db.Table(
     'request_environment_variable',
-    db.Column('request_id', db.Integer, db.ForeignKey('request.id'), nullable=False),
-    db.Column('env_var_id', db.Integer, db.ForeignKey('environment_variable.id'), nullable=False),
+    db.Column('request_id', db.Integer, db.ForeignKey('request.id'), index=True, nullable=False),
+    db.Column(
+        'env_var_id',
+        db.Integer,
+        db.ForeignKey('environment_variable.id'),
+        index=True,
+        nullable=False,
+    ),
     db.UniqueConstraint('request_id', 'env_var_id'),
 )
 
 request_flag_table = db.Table(
     'request_flag',
-    db.Column('request_id', db.Integer, db.ForeignKey('request.id'), nullable=False),
-    db.Column('flag_id', db.Integer, db.ForeignKey('flag.id'), nullable=False),
+    db.Column('request_id', db.Integer, db.ForeignKey('request.id'), index=True, nullable=False),
+    db.Column('flag_id', db.Integer, db.ForeignKey('flag.id'), index=True, nullable=False),
     db.UniqueConstraint('request_id', 'flag_id'),
 )
 
@@ -57,9 +69,9 @@ class RequestStateMapping(Enum):
 class Dependency(db.Model):
     """A dependency (e.g. gomod dependency) associated with the request."""
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String, nullable=False)
-    type = db.Column(db.String, nullable=False)
-    version = db.Column(db.String, nullable=False)
+    name = db.Column(db.String, index=True, nullable=False)
+    type = db.Column(db.String, index=True, nullable=False)
+    version = db.Column(db.String, index=True, nullable=False)
     __table_args__ = (
         db.UniqueConstraint('name', 'type', 'version'),
     )
@@ -510,7 +522,7 @@ class RequestState(db.Model):
     state = db.Column(db.Integer, nullable=False)
     state_reason = db.Column(db.String, nullable=False)
     updated = db.Column(db.DateTime(), nullable=False, default=sqlalchemy.func.now())
-    request_id = db.Column(db.Integer, db.ForeignKey('request.id'), nullable=False)
+    request_id = db.Column(db.Integer, db.ForeignKey('request.id'), index=True, nullable=False)
     request = db.relationship('Request', back_populates='states')
 
     @property
@@ -550,7 +562,7 @@ class EnvironmentVariable(db.Model):
 
 class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String, unique=True, nullable=False)
+    username = db.Column(db.String, index=True, unique=True, nullable=False)
     requests = db.relationship('Request', back_populates='user')
 
 


### PR DESCRIPTION
The database migration relies on #60.

The approach taken here is to add indexes to all the foreign keys on the join tables, and any commonly used columns that are currently filtered on that will grow significantly in production.