### PR TITLE
Don't index the config_file_base64 table's content column

### DIFF
--- a/cachito/web/migrations/versions/193baf9d7cbf_config_file_base64.py
+++ b/cachito/web/migrations/versions/193baf9d7cbf_config_file_base64.py
@@ -25,9 +25,6 @@ def upgrade():
         sa.UniqueConstraint("content", "path"),
     )
     op.create_index(
-        op.f("ix_config_file_base64_content"), "config_file_base64", ["content"], unique=False
-    )
-    op.create_index(
         op.f("ix_config_file_base64_path"), "config_file_base64", ["path"], unique=False
     )
 
@@ -62,6 +59,5 @@ def downgrade():
 
     with op.batch_alter_table("config_file_base64") as batch_op:
         batch_op.drop_index(batch_op.f("ix_config_file_base64_path"))
-        batch_op.drop_index(batch_op.f("ix_config_file_base64_content"))
 
     op.drop_table("config_file_base64")

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -816,7 +816,7 @@ class ConfigFileBase64(ConfigFileBase, db.Model):
     """A configuration file that the consumer must set for the bundle to be usable."""
 
     __table_args__ = (db.UniqueConstraint("content", "path"),)
-    content = db.Column(db.String, nullable=False, index=True)
+    content = db.Column(db.String, nullable=False)
     type_name = "base64"
 
     @classmethod


### PR DESCRIPTION
Databases such as Postgresql do not support indexes on string columns that are over a certain length. Some configuration files will be well over that limit.

This commit modifies an existing migration instead of creating a new one since it hasn't been released.