### PR TITLE
Refactor paths

### DIFF
--- a/cachito/paths.py
+++ b/cachito/paths.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+from pathlib import Path
+import shutil
+
+log = logging.getLogger(__name__)
+
+
+# Subclassing from type(Path()) is a workaround because pathlib does not
+# support subclass from Path directly. This base type will be the correct type
+# for Linux or Windows individually.
+class RequestBundleDir(type(Path())):
+    """
+    Represents a directory tree for a request.
+
+    :param int request_id: the request ID.
+    :param str root: the root directory. A request bundle directory will be
+        created under ``root/temp/``.
+    """
+
+    go_mod_cache_download_part = Path('pkg', 'mod', 'cache', 'download')
+
+    def __new__(cls, request_id, root):
+        self = super().__new__(cls, root, 'temp', str(request_id))
+
+        self.source_dir = self.joinpath('app')
+        self.go_mod_file = self.joinpath('app', 'go.mod')
+        self.deps_dir = self.joinpath('deps')
+        self.gomod_download_dir = self.joinpath('deps', 'gomod', cls.go_mod_cache_download_part)
+
+        self.bundle_archive_file = Path(root, f'{request_id}.tar.gz')
+
+        return self
+
+    def rmtree(self):
+        """Remove this directory tree entirely."""
+        shutil.rmtree(str(self))

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -2,7 +2,6 @@
 from collections import OrderedDict
 from copy import deepcopy
 from enum import Enum
-import os
 import re
 
 import flask
@@ -367,28 +366,6 @@ class Request(db.Model):
             mapping.replaced_dependency_id = replaced_dependency.id
 
         db.session.add(mapping)
-
-    @property
-    def bundle_archive(self):
-        """
-        Get the path to the request's bundle archive.
-
-        :return: the path to the request's bundle archive
-        :rtype: str
-        """
-        cachito_bundles_dir = flask.current_app.config['CACHITO_BUNDLES_DIR']
-        return os.path.join(cachito_bundles_dir, f'{self.id}.tar.gz')
-
-    @property
-    def bundle_temp_files(self):
-        """
-        Get the path to the request's temporary files used to create the bundle archive.
-
-        :return: the path to the temporary files
-        :rtype: str
-        """
-        cachito_bundles_dir = flask.current_app.config['CACHITO_BUNDLES_DIR']
-        return os.path.join(cachito_bundles_dir, 'temp', str(self.id))
 
     @property
     def dependencies_count(self):

--- a/cachito/workers/paths.py
+++ b/cachito/workers/paths.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+import pathlib
+
+from cachito import paths
+from cachito.workers.config import get_worker_config
+
+log = logging.getLogger(__name__)
+
+
+class RequestBundleDir(paths.RequestBundleDir):
+    """
+    Represents a concrete request bundle directory used on worker whose root
+    directory defaults to ``cachito_bundles_dir`` in config.
+
+    By default, this request bundle directory and its dependency directory will
+    be created when this object is instantiated.
+
+    :param int request_id: the request ID.
+    """
+
+    def __new__(cls, request_id):
+        root_dir = get_worker_config().cachito_bundles_dir
+        self = super().__new__(cls, request_id, root_dir)
+
+        log.debug('Ensure directory %s exists.', self)
+        log.debug('Ensure directory %s exists.', self.deps_dir)
+        self.deps_dir.mkdir(parents=True, exist_ok=True)
+
+        return self
+
+
+# Similar with cachito.paths.RequestBundleDir, this base type will be the
+# correct type for Linux or Windows individually.
+class SourcesDir(type(pathlib.Path())):
+    """
+    Represents a sources directory tree for a package, which will be created
+    automatically when this object is instantiated.
+
+    :param str repo_name: a namespaced repository name of package. For example,
+        ``release-engineering/retrodep``.
+    :param str ref: the revision reference used to construct archive filename.
+    """
+
+    def __new__(cls, repo_name, ref):
+        self = super().__new__(cls, get_worker_config().cachito_sources_dir)
+
+        repo_relative_dir = pathlib.Path(*repo_name.split('/'))
+        self.package_dir = self.joinpath(repo_relative_dir)
+        self.archive_path = self.joinpath(repo_relative_dir, f'{ref}.tar.gz')
+
+        log.debug('Ensure directory %s exists.', self.package_dir)
+        self.package_dir.mkdir(parents=True, exist_ok=True)
+
+        return self

--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -1,17 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import os
-import shutil
 import subprocess
 
 import requests
 
 from cachito.errors import CachitoError
 from cachito.workers.config import get_worker_config
-from cachito.workers.utils import get_request_bundle_dir
 
 __all__ = [
-    'add_deps_to_bundle',
     'run_cmd',
     'update_request_with_deps',
     'update_request_with_packages',
@@ -111,25 +107,6 @@ def update_request_with_packages(request_id, packages, pkg_manager=None, env_var
             rv.text,
         )
         raise CachitoError(f'Setting the packages on request {request_id} failed')
-
-
-def add_deps_to_bundle(src_deps_path, dest_cache_path, request_id):
-    """
-    Add the dependencies to a directory that will be part of the bundle archive.
-
-    :param str src_deps_path: the path to the dependencies to add to the bundle archive
-    :param str dest_cache_path: the relative path in the "deps" directory in the bundle to add the
-        content of src_deps_path to
-    :param int request_id: the request the bundle is for
-    """
-    deps_path = os.path.join(get_request_bundle_dir(request_id), 'deps')
-    if not os.path.exists(deps_path):
-        log.debug('Creating %s', deps_path)
-        os.makedirs(deps_path, exist_ok=True)
-
-    dest_deps_path = os.path.join(deps_path, dest_cache_path)
-    log.debug('Adding dependencies from %s to %s', src_deps_path, dest_deps_path)
-    shutil.copytree(src_deps_path, dest_deps_path)
 
 
 def run_cmd(cmd, params, exc_msg=None):

--- a/cachito/workers/utils.py
+++ b/cachito/workers/utils.py
@@ -2,8 +2,6 @@
 import os
 import tarfile
 
-from cachito.workers.config import get_worker_config
-
 
 def extract_app_src(archive_path, parent_dir):
     """
@@ -17,27 +15,3 @@ def extract_app_src(archive_path, parent_dir):
     with tarfile.open(archive_path, 'r:*') as archive:
         archive.extractall(parent_dir)
     return os.path.join(parent_dir, 'app')
-
-
-def get_request_bundle_dir(request_id):
-    """
-    Get the path to the directory where the bundle is being created for the request.
-
-    :param int request_id: the request ID to get the directory for
-    :return: the path to the where the bundle is being created
-    :rtype: str
-    """
-    config = get_worker_config()
-    return os.path.join(config.cachito_bundles_dir, 'temp', str(request_id))
-
-
-def get_request_bundle_path(request_id):
-    """
-    Get the path to the request's bundle.
-
-    :param int request_id: the request ID to get the bundle path for
-    :return: the path to the request's bundle
-    :rtype: str
-    """
-    config = get_worker_config()
-    return os.path.join(config.cachito_bundles_dir, f'{request_id}.tar.gz')

--- a/tests/test_workers/test_pkg_managers/test_general.py
+++ b/tests/test_workers/test_pkg_managers/test_general.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import os
 from unittest import mock
 
 import requests
@@ -7,7 +6,6 @@ import pytest
 
 from cachito.errors import CachitoError
 from cachito.workers.pkg_managers import (
-    add_deps_to_bundle,
     update_request_with_deps,
     update_request_with_packages,
 )
@@ -69,38 +67,3 @@ def test_update_request_with_packages_failed_connection(mock_requests):
     expected_msg = 'The connection failed when adding packages to the request 1'
     with pytest.raises(CachitoError, match=expected_msg):
         update_request_with_packages(1, packages)
-
-
-@mock.patch('cachito.workers.utils.get_worker_config')
-def test_add_deps_to_bundle(mock_get_worker_config, tmpdir):
-    # Make the bundles and sources dir configs point to under the pytest managed temp dir
-    bundles_dir = tmpdir.mkdir('bundles')
-    mock_get_worker_config.return_value = mock.Mock(cachito_bundles_dir=str(bundles_dir))
-    # Create a temporary directory to store the application deps
-    relative_tmpdir = 'temp'
-    tmpdir.mkdir(relative_tmpdir)
-    deps_path = tmpdir.join(relative_tmpdir, 'deps')
-
-    # Create the dependencies cache that mocks the output of `go mod download`
-    deps_contents = {
-        'pkg/mod/cache/download/server.com/dep1/@v/dep1.zip': b'dep1 archive',
-        'pkg/mod/cache/download/server.com/dep2/@v/dep2.zip': b'dep2 archive',
-    }
-
-    for name, data in deps_contents.items():
-        path = deps_path.join(name)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        open(path, 'wb').write(data)
-
-    cache_path = os.path.join('pkg', 'mod', 'cache', 'download')
-    # The path to the part of the gomod cache that should be added to the bundle
-    src_deps_path = os.path.join(deps_path, cache_path)
-    # The path to where the cache should end up in the bundle archive
-    dest_cache_path = os.path.join('gomod', cache_path)
-    request_id = 3
-    add_deps_to_bundle(src_deps_path, dest_cache_path, request_id)
-
-    # Verify the deps were copied
-    for expected in list(deps_contents.keys()):
-        expected_path = str(bundles_dir.join('temp', str(request_id), 'deps', 'gomod', expected))
-        assert os.path.exists(expected_path) is True

--- a/tests/test_workers/test_utils.py
+++ b/tests/test_workers/test_utils.py
@@ -14,17 +14,3 @@ def test_extract_app_src(mock_tarfile_open):
     rv = utils.extract_app_src('/tmp/test.tar.gz', '/tmp/bundles')
 
     assert rv == '/tmp/bundles/app'
-
-
-@patch('cachito.workers.utils.get_worker_config')
-def test_get_request_bundle_dir(mock_gwc):
-    mock_gwc.return_value.cachito_bundles_dir = '/tmp/some/path'
-    rv = utils.get_request_bundle_dir(3)
-    assert rv == '/tmp/some/path/temp/3'
-
-
-@patch('cachito.workers.utils.get_worker_config')
-def test_get_request_bundle_path(mock_gwc):
-    mock_gwc.return_value.cachito_bundles_dir = '/tmp/some/path'
-    rv = utils.get_request_bundle_path(3)
-    assert rv == '/tmp/some/path/3.tar.gz'


### PR DESCRIPTION
Cachito has a few of directories to hold various types of data. Instead
of calling os.path.join to construct those directories, this proposed
change moves the directories into two dedicated paths in a declarative
way. As a result, less code there.

RequestBundleDir breaks Python code style rule intentionally to make the
relative paths easier to read.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>