### PR TITLE
Store the Kerberos users as case sensitive

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -181,9 +181,7 @@ def patch_request(request_id):
     :raise NotFound: if the request is not found
     :raise ValidationError: if the JSON is invalid
     """
-    # Convert the allowed users to lower-case since they are stored in the database as lower-case
-    # for consistency
-    allowed_users = [user.lower() for user in flask.current_app.config['CACHITO_WORKER_USERNAMES']]
+    allowed_users = flask.current_app.config['CACHITO_WORKER_USERNAMES']
     # current_user.is_authenticated is only ever False when auth is disabled
     if current_user.is_authenticated and current_user.username not in allowed_users:
         raise Unauthorized('This API endpoint is restricted to Cachito workers')

--- a/cachito/web/auth.py
+++ b/cachito/web/auth.py
@@ -46,8 +46,7 @@ def load_user_from_request(request):
             )
         return
 
-    # Convert the username to lower-case for consistency
-    username = remote_user.lower()
+    username = remote_user
     current_app.logger.info(f'The user "{username}" was authenticated successfully by httpd')
 
     user = User.get_or_create(username)

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -37,7 +37,7 @@ class DevelopmentConfig(Config):
 class TestingConfig(DevelopmentConfig):
     """The testing Cachito Flask configuration."""
     CACHITO_USER_REPRESENTATIVES = ['tbrady@DOMAIN.LOCAL']
-    CACHITO_WORKER_USERNAMES = ['worker@domain.local']
+    CACHITO_WORKER_USERNAMES = ['worker@DOMAIN.LOCAL']
     # IMPORTANT: don't use in-memory sqlite. Alembic migrations will create a new
     # connection producing a new instance of the database which is deleted immediately
     # after the migration completes...

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -524,12 +524,7 @@ class Request(db.Model):
         if current_user.is_authenticated:
             submitted_for_username = request_kwargs.pop('user', None)
             if submitted_for_username:
-                # Convert the allowed users to lower-case since they are stored in the database as
-                # lower-case for consistency
-                allowed_users = {
-                    user.lower()
-                    for user in flask.current_app.config['CACHITO_USER_REPRESENTATIVES']
-                }
+                allowed_users = flask.current_app.config['CACHITO_USER_REPRESENTATIVES']
                 if current_user.username not in allowed_users:
                     raise Forbidden(
                         'You are not authorized to create a request on behalf of another user'

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -323,7 +323,7 @@ components:
           example: "2019-09-17T19:42:47.149979"
         user:
           type: string
-          example: tbrady@domain.local
+          example: tbrady@DOMAIN.LOCAL
     Request:
       allOf:
       - type: object
@@ -363,7 +363,7 @@ components:
           description: >
             The user this request is created on behalf of. This is reserved for privileged users
             that can act as a representative.
-          example: tbrady@domain.local
+          example: tbrady@DOMAIN.LOCAL
       required:
       - ref
       - repo
@@ -409,7 +409,7 @@ components:
               $ref: "#/components/schemas/StateHistory"
           submitted_by:
             type: string
-            example: osbs@domain.local
+            example: osbs@DOMAIN.LOCAL
       - $ref: "#/components/schemas/RequestBase"
     StateHistory:
       type: object

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -25,7 +25,7 @@ from cachito.workers.tasks import (
         ['gomod'],
         None,
     ),
-    ([], [], 'tom_hanks@domain.local'),
+    ([], [], 'tom_hanks@DOMAIN.LOCAL'),
 ))
 @mock.patch('cachito.web.api_v1.chain')
 def test_create_and_fetch_request(
@@ -56,10 +56,10 @@ def test_create_and_fetch_request(
             assert expected_value == created_request[key]
 
     if user:
-        assert created_request['user'] == 'tom_hanks@domain.local'
-        assert created_request['submitted_by'] == 'tbrady@domain.local'
+        assert created_request['user'] == 'tom_hanks@DOMAIN.LOCAL'
+        assert created_request['submitted_by'] == 'tbrady@DOMAIN.LOCAL'
     else:
-        assert created_request['user'] == 'tbrady@domain.local'
+        assert created_request['user'] == 'tbrady@DOMAIN.LOCAL'
         assert created_request['submitted_by'] is None
 
     error_callback = failed_request_callback.s(1)
@@ -106,7 +106,7 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
     created_request = rv.json
     for key, expected_value in data.items():
         assert expected_value == created_request[key]
-    assert created_request['user'] == 'tbrady@domain.local'
+    assert created_request['user'] == 'tbrady@DOMAIN.LOCAL'
 
     error_callback = failed_request_callback.s(1)
     mock_chain.assert_called_once_with([
@@ -299,10 +299,10 @@ def test_create_request_cannot_set_user(client, db):
     data = {
         'repo': 'https://github.com/release-engineering/retrodep.git',
         'ref': 'c50b93a32df1c9d700e3e80996845bc2e13be848',
-        'user': 'tom_hanks@domain.local',
+        'user': 'tom_hanks@DOMAIN.LOCAL',
     }
 
-    auth_env = {'REMOTE_USER': 'homer_simpson@domain.local'}
+    auth_env = {'REMOTE_USER': 'homer_simpson@DOMAIN.LOCAL'}
     rv = client.post('/api/v1/requests', json=data, environ_base=auth_env)
     assert rv.status_code == 403
     error = rv.json

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -42,9 +42,7 @@ def test_create_and_fetch_request(
     if user:
         data['user'] = user
 
-    with mock.patch.dict(app.config, {'LOGIN_DISABLED': False}):
-        rv = client.post(
-            '/api/v1/requests', json=data, environ_base=auth_env)
+    rv = client.post('/api/v1/requests', json=data, environ_base=auth_env)
     assert rv.status_code == 201
     created_request = rv.json
 
@@ -99,9 +97,7 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
     db.session.add(flag)
     db.session.commit()
 
-    with mock.patch.dict(app.config, {'LOGIN_DISABLED': False}):
-        rv = client.post(
-            '/api/v1/requests', json=data, environ_base=auth_env)
+    rv = client.post('/api/v1/requests', json=data, environ_base=auth_env)
     assert rv.status_code == 201
     created_request = rv.json
     for key, expected_value in data.items():
@@ -396,8 +392,7 @@ def test_create_request_connection_error(mock_chain, app, auth_env, client, db):
     }
 
     mock_chain.side_effect = kombu.exceptions.OperationalError('Failed to connect')
-    with mock.patch.dict(app.config, {'LOGIN_DISABLED': False}):
-        rv = client.post('/api/v1/requests', json=data, environ_base=auth_env)
+    rv = client.post('/api/v1/requests', json=data, environ_base=auth_env)
 
     assert rv.status_code == 500
     assert rv.json == {'error': 'Failed to connect to the broker to schedule a task'}


### PR DESCRIPTION
Some implementations of Kerberos are case insensitive but not all of them. We should store the Kerberos principals as case sensitive.