### PR TITLE
fixed failing test cases on macos

### DIFF
--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import os
+import tempfile
 from unittest import mock
 
 import kombu.exceptions
@@ -429,7 +431,7 @@ def test_create_request_connection_error(mock_chain, app, auth_env, client, db):
 @mock.patch('flask.send_file')
 @mock.patch('cachito.web.api_v1.Request')
 def test_download_archive(mock_request, mock_send_file, mock_exists, client, app):
-    bundle_archive_path = '/tmp/cachito-archives/bundles/1.tar.gz'
+    bundle_archive_path = os.path.join(tempfile.gettempdir(), 'cachito-archives/bundles/1.tar.gz')
     mock_request.query.get_or_404().state.state_name = 'complete'
     mock_request.query.get_or_404().bundle_archive = bundle_archive_path
     mock_exists.return_value = True
@@ -493,8 +495,9 @@ def test_set_state(mock_rmtree, mock_exists, state, app, client, db, worker_auth
     assert fetched_request['state_history'][0]['state_reason'] == state_reason
     assert fetched_request['state_history'][0]['updated']
     assert fetched_request['state_history'][1]['state'] == 'in_progress'
-    mock_exists.assert_called_once_with('/tmp/cachito-archives/bundles/temp/1')
-    mock_rmtree.assert_called_once_with('/tmp/cachito-archives/bundles/temp/1')
+    temp_dir = os.path.join(tempfile.gettempdir(), 'cachito-archives/bundles/temp/1')
+    mock_exists.assert_called_once_with(temp_dir)
+    mock_rmtree.assert_called_once_with(temp_dir)
 
 
 def test_set_pkg_managers(app, client, db, worker_auth_env):
@@ -546,7 +549,12 @@ def test_set_state_stale(mock_remove, mock_exists, bundle_exists, app, client, d
     assert fetched_request['state'] == state
     assert fetched_request['state_reason'] == state_reason
     if bundle_exists:
-        mock_remove.assert_called_once_with('/tmp/cachito-archives/bundles/1.tar.gz')
+        mock_remove.assert_called_once_with(
+            os.path.join(
+                tempfile.gettempdir(),
+                'cachito-archives/bundles/1.tar.gz',
+            )
+        )
     else:
         mock_remove.assert_not_called()
 

--- a/tests/test_cachito_config.py
+++ b/tests/test_cachito_config.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import os
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -10,7 +12,12 @@ from cachito.errors import ConfigError
 @patch('os.path.isdir', return_value=True)
 def test_validate_cachito_config_success(mock_isdir, app):
     validate_cachito_config(app.config)
-    mock_isdir.assert_any_call('/tmp/cachito-archives/bundles')
+    mock_isdir.assert_any_call(
+        os.path.join(
+            tempfile.gettempdir(),
+            'cachito-archives/bundles',
+        )
+    )
 
 
 @patch('os.path.isdir', return_value=True)


### PR DESCRIPTION
the temporary directory (`tempfile.gettempdir()`) comes up with a different value on macos (e.g. `/var/folders/0h/28qktgvj01j9hp61hck2p7sc0000gn/T/cachito-archives/bundles`), so we need to remove the hard-coded `/tmp` value

Fixes #96 