### PR TITLE
Add the new request state to the database session before flushing

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -579,6 +579,7 @@ class Request(db.Model):
         self.states.append(request_state)
         # Send the changes queued up in SQLAlchemy to the database's transaction buffer.
         # This will genereate an ID that can be used below.
+        db.session.add(request_state)
         db.session.flush()
         self.request_state_id = request_state.id
 


### PR DESCRIPTION
This will prevent the request_state_id column from being null after a new state is added. This only seems to happen with Postgresql since the SQLite tests pass.