### PR TITLE
WIP: Add ruby / bundler support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,9 @@ venv:
 run:
 	docker-compose up
 
+proxy_setup:
+	curl -u admin:admin123 -X POST --header 'Content-Type: application/json' http://localhost:8881/service/rest/v1/script -d @nexus.json
+	curl -u admin:admin123 -X POST --header 'Content-Type: text/plain' --header "accept: application/json" http://localhost:8881/service/rest/v1/script/proxy/run
+
 test:
 	tox

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -151,6 +151,13 @@ def create_request():
             ).on_error(error_callback)
         )
 
+    if 'bundler' in pkg_manager_names or auto_detect:
+        chain_tasks.append(
+            tasks.fetch_bundler_source.si(
+                request.id, auto_detect,
+            ).on_error(error_callback)
+        )
+
     chain_tasks.extend([
         tasks.create_bundle_archive.si(request.id).on_error(error_callback),
         tasks.set_request_state.si(request.id, 'complete', 'Completed successfully'),

--- a/cachito/web/migrations/versions/c8b2a3a26191_initial_migration.py
+++ b/cachito/web/migrations/versions/c8b2a3a26191_initial_migration.py
@@ -53,6 +53,7 @@ def upgrade():
     # Insert supported pkg managers
     op.bulk_insert(pkg_manager_table, [
         {'name': 'gomod'},
+        {'name': 'bundler'},
     ])
 
     op.create_table(

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -67,6 +67,7 @@ class DevelopmentConfig(Config):
     broker_url = 'amqp://cachito:cachito@rabbitmq:5672//'
     cachito_api_url = 'http://cachito-api:8080/api/v1/'
     cachito_athens_url = 'http://athens:3000'
+    cachito_nexus_url = 'http://nexus:8081/nexus/content/repositories/rubygems_org_proxy/'
     cachito_bundles_dir = os.path.join(ARCHIVES_VOLUME, 'bundles')
     cachito_log_level = 'DEBUG'
     cachito_sources_dir = os.path.join(ARCHIVES_VOLUME, 'sources')

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -67,7 +67,7 @@ class DevelopmentConfig(Config):
     broker_url = 'amqp://cachito:cachito@rabbitmq:5672//'
     cachito_api_url = 'http://cachito-api:8080/api/v1/'
     cachito_athens_url = 'http://athens:3000'
-    cachito_nexus_url = 'http://nexus:8081/nexus/content/repositories/rubygems_org_proxy/'
+    cachito_nexus_url = 'http://nexus:8081/repository/rubygems_org/'
     cachito_bundles_dir = os.path.join(ARCHIVES_VOLUME, 'bundles')
     cachito_log_level = 'DEBUG'
     cachito_sources_dir = os.path.join(ARCHIVES_VOLUME, 'sources')

--- a/cachito/workers/pkg_managers/__init__.py
+++ b/cachito/workers/pkg_managers/__init__.py
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from cachito.workers.pkg_managers.general import *  # noqa: F401, F403
 from cachito.workers.pkg_managers.golang import *  # noqa: F401, F403
+from cachito.workers.pkg_managers.ruby import *  # noqa: F401, F403

--- a/cachito/workers/pkg_managers/ruby.py
+++ b/cachito/workers/pkg_managers/ruby.py
@@ -36,6 +36,7 @@ def resolve_bundler(app_source_path, request):
     with tempfile.TemporaryDirectory(prefix='cachito-') as temp_dir:
         env = {
             'BUNDLE_PATH': temp_dir,
+            'BUNDLE_DISABLE_SHARED_GEMS': '1',
             'PATH': os.environ.get('PATH', ''),
         }
 

--- a/cachito/workers/pkg_managers/ruby.py
+++ b/cachito/workers/pkg_managers/ruby.py
@@ -53,7 +53,10 @@ def resolve_bundler(app_source_path, request):
 
         log.info('Downloading the bundler dependencies')
         path_param = '--path=' + temp_dir
-        bundle_package_output = run_bundler_cmd(('bundle', 'package', '--no-install', '--all', path_param), run_params)
+        bundle_package_output = run_bundler_cmd(
+            ('bundle', 'package', '--no-install', '--all', path_param),
+            run_params
+        )
 
         deps = []
         for line in bundle_package_output.splitlines():

--- a/cachito/workers/pkg_managers/ruby.py
+++ b/cachito/workers/pkg_managers/ruby.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# from datetime import datetime
+import functools
+import logging
+import os
+# import re
+import tempfile
+
+# import git
+# import semver
+
+# from cachito.errors import CachitoError
+from cachito.workers.config import get_worker_config
+from cachito.workers.pkg_managers.general import add_deps_to_bundle, run_cmd
+
+# __all__ = ['get_golang_version', 'resolve_bundler']
+__all__ = ['resolve_bundler']
+
+log = logging.getLogger(__name__)
+run_bundler_cmd = functools.partial(run_cmd, exc_msg='Processing bundler dependencies failed')
+
+
+def resolve_bundler(app_source_path, request):
+    """
+    Resolve and fetch bundler dependencies for given app source archive.
+
+    :param str app_source_path: the full path to the application source code
+    :param dict request: the Cachito request this is for
+    :return: a tuple of the ruby gem itself and the list of dictionaries representing the
+        dependencies
+    :rtype: (dict, list)
+    :raises CachitoError: if fetching dependencies fails
+    """
+
+    worker_config = get_worker_config()
+    with tempfile.TemporaryDirectory(prefix='cachito-') as temp_dir:
+        env = {
+            'BUNDLE_PATH': temp_dir,
+            'PATH': os.environ.get('PATH', ''),
+        }
+
+        run_params = {'env': env, 'cwd': app_source_path}
+
+        run_bundler_cmd(
+            ('bundle', 'config', 'mirror.http://rubygems.org', worker_config.cachito_nexus_url),
+            run_params
+        )
+        run_bundler_cmd(
+            ('bundle', 'config', 'mirror.https://rubygems.org', worker_config.cachito_nexus_url),
+            run_params
+        )
+
+        log.info('Downloading the bundler dependencies')
+        path_param = '--path=' + temp_dir
+        bundle_package_output = run_bundler_cmd(('bundle', 'package', '--no-install', '--all', path_param), run_params)
+
+        deps = []
+        for line in bundle_package_output.splitlines():
+            log.debug('read line: %s', line)
+            if line.strip().startswith('Fetching'):
+                parts = [part for part in line.split(' ') if part != '']
+                if len(parts) == 3:
+                    deps.append({
+                        'name': parts[1],
+                        'type': 'bundler',
+                        'version': parts[2],
+                    })
+                    log.debug('Added dependency: %s @ version: %s', parts[1], parts[2])
+                else:
+                    log.warning('Unexpected bundler list output: %s', line)
+
+        app = {
+            'name': request['repo'],
+            'type': 'bundler',
+            'version': request['ref'],
+        }
+
+        # Add the bundler cache to the bundle the user will later download
+        cache_path = os.path.join('vendor', 'cache')
+        src_cache_path = os.path.join(temp_dir, cache_path)
+        dest_cache_path = os.path.join('bundler', cache_path)
+        add_deps_to_bundle(src_cache_path, dest_cache_path, request['id'])
+
+        return app, deps

--- a/cachito/workers/tasks/__init__.py
+++ b/cachito/workers/tasks/__init__.py
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from cachito.workers.tasks.general import *  # noqa: F401, F403
 from cachito.workers.tasks.golang import *  # noqa: F401, F403
+from cachito.workers.tasks.ruby import *  # noqa: F401, F403

--- a/cachito/workers/tasks/ruby.py
+++ b/cachito/workers/tasks/ruby.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+import os
+
+from cachito.errors import CachitoError
+from cachito.workers.pkg_managers import resolve_bundler, update_request_with_deps
+from cachito.workers.tasks.celery import app
+from cachito.workers.tasks.general import set_request_state
+from cachito.workers.utils import get_request_bundle_dir
+
+
+__all__ = ['fetch_bundler_source']
+log = logging.getLogger(__name__)
+
+
+@app.task
+def fetch_bundler_source(request_id, auto_detect=False):
+    """
+    Resolve and fetch bundler dependencies for a given request.
+
+    :param int request_id: the Cachito request ID this is for
+    :param bool auto_detect: automatically detect if the application uses bundler for dependency management
+    """
+    app_source_path = os.path.join(get_request_bundle_dir(request_id), 'app')
+    if auto_detect:
+        log.debug('Checking if the application source uses bundler for dependency management')
+        gemfile_lock = os.path.join(app_source_path, 'Gemfile.lock')
+        if not os.path.exists(gemfile_lock):
+            log.info('The application source does not use bundler')
+            return
+
+    log.info('Fetching bundler dependencies for request %d', request_id)
+    request = set_request_state(request_id, 'in_progress', 'Fetching the ruby dependencies')
+    try:
+        ruby_app, deps = resolve_bundler(app_source_path, request)
+    except CachitoError:
+        log.exception('Failed to fetch ruby dependencies for request %d', request_id)
+        raise
+
+    env_vars = {}
+    if len(deps):
+        env_vars['BUNDLE_PATH'] = 'vendor/cache'
+    update_request_with_deps(request_id, deps, env_vars, 'bundler', [ruby_app])

--- a/cachito/workers/tasks/ruby.py
+++ b/cachito/workers/tasks/ruby.py
@@ -19,7 +19,8 @@ def fetch_bundler_source(request_id, auto_detect=False):
     Resolve and fetch bundler dependencies for a given request.
 
     :param int request_id: the Cachito request ID this is for
-    :param bool auto_detect: automatically detect if the application uses bundler for dependency management
+    :param bool auto_detect: automatically detect if the application uses bundler for
+        dependency management
     """
     app_source_path = os.path.join(get_request_bundle_dir(request_id), 'app')
     if auto_detect:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,13 @@ services:
     ports:
       - 3000:3000
 
+  nexus:
+    image: sonatype/nexus3
+    volumes:
+      - ./tmp/nexus-data:/nexus-data:z
+    ports:
+      - 8881:8081
+
   cachito-api:
     build:
       context: .

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -7,6 +7,8 @@ RUN dnf -y install \
     --setopt=install_weak_deps=false \
     --setopt=tsflags=nodocs \
     golang \
+    ruby \
+    rubygems \
     git-core \
     mercurial \
     python3-celery \
@@ -16,6 +18,9 @@ RUN dnf -y install \
     python3-requests-kerberos \
     python3-semver \
     && dnf clean all
+
+RUN gem install bundler
+
 COPY . .
 RUN pip3 install . --no-deps
 EXPOSE 8080

--- a/nexus.json
+++ b/nexus.json
@@ -1,0 +1,5 @@
+{
+  "name": "proxy",
+  "type": "groovy",
+  "content": "repository.createRubygemsProxy('rubygems_org','https://rubygems.org')"
+}

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -8,13 +8,19 @@ import pytest
 
 from cachito.web.models import Request, EnvironmentVariable, Flag, RequestStateMapping
 from cachito.workers.tasks import (
-    fetch_app_source, fetch_gomod_source, fetch_bundler_source, set_request_state, failed_request_callback,
+    fetch_app_source,
+    fetch_gomod_source,
+    fetch_bundler_source,
+    set_request_state,
+    failed_request_callback,
     create_bundle_archive,
 )
 
 
 @pytest.mark.parametrize('repo, ref, dependency_replacements, pkg_managers, user', (
-    ('https://github.com/release-engineering/retrodep.git', 'c50b93a32df1c9d700e3e80996845bc2e13be848', [], [], None),
+    (
+        'https://github.com/release-engineering/retrodep.git',
+        'c50b93a32df1c9d700e3e80996845bc2e13be848', [], [], None),
     (
         'https://github.com/release-engineering/retrodep.git',
         'c50b93a32df1c9d700e3e80996845bc2e13be848',
@@ -22,7 +28,13 @@ from cachito.workers.tasks import (
         ['gomod'],
         None
     ),
-    ('https://github.com/3scale/echo-api.git', '13a6a3fb4ab8b5bd56a74b3f5e475a87195eb87b', [], ['bundler'], None),
+    (
+        'https://github.com/3scale/echo-api.git',
+        '13a6a3fb4ab8b5bd56a74b3f5e475a87195eb87b',
+        [],
+        ['bundler'],
+        None
+    ),
     (
         'https://github.com/release-engineering/retrodep.git',
         'c50b93a32df1c9d700e3e80996845bc2e13be848',
@@ -95,7 +107,9 @@ def test_create_and_fetch_request(
 
     fetch_calls = []
     if 'gomod' in pkg_managers or auto_detect:
-        fetch_calls.append(fetch_gomod_source.si(1, auto_detect, dependency_replacements).on_error(error_callback),)
+        fetch_calls.append(
+            fetch_gomod_source.si(1, auto_detect, dependency_replacements).on_error(error_callback),
+        )
     if 'bundler' in pkg_managers or auto_detect:
         fetch_calls.append(fetch_bundler_source.si(1, auto_detect).on_error(error_callback))
 
@@ -134,10 +148,26 @@ def test_create_request_ssl_auth(mock_chain, auth_ssl_env, client, db):
     cert_dn = 'CN=tbrady,OU=serviceusers,DC=domain,DC=local'
     assert created_request['user'] == cert_dn
 
+
 @pytest.mark.parametrize('repo, ref, pkg_managers, flags', (
-    ('https://github.com/release-engineering/retrodep.git', 'c50b93a32df1c9d700e3e80996845bc2e13be848', [], []),
-    ('https://github.com/release-engineering/retrodep.git', 'c50b93a32df1c9d700e3e80996845bc2e13be848', ['gomod'], []),
-    ('https://github.com/3scale/echo-api.git', '13a6a3fb4ab8b5bd56a74b3f5e475a87195eb87b', ['bundler'], []),
+    (
+        'https://github.com/release-engineering/retrodep.git',
+        'c50b93a32df1c9d700e3e80996845bc2e13be848',
+        [],
+        []
+    ),
+    (
+        'https://github.com/release-engineering/retrodep.git',
+        'c50b93a32df1c9d700e3e80996845bc2e13be848',
+        ['gomod'],
+        []
+    ),
+    (
+        'https://github.com/3scale/echo-api.git',
+        '13a6a3fb4ab8b5bd56a74b3f5e475a87195eb87b',
+        ['bundler'],
+        []
+    ),
     (
         'https://github.com/release-engineering/retrodep.git',
         'c50b93a32df1c9d700e3e80996845bc2e13be848',
@@ -152,7 +182,17 @@ def test_create_request_ssl_auth(mock_chain, auth_ssl_env, client, db):
     ),
 ))
 @mock.patch('cachito.web.api_v1.chain')
-def test_create_and_fetch_request_with_flag(mock_chain, repo, ref, pkg_managers, flags, app, auth_env, client, db):
+def test_create_and_fetch_request_with_flag(
+    mock_chain,
+    repo,
+    ref,
+    pkg_managers,
+    flags,
+    app,
+    auth_env,
+    client,
+    db
+):
     data = {
         'repo': repo,
         'ref': ref,
@@ -264,9 +304,21 @@ def test_fetch_paginated_requests(
 
 
 @pytest.mark.parametrize('repo_template, ref, pkg_managers', (
-    ('https://github.com/release-engineering/retrodep{}.git', 'c50b93a32df1c9d700e3e80996845bc2e13be848', []),
-    ('https://github.com/release-engineering/retrodep{}.git', 'c50b93a32df1c9d700e3e80996845bc2e13be848', ['gomod']),
-    ('https://github.com/3scale/echo-api{}.git', '13a6a3fb4ab8b5bd56a74b3f5e475a87195eb87b', ['bundler']),
+    (
+        'https://github.com/release-engineering/retrodep{}.git',
+        'c50b93a32df1c9d700e3e80996845bc2e13be848',
+        []
+    ),
+    (
+        'https://github.com/release-engineering/retrodep{}.git',
+        'c50b93a32df1c9d700e3e80996845bc2e13be848',
+        ['gomod']
+    ),
+    (
+        'https://github.com/3scale/echo-api{}.git',
+        '13a6a3fb4ab8b5bd56a74b3f5e475a87195eb87b',
+        ['bundler']
+    ),
 ))
 def test_create_request_filter_state(repo_template, ref, pkg_managers, app, auth_env, client, db):
     """Test that requests can be filtered by state."""
@@ -572,8 +624,16 @@ def test_set_state(mock_rmtree, mock_exists, state, app, client, db, worker_auth
 
 
 @pytest.mark.parametrize('repo, ref, pkg_managers', (
-    ('https://github.com/release-engineering/retrodep.git', 'c50b93a32df1c9d700e3e80996845bc2e13be848', ['gomod']),
-    ('https://github.com/3scale/echo-api.git', '13a6a3fb4ab8b5bd56a74b3f5e475a87195eb87b', ['bundler']),
+    (
+        'https://github.com/release-engineering/retrodep.git',
+        'c50b93a32df1c9d700e3e80996845bc2e13be848',
+        ['gomod']
+    ),
+    (
+        'https://github.com/3scale/echo-api.git',
+        '13a6a3fb4ab8b5bd56a74b3f5e475a87195eb87b',
+        ['bundler']
+    ),
 ))
 def test_set_pkg_managers(repo, ref, pkg_managers, app, client, db, worker_auth_env):
     data = {
@@ -686,7 +746,16 @@ def test_set_state_no_duplicate(app, client, db, worker_auth_env):
     ({'spam': 'maps'}, ['gomod'], {'name': 'all_systems_go', 'type': 'gomod', 'version': 'v1.0.0'}),
     ({'spam': 'maps'}, ['bundler'], {'name': 'nokogiri', 'type': 'bundler', 'version': '1.10.9'}),
 ))
-def test_set_deps(app, client, db, worker_auth_env, sample_deps_replace, env_vars, dep, pkg_managers):
+def test_set_deps(
+    app,
+    client,
+    db,
+    worker_auth_env,
+    sample_deps_replace,
+    env_vars,
+    dep,
+    pkg_managers
+):
     data = {
         'repo': 'https://github.com/release-engineering/retrodep.git',
         'ref': 'c50b93a32df1c9d700e3e80996845bc2e13be848',


### PR DESCRIPTION
This PR teaches cachito how to handle projects with ruby gems as dependencies. 

It relies on an existing `Gemfile.lock` in the root of the folder and eventually downloads all packages with `bundle package --no-install --all `, which it then adds to the archive made available for download.

Some notes: 

* `replacements` are not necessary in ruby, so logic is significantly simpler than golang
* Uses git repo URL as "app name", since there's no standard app naming conventions for ruby projects. As such, bundler does not offer a way to retrieve a name for the app it is installing dependencies for, but we can rely on project URL as a unique name.
* Uses Sonatype Nexus 3 as rubygems.org proxy (we are already relying on Nexus for storing ruby gems during productisation at 3scale)

TODO: 
- [x] Add test cases for ruby / bundler 
- [ ] Document requirements for ruby projects
- [ ] Explain usage of download archive with example Dockerfile