### PR TITLE
Split pkg_manager.py into its own subpackage

### DIFF
--- a/cachito/workers/pkg_managers/__init__.py
+++ b/cachito/workers/pkg_managers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from cachito.workers.pkg_managers.general import *  # noqa: F401, F403
+from cachito.workers.pkg_managers.golang import *  # noqa: F401, F403

--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+import os
+import shutil
+import subprocess
+
+import requests
+
+from cachito.errors import CachitoError
+from cachito.workers.config import get_worker_config
+from cachito.workers.utils import get_request_bundle_dir
+
+__all__ = ['add_deps_to_bundle', 'run_cmd', 'update_request_with_deps']
+
+log = logging.getLogger(__name__)
+
+
+def update_request_with_deps(request_id, deps, env_vars=None, pkg_manager=None):
+    """
+    Update the Cachito request with the resolved dependencies.
+
+    :param int request_id: the ID of the Cachito request
+    :param list deps: the list of dependency dictionaries to record
+    :param dict env_vars: mapping of environment variables to record
+    :param str pkg_manager: a package manager to add to the request if auto-detection was used
+    :raise CachitoError: if the request to the Cachito API fails
+    """
+    # Import this here to avoid a circular import
+    from cachito.workers.requests import requests_auth_session
+    config = get_worker_config()
+    request_url = f'{config.cachito_api_url.rstrip("/")}/requests/{request_id}'
+
+    log.info('Adding %d dependencies to request %d', len(deps), request_id)
+    for index in range(0, len(deps), config.cachito_deps_patch_batch_size):
+        batch_upper_limit = index + config.cachito_deps_patch_batch_size
+        payload = {'dependencies': deps[index:batch_upper_limit]}
+        if index == 0:
+            if env_vars:
+                log.info('Adding environment variables to the request %d: %s', request_id, env_vars)
+                payload['environment_variables'] = env_vars
+            if pkg_manager:
+                log.info(
+                    'Adding the package manager "%s" to the request %d',
+                    pkg_manager, request_id,
+                )
+                payload['pkg_managers'] = [pkg_manager]
+        try:
+            log.info('Patching deps {} through {} out of {}'.format(
+                index + 1, min(batch_upper_limit, len(deps)), len(deps)))
+            rv = requests_auth_session.patch(
+                request_url, json=payload, timeout=config.cachito_api_timeout)
+        except requests.RequestException:
+            msg = f'The connection failed when setting the dependencies on request {request_id}'
+            log.exception(msg)
+            raise CachitoError(msg)
+
+        if not rv.ok:
+            log.error(
+                'The worker failed to set the dependencies on request %d. The status was %d. '
+                'The text was:\n%s',
+                request_id, rv.status_code, rv.text,
+            )
+            raise CachitoError(f'Setting the dependencies on request {request_id} failed')
+
+
+def add_deps_to_bundle(src_deps_path, dest_cache_path, request_id):
+    """
+    Add the dependencies to a directory that will be part of the bundle archive.
+
+    :param str src_deps_path: the path to the dependencies to add to the bundle archive
+    :param str dest_cache_path: the relative path in the "deps" directory in the bundle to add the
+        content of src_deps_path to
+    :param int request_id: the request the bundle is for
+    """
+    deps_path = os.path.join(get_request_bundle_dir(request_id), 'deps')
+    if not os.path.exists(deps_path):
+        log.debug('Creating %s', deps_path)
+        os.makedirs(deps_path, exist_ok=True)
+
+    dest_deps_path = os.path.join(deps_path, dest_cache_path)
+    log.debug('Adding dependencies from %s to %s', src_deps_path, dest_deps_path)
+    shutil.copytree(src_deps_path, dest_deps_path)
+
+
+def run_cmd(cmd, params):
+    """
+    Run the given command with provided parameters.
+
+    :param iter cmd: iterable representing command to be executed
+    :param dict params: keyword parameters for command execution
+    :returns: the command output
+    :rtype: str
+    """
+    params.setdefault('capture_output', True)
+    params.setdefault('universal_newlines', True)
+    params.setdefault('encoding', 'utf-8')
+
+    response = subprocess.run(cmd, **params)
+
+    if response.returncode != 0:
+        log.error(
+            'Processing gomod dependencies with "%s" failed with: %s',
+            ' '.join(cmd),
+            response.stderr,
+        )
+        raise CachitoError('Processing gomod dependencies failed')
+
+    return response.stdout

--- a/cachito/workers/pkg_managers/golang.py
+++ b/cachito/workers/pkg_managers/golang.py
@@ -1,16 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
 import os
-import shutil
-import subprocess
 import tempfile
-
-import requests
 
 from cachito.errors import CachitoError
 from cachito.workers.config import get_worker_config
-from cachito.workers.utils import get_request_bundle_dir
+from cachito.workers.pkg_managers.general import add_deps_to_bundle, run_cmd
 
+__all__ = ['resolve_gomod_deps']
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +26,7 @@ class GoCacheTemporaryDirectory(tempfile.TemporaryDirectory):
         """
         try:
             env = {'GOPATH': self.name, 'GOCACHE': self.name}
-            _run_cmd(('go', 'clean', '-modcache'), {'env': env})
+            run_cmd(('go', 'clean', '-modcache'), {'env': env})
         finally:
             super().__exit__(exc, value, tb)
 
@@ -70,11 +67,11 @@ def resolve_gomod_deps(app_source_path, request_id, dep_replacements=None):
             new_name = dep_replacement.get('new_name', name)
             version = dep_replacement['version']
             log.info('Applying the gomod replacement %s => %s@%s', name, new_name, version)
-            _run_cmd(('go', 'mod', 'edit', '-replace', f'{name}={new_name}@{version}'), run_params)
+            run_cmd(('go', 'mod', 'edit', '-replace', f'{name}={new_name}@{version}'), run_params)
 
         log.info('Downloading the gomod dependencies')
-        _run_cmd(('go', 'mod', 'download'), run_params)
-        go_list_output = _run_cmd(
+        run_cmd(('go', 'mod', 'download'), run_params)
+        go_list_output = run_cmd(
             ('go', 'list', '-m', '-f', '{{.Path}} {{.Version}} {{.Replace}}', 'all'), run_params)
 
         deps = []
@@ -133,96 +130,3 @@ def resolve_gomod_deps(app_source_path, request_id, dep_replacements=None):
         add_deps_to_bundle(src_cache_path, dest_cache_path, request_id)
 
         return deps
-
-
-def update_request_with_deps(request_id, deps, env_vars=None, pkg_manager=None):
-    """
-    Update the Cachito request with the resolved dependencies.
-
-    :param int request_id: the ID of the Cachito request
-    :param list deps: the list of dependency dictionaries to record
-    :param dict env_vars: mapping of environment variables to record
-    :param str pkg_manager: a package manager to add to the request if auto-detection was used
-    :raise CachitoError: if the request to the Cachito API fails
-    """
-    # Import this here to avoid a circular import
-    from cachito.workers.requests import requests_auth_session
-    config = get_worker_config()
-    request_url = f'{config.cachito_api_url.rstrip("/")}/requests/{request_id}'
-
-    log.info('Adding %d dependencies to request %d', len(deps), request_id)
-    for index in range(0, len(deps), config.cachito_deps_patch_batch_size):
-        batch_upper_limit = index + config.cachito_deps_patch_batch_size
-        payload = {'dependencies': deps[index:batch_upper_limit]}
-        if index == 0:
-            if env_vars:
-                log.info('Adding environment variables to the request %d: %s', request_id, env_vars)
-                payload['environment_variables'] = env_vars
-            if pkg_manager:
-                log.info(
-                    'Adding the package manager "%s" to the request %d',
-                    pkg_manager, request_id,
-                )
-                payload['pkg_managers'] = [pkg_manager]
-        try:
-            log.info('Patching deps {} through {} out of {}'.format(
-                index + 1, min(batch_upper_limit, len(deps)), len(deps)))
-            rv = requests_auth_session.patch(
-                request_url, json=payload, timeout=config.cachito_api_timeout)
-        except requests.RequestException:
-            msg = f'The connection failed when setting the dependencies on request {request_id}'
-            log.exception(msg)
-            raise CachitoError(msg)
-
-        if not rv.ok:
-            log.error(
-                'The worker failed to set the dependencies on request %d. The status was %d. '
-                'The text was:\n%s',
-                request_id, rv.status_code, rv.text,
-            )
-            raise CachitoError(f'Setting the dependencies on request {request_id} failed')
-
-
-def add_deps_to_bundle(src_deps_path, dest_cache_path, request_id):
-    """
-    Add the dependencies to a directory that will be part of the bundle archive.
-
-    :param str src_deps_path: the path to the dependencies to add to the bundle archive
-    :param str dest_cache_path: the relative path in the "deps" directory in the bundle to add the
-        content of src_deps_path to
-    :param int request_id: the request the bundle is for
-    """
-    deps_path = os.path.join(get_request_bundle_dir(request_id), 'deps')
-    if not os.path.exists(deps_path):
-        log.debug('Creating %s', deps_path)
-        os.makedirs(deps_path, exist_ok=True)
-
-    dest_deps_path = os.path.join(deps_path, dest_cache_path)
-    log.debug('Adding dependencies from %s to %s', src_deps_path, dest_deps_path)
-    shutil.copytree(src_deps_path, dest_deps_path)
-
-
-def _run_cmd(cmd, params):
-    """
-    Run the given command with provided parameters.
-
-    :param iter cmd: iterable representing command to be executed
-    :param dict params: keyword parameters for command execution
-    :returns: the command output
-    :rtype: str
-    """
-    params.setdefault('capture_output', True)
-    params.setdefault('universal_newlines', True)
-    params.setdefault('encoding', 'utf-8')
-
-    response = subprocess.run(cmd, **params)
-
-    if response.returncode != 0:
-        log.error(
-            'Processing gomod dependencies with "%s" failed with: %s',
-            ' '.join(cmd),
-            response.stderr,
-        )
-        raise CachitoError('Processing gomod dependencies failed')
-
-    return response.stdout

--- a/cachito/workers/tasks/golang.py
+++ b/cachito/workers/tasks/golang.py
@@ -3,9 +3,7 @@ import logging
 import os
 
 from cachito.errors import CachitoError
-from cachito.workers.pkg_manager import (
-    resolve_gomod_deps, update_request_with_deps,
-)
+from cachito.workers.pkg_managers import resolve_gomod_deps, update_request_with_deps
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.general import set_request_state
 from cachito.workers.utils import get_request_bundle_dir

--- a/tests/test_workers/test_pkg_managers/test_general.py
+++ b/tests/test_workers/test_pkg_managers/test_general.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import os
+from unittest import mock
+
+from cachito.workers.pkg_managers import add_deps_to_bundle, update_request_with_deps
+
+
+@mock.patch('cachito.workers.config.Config.cachito_deps_patch_batch_size', 5)
+@mock.patch('cachito.workers.requests.requests_auth_session')
+def test_update_request_with_deps(mock_requests, sample_deps_replace):
+    mock_requests.patch.return_value.ok = True
+    update_request_with_deps(1, sample_deps_replace)
+    url = 'http://cachito.domain.local/api/v1/requests/1'
+    calls = [
+        mock.call(url, json={'dependencies': sample_deps_replace[:5]}, timeout=60),
+        mock.call(url, json={'dependencies': sample_deps_replace[5:10]}, timeout=60),
+        mock.call(url, json={'dependencies': sample_deps_replace[10:]}, timeout=60),
+    ]
+    assert mock_requests.patch.call_count == 3
+    mock_requests.patch.assert_has_calls(calls)
+
+
+@mock.patch('cachito.workers.utils.get_worker_config')
+def test_add_deps_to_bundle(mock_get_worker_config, tmpdir):
+    # Make the bundles and sources dir configs point to under the pytest managed temp dir
+    bundles_dir = tmpdir.mkdir('bundles')
+    mock_get_worker_config.return_value = mock.Mock(cachito_bundles_dir=str(bundles_dir))
+    # Create a temporary directory to store the application deps
+    relative_tmpdir = 'temp'
+    tmpdir.mkdir(relative_tmpdir)
+    deps_path = tmpdir.join(relative_tmpdir, 'deps')
+
+    # Create the dependencies cache that mocks the output of `go mod download`
+    deps_contents = {
+        'pkg/mod/cache/download/server.com/dep1/@v/dep1.zip': b'dep1 archive',
+        'pkg/mod/cache/download/server.com/dep2/@v/dep2.zip': b'dep2 archive',
+    }
+
+    for name, data in deps_contents.items():
+        path = deps_path.join(name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        open(path, 'wb').write(data)
+
+    cache_path = os.path.join('pkg', 'mod', 'cache', 'download')
+    # The path to the part of the gomod cache that should be added to the bundle
+    src_deps_path = os.path.join(deps_path, cache_path)
+    # The path to where the cache should end up in the bundle archive
+    dest_cache_path = os.path.join('gomod', cache_path)
+    request_id = 3
+    add_deps_to_bundle(src_deps_path, dest_cache_path, request_id)
+
+    # Verify the deps were copied
+    for expected in list(deps_contents.keys()):
+        expected_path = str(bundles_dir.join('temp', str(request_id), 'deps', 'gomod', expected))
+        assert os.path.exists(expected_path) is True


### PR DESCRIPTION
This will make it cleaner when future code is added to the Golang package manager.