### PR TITLE
Add the configuration API endpoint

### DIFF
--- a/cachito/web/migrations/versions/193baf9d7cbf_config_file_base64.py
+++ b/cachito/web/migrations/versions/193baf9d7cbf_config_file_base64.py
@@ -1,0 +1,67 @@
+"""Add the config_file_base64 table
+
+Revision ID: 193baf9d7cbf
+Revises: 3c208b05d703
+Create Date: 2020-04-03 19:16:34.581217
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "193baf9d7cbf"
+down_revision = "3c208b05d703"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "config_file_base64",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
+        sa.Column("content", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("content", "path"),
+    )
+    op.create_index(
+        op.f("ix_config_file_base64_content"), "config_file_base64", ["content"], unique=False
+    )
+    op.create_index(
+        op.f("ix_config_file_base64_path"), "config_file_base64", ["path"], unique=False
+    )
+
+    op.create_table(
+        "request_config_file_base64",
+        sa.Column("request_id", sa.Integer(), nullable=False),
+        sa.Column("config_file_base64_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["config_file_base64_id"], ["config_file_base64.id"]),
+        sa.ForeignKeyConstraint(["request_id"], ["request.id"]),
+        sa.UniqueConstraint("request_id", "config_file_base64_id"),
+    )
+    op.create_index(
+        op.f("ix_request_config_file_base64_config_file_base64_id"),
+        "request_config_file_base64",
+        ["config_file_base64_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_request_config_file_base64_request_id"),
+        "request_config_file_base64",
+        ["request_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    with op.batch_alter_table("request_config_file_base64") as batch_op:
+        batch_op.drop_index(batch_op.f("ix_request_config_file_base64_request_id"))
+        batch_op.drop_index(batch_op.f("ix_request_config_file_base64_config_file_base64_id"))
+
+    op.drop_table("request_config_file_base64")
+
+    with op.batch_alter_table("config_file_base64") as batch_op:
+        batch_op.drop_index(batch_op.f("ix_config_file_base64_path"))
+        batch_op.drop_index(batch_op.f("ix_config_file_base64_content"))
+
+    op.drop_table("config_file_base64")

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -709,7 +709,7 @@ class User(db.Model, UserMixin):
         """
         user = cls.query.filter_by(username=username).first()
         if not user:
-            user = User(username=username)
+            user = cls(username=username)
             db.session.add(user)
 
         return user

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -146,7 +146,7 @@ paths:
       - name: id
         in: path
         required: true
-        description: The ID of the Cachito request to retrieve
+        description: The ID of the Cachito request to update
         schema:
           type: integer
       responses:

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -185,6 +185,78 @@ paths:
               $ref: '#/components/schemas/RequestUpdate'
       security:
       - "Kerberos Authentication": []
+  "/requests/{id}/configuration-files":
+    get:
+      description: Return the configuration files of a request
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: The ID of the Cachito request to retrieve the configuration files for
+        schema:
+          type: integer
+      responses:
+        "200":
+          description: The configuration files of the Cachito request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RequestConfiguration"
+        "404":
+          description: The request wasn't found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: The requested resource was not found
+    post:
+      description: Add configuration files to the request (requires special authorization)
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: The ID of the Cachito request to update
+        schema:
+          type: integer
+      responses:
+        "204":
+          description: The request's configuration files were updated
+        "404":
+          description: The request wasn't found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: The requested resource was not found
+        "400":
+          description: The input is invalid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: The input data must be a JSON object
+      requestBody:
+        description: The configuration files
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/RequestConfiguration"
+      security:
+      - "Kerberos Authentication": []
   "/requests/{id}/download":
     get:
       description: Download a Cachito request bundle
@@ -345,6 +417,25 @@ components:
             type: integer
             example: 1
       - $ref: "#/components/schemas/RequestBase"
+    RequestConfiguration:
+      type: object
+      properties:
+        content:
+          type: any
+          description: This varies based on the type
+          example: IlNodXQgdXAgYnJhaW4gb3IgSSdsbCBzdGFiIHlvdSB3aXRoIGEgUS1UaXAiIC0gSG9tZXIgSi4gU2ltcHNvbg==
+        path:
+          type: string
+          description: The relative path in the bundle that the configuration should be created at
+          example: app/.npmrc
+        type:
+          type: string
+          description: The type of the configuration file content
+          example: base64
+      required:
+      - content
+      - path
+      - type
     RequestNew:
       type: object
       properties:
@@ -405,6 +496,10 @@ components:
       allOf:
       - type: object
         properties:
+          configuration_files:
+            type: string
+            description: The URL to the API endpoint with the configuration files
+            example: "https://cachito.domain.local/api/v1/requests/1/configuration-files"
           dependencies:
             type: array
             items:

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -853,7 +853,7 @@ def test_set_state_not_logged_in(client, db):
         ),
     ),
 )
-def test_state_change_invalid(
+def test_request_patch_invalid(
     app, client, db, worker_auth_env, request_id, payload, status_code, message
 ):
     data = {


### PR DESCRIPTION
This allows Cachito to specify configuration files that must be set by the consumer of the bundle for it to be usable.