### PR TITLE
Install mercurial on workers

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -8,6 +8,7 @@ RUN dnf -y install \
     --setopt=tsflags=nodocs \
     golang \
     git-core \
+    mercurial \
     python3-celery \
     python3-GitPython \
     python3-pip \


### PR DESCRIPTION
Some golang modules are hosted on bitbucket.org which is a Mercurial
server.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>