### PR TITLE
Don't have a unique constraint on the config_file_base64 table

### DIFF
--- a/cachito/web/migrations/versions/193baf9d7cbf_config_file_base64.py
+++ b/cachito/web/migrations/versions/193baf9d7cbf_config_file_base64.py
@@ -22,7 +22,6 @@ def upgrade():
         sa.Column("path", sa.String(), nullable=False),
         sa.Column("content", sa.String(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("content", "path"),
     )
     op.create_index(
         op.f("ix_config_file_base64_path"), "config_file_base64", ["path"], unique=False

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -815,7 +815,6 @@ class ConfigFileBase:
 class ConfigFileBase64(ConfigFileBase, db.Model):
     """A configuration file that the consumer must set for the bundle to be usable."""
 
-    __table_args__ = (db.UniqueConstraint("content", "path"),)
     content = db.Column(db.String, nullable=False)
     type_name = "base64"
 


### PR DESCRIPTION
Databases such as Postgresql do not support unique constraints on string columns that are over a certain length. Some configuration files will be well over that limit.

This commit modifies an existing migration instead of creating a new one since it hasn't been released.