### PR TITLE
Pass GIT_TERMINAL_PROMPT to argument env of Repo.clone_from

### DIFF
--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -139,11 +139,14 @@ class Git(SCM):
         """
         with tempfile.TemporaryDirectory(prefix='cachito-') as temp_dir:
             log.debug('Cloning the Git repository from %s', self.url)
-            # Don't allow git to prompt for a username if we don't have access
-            os.environ['GIT_TERMINAL_PROMPT'] = '0'
             clone_path = os.path.join(temp_dir, 'repo')
             try:
-                repo = git.repo.Repo.clone_from(self.url, clone_path, no_checkout=True)
+                repo = git.repo.Repo.clone_from(
+                    self.url, clone_path,
+                    no_checkout=True,
+                    # Don't allow git to prompt for a username if we don't have access
+                    env={'GIT_TERMINAL_PROMPT': '0'}
+                )
             except:  # noqa E722
                 log.exception('Cloning the Git repository from %s failed', self.url)
                 raise CachitoError('Cloning the Git repository failed')

--- a/tests/test_workers/test_scm.py
+++ b/tests/test_workers/test_scm.py
@@ -53,7 +53,10 @@ def test_clone_and_archive(mock_archive_path, mock_clone, mock_temp_dir, mock_ta
     # Verify the tempfile.TemporaryDirectory context manager was used
     mock_temp_dir.return_value.__enter__.assert_called_once()
     # Verify the repo was cloned and checked out properly
-    mock_clone.assert_called_once_with(url, '/tmp/cachito-temp/repo', no_checkout=True)
+    mock_clone.assert_called_once_with(
+        url, '/tmp/cachito-temp/repo',
+        no_checkout=True, env={'GIT_TERMINAL_PROMPT': '0'}
+    )
     assert mock_clone.return_value.head.reference == mock_commit
     mock_clone.return_value.head.reset.assert_called_once_with(index=True, working_tree=True)
     # Verfiy the archive was created


### PR DESCRIPTION
Repo.clone_from accepts environment variables via argument env which
will be passed to the argument env of subprocess.Popen eventually.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>