### PR TITLE
Handle user set when auth is disabled

### DIFF
--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -48,6 +48,16 @@ class TestingConfig(DevelopmentConfig):
     TESTING = True
 
 
+class TestingConfigNoAuth(TestingConfig):
+    """The testing Cachito Flask configuration without authentication."""
+    # This is needed because Flask seems to read the LOGIN_DISABLED setting
+    # and configure the relevant extensions at app creation time. Changing this
+    # during a test run still leaves login enabled. This behavior also applies
+    # to ENV and DEBUG config values:
+    #   https://flask.palletsprojects.com/en/1.1.x/config/#environment-and-debug-features
+    LOGIN_DISABLED = True
+
+
 def validate_cachito_config(config, cli=False):
     """
     Perform basic validatation on the Cachito configuration.

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -520,9 +520,11 @@ class Request(db.Model):
         for dependency_replacement in dependency_replacements:
             Dependency.validate_replacement_json(dependency_replacement)
 
+        submitted_for_username = request_kwargs.pop('user', None)
         # current_user.is_authenticated is only ever False when auth is disabled
+        if submitted_for_username and not current_user.is_authenticated:
+            raise ValidationError('Cannot set "user" when authentication is disabled')
         if current_user.is_authenticated:
-            submitted_for_username = request_kwargs.pop('user', None)
             if submitted_for_username:
                 # Convert the allowed users to lower-case since they are stored in the database as
                 # lower-case for consistency

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,21 @@ from cachito.web.config import TEST_DB_FILE
 from cachito.web.app import create_app
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def app(request):
     """Return Flask application for the pytest session."""
-    app = create_app('cachito.web.config.TestingConfig')
+    return _make_app(request, 'cachito.web.config.TestingConfig')
+
+
+@pytest.fixture()
+def app_no_auth(request):
+    """Return Flask application without authentication for the pytest session."""
+    return _make_app(request, 'cachito.web.config.TestingConfigNoAuth')
+
+
+def _make_app(request, config):
+    """Helper method to create an application for the given config name"""
+    app = create_app(config)
     # Establish an application context before running the tests. This allows the use of
     # Flask-SQLAlchemy in the test setup.
     ctx = app.app_context()
@@ -31,10 +42,16 @@ def auth_env():
     return {'REMOTE_USER': 'tbrady@DOMAIN.LOCAL'}
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def client(app):
     """Return Flask application client for the pytest session."""
     return app.test_client()
+
+
+@pytest.fixture()
+def client_no_auth(app_no_auth):
+    """Return Flask application client without authentication for the pytest session."""
+    return app_no_auth.test_client()
 
 
 @pytest.fixture()

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -309,6 +309,18 @@ def test_create_request_cannot_set_user(client, db):
     assert error['error'] == 'You are not authorized to create a request on behalf of another user'
 
 
+def test_cannot_set_user_if_auth_disabled(client_no_auth):
+    data = {
+        'repo': 'https://github.com/release-engineering/retrodep.git',
+        'ref': 'c50b93a32df1c9d700e3e80996845bc2e13be848',
+        'user': 'tselleck',
+    }
+
+    rv = client_no_auth.post('/api/v1/requests', json=data)
+    assert rv.status_code == 400
+    assert rv.json['error'] == 'Cannot set "user" when authentication is disabled'
+
+
 def test_create_request_not_logged_in(client, db):
     data = {
         'repo': 'https://github.com/release-engineering/retrodep.git',


### PR DESCRIPTION
With this change, clients are given a meaningful error message when a
request is made with a specified user.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>