### PR TITLE
Add support for non-registry npm dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ with the `mod_auth_gssapi` module.
 
 ## Package Managers
 
-#### npm
+### npm
 
 The npm package manager works by parsing the `npm-shrinkwrap.json` or `package-lock.json` file
 present in the source repository to determine what dependencies are required to build the
@@ -197,5 +197,13 @@ published alongside your application sources. In addition, they can be used to p
 registry in the event that the application needs to be built without Cachito and the Nexus instance
 it manages.
 
-This package manager does not currently support dependencies not from the npm registry. This will
-come at a later date.
+Cachito can also handle dependencies that are not from the npm registry such as those directly
+from GitHub, a Git repository, or an HTTP(S) URL. If the dependency location is not supported,
+Cachito will fail the request. When Cachito encounters a supported location, it will download the
+dependency, modify the version in the [package.json](https://docs.npmjs.com/files/package.json) to
+be unique, upload it to Nexus, modify the top level project's
+[package.json](https://docs.npmjs.com/files/package.json) and lock files to use the dependency from
+Nexus instead. The modified files will accessible at the `/api/v1/requests/<id>/configuration-files`
+API endpoint. If Cachito encounters this same dependency again in a future request, it will use it
+directly from Nexus rather than downloading it and uploading it again. This guarantees that any
+dependency used for a Cachito request can be used again in a future Cachito request.

--- a/cachito/paths.py
+++ b/cachito/paths.py
@@ -32,6 +32,7 @@ class RequestBundleDir(type(Path())):
         self.gomod_download_dir = self.joinpath("deps", "gomod", cls.go_mod_cache_download_part)
 
         self.npm_deps_dir = self.joinpath("deps", "npm")
+        self.npm_package_file = self.joinpath("app", "package.json")
         self.npm_package_lock_file = self.joinpath("app", "package-lock.json")
         self.npm_shrinkwrap_file = self.joinpath("app", "npm-shrinkwrap.json")
 

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import base64
+import io
+import json
 import logging
 import os
 import random
+import re
 import secrets
+import tarfile
 import tempfile
 import textwrap
 
@@ -17,12 +21,16 @@ from cachito.workers.pkg_managers.general import run_cmd
 __all__ = [
     "download_dependencies",
     "finalize_nexus_for_js_request",
+    "find_package_json",
     "generate_and_write_npmrc_file",
     "generate_npmrc_content",
+    "get_js_hosted_repo_name",
     "get_js_proxy_repo_name",
     "get_js_proxy_repo_url",
     "get_js_proxy_username",
+    "get_npm_component_info_from_nexus",
     "prepare_nexus_for_js_request",
+    "upload_non_registry_dependency",
 ]
 
 log = logging.getLogger(__name__)
@@ -40,7 +48,7 @@ def download_dependencies(request_id, deps):
 
     :param int request_id: the ID of the request these dependencies are being downloaded for
     :param list deps: a list of dependencies where each dependency has the keys: bundled, name,
-        and version
+        version, and version_in_nexus
     :raises CachitoError: if any of the downloads fail
     """
     conf = get_worker_config()
@@ -66,7 +74,13 @@ def download_dependencies(request_id, deps):
         counter = 0
         batch_size = get_worker_config().cachito_js_download_batch_size
         for dep in deps:
-            dep_identifier = f"{dep['name']}@{dep['version']}"
+            if dep.get("version_in_nexus"):
+                version = dep["version_in_nexus"]
+            else:
+                version = dep["version"]
+
+            dep_identifier = f"{dep['name']}@{version}"
+
             if dep["bundled"]:
                 log.debug("Not downloading %s since it is a bundled dependency", dep_identifier)
                 continue
@@ -110,6 +124,45 @@ def finalize_nexus_for_js_request(request_id):
             "consumption"
         )
     return username, password
+
+
+def find_package_json(package_archive):
+    """
+    Find the package.json in a tar achive of an npm package.
+
+    This logic is based on that of the npm CLI. If yarn support is added to Cachito, this may need
+    to be adjusted if the algorithm is different.
+
+    The npm CLI will parse a tar archive stream of the npm package.
+      https://github.com/npm/cli/blob/cf7da1e1a0dc9becbe382ac5abd8830551009a53/node_modules/pacote/lib/finalize-manifest.js#L151
+      https://github.com/npm/cli/blob/cf7da1e1a0dc9becbe382ac5abd8830551009a53/node_modules/pacote/lib/finalize-manifest.js#L154
+    It then gets the package.json contents by callling ``jsonFromStream``.
+      https://github.com/npm/cli/blob/cf7da1e1a0dc9becbe382ac5abd8830551009a53/node_modules/pacote/lib/finalize-manifest.js#L151
+    In ``jsonFromStream``, for each entry in the tar archive, where I assume the ordering in the
+    archive is preserved, search for a package.json file that is one or less levels deep in the
+    directory tree. Once found, it will read the package.json file.
+      https://github.com/npm/cli/blob/cf7da1e1a0dc9becbe382ac5abd8830551009a53/node_modules/pacote/lib/finalize-manifest.js#L200-L218
+    If no package.json file is found, an error is thrown.
+      https://github.com/npm/cli/blob/cf7da1e1a0dc9becbe382ac5abd8830551009a53/node_modules/pacote/lib/finalize-manifest.js#L156-L160
+
+    :param str package_archive: the path to the tar archive of the npm package
+    :return: the path to the package.json file in the tarball or None
+    :rtype: str or None
+    """
+    log.debug("Finding the package.json file in the archive %s", package_archive)
+    with tarfile.open(package_archive, "r:*") as f:
+        # Iterate through all the members of the tar archive in order
+        for member in f.getmembers():
+            # If one or more directories are present in the tar archive, remove the first directory
+            # and then check if the value is equal to package.json
+            #   https://github.com/npm/cli/blob/cf7da1e1a0dc9becbe382ac5abd8830551009a53/node_modules/pacote/lib/finalize-manifest.js#L201-L204
+            if re.sub(r"[^/]+/", "", member.name, count=1) == "package.json":
+                log.debug(
+                    "Found the package.json file at %s in the archive %s",
+                    member.name,
+                    package_archive,
+                )
+                return member.name
 
 
 def generate_and_write_npmrc_file(npm_rc_path, request_id, username, password, custom_ca_path=None):
@@ -167,6 +220,16 @@ def generate_npmrc_content(request_id, username, password, custom_ca_path=None):
     return npm_rc
 
 
+def get_js_hosted_repo_name():
+    """
+    Get the name of NPM hosted repository.
+
+    :return: the name of NPM hosted repository
+    :rtype: str
+    """
+    return "cachito-js-hosted"
+
+
 def get_js_proxy_repo_name(request_id):
     """
     Get the name of npm proxy repository for the request.
@@ -202,6 +265,32 @@ def get_js_proxy_username(request_id):
     return f"cachito-js-{request_id}"
 
 
+def get_npm_component_info_from_nexus(name, version, max_attempts=1):
+    """
+    Get the NPM component information from the NPM hosted repository using Nexus' REST API.
+
+    :param str name: the name of the dependency including the scope if present
+    :param str version: the version of the dependency; a wildcard can be specified but it should
+        not match more than a single version
+    :param int max_attempts: the number of attempts to try to get a result; this defaults to ``1``
+    :return: the JSON about the NPM component or None
+    :rtype: dict or None
+    :raise CachitoError: if the search fails or more than one component is returned
+    """
+    if name.startswith("@"):
+        component_group, component_name = name.split("/", 1)
+        # Remove the "@" prefix
+        component_group = component_group[1:]
+    else:
+        component_name = name
+        component_group = None
+
+    repository = get_js_hosted_repo_name()
+    return nexus.get_component_info_from_nexus(
+        repository, "npm", component_name, version, component_group, max_attempts
+    )
+
+
 def prepare_nexus_for_js_request(request_id):
     """
     Prepare Nexus so that Cachito can stage JavaScript content.
@@ -224,3 +313,74 @@ def prepare_nexus_for_js_request(request_id):
     except NexusScriptError:
         log.exception(f"Failed to execute the script {script_name}")
         raise CachitoError("Failed to prepare Nexus for Cachito to stage JavaScript content")
+
+
+def upload_non_registry_dependency(dep_identifier, version_suffix):
+    """
+    Upload the non-registry npm dependency to the Nexus hosted repository with a custom version.
+
+    :param str dep_identifier: the identifier of the dependency to download
+    :param str version_suffix: the suffix to append to the dependency's version in its package.json
+        file
+    :raise CachitoError: if the dependency cannot be download, uploaded, or is invalid
+    """
+    with tempfile.TemporaryDirectory(prefix="cachito-") as temp_dir:
+        env = {
+            "NPM_CONFIG_CACHE": os.path.join(temp_dir, "cache"),
+            "PATH": os.environ.get("PATH", ""),
+        }
+        run_params = {"env": env, "cwd": temp_dir}
+        npm_pack_args = ["npm", "pack", dep_identifier]
+        log.info("Downloading the npm dependency %s to be uploaded to Nexus", dep_identifier)
+        # An example of the command's stdout:
+        #   "reactivex-rxjs-6.5.5.tgz\n"
+        stdout = run_cmd(
+            npm_pack_args, run_params, f"Failed to download the npm dependency {dep_identifier}"
+        )
+        dep_archive = os.path.join(temp_dir, stdout.strip())
+
+        package_json_rel_path = find_package_json(dep_archive)
+        if not package_json_rel_path:
+            msg = f"The dependency {dep_identifier} does not have a package.json file"
+            log.error(msg)
+            raise CachitoError(msg)
+
+        modified_dep_archive = os.path.join(
+            os.path.dirname(dep_archive), f"modified-{os.path.basename(dep_archive)}"
+        )
+        with tarfile.open(dep_archive, mode="r:*") as dep_archive_file:
+            with tarfile.open(modified_dep_archive, mode="x:gz") as modified_dep_archive_file:
+                for member in dep_archive_file.getmembers():
+                    # Add all the files except for the package.json file without any modifications
+                    if member.path != package_json_rel_path:
+                        modified_dep_archive_file.addfile(
+                            member, dep_archive_file.extractfile(member)
+                        )
+                        continue
+
+                    # Modify the version in the package.json file
+                    try:
+                        package_json = json.load(dep_archive_file.extractfile(member))
+                    except json.JSONDecodeError:
+                        msg = (
+                            f"The dependency {dep_identifier} does not have a valid "
+                            "package.json file"
+                        )
+                        log.exception(msg)
+                        raise CachitoError(msg)
+
+                    new_version = f"{package_json['version']}{version_suffix}"
+                    log.debug(
+                        "Modifying the version of %s from %s to %s",
+                        dep_identifier,
+                        package_json["version"],
+                        new_version,
+                    )
+                    package_json["version"] = new_version
+                    package_json_bytes = json.dumps(package_json, indent=2).encode("utf-8")
+                    package_json_file_obj = io.BytesIO(package_json_bytes)
+                    member.size = len(package_json_bytes)
+                    modified_dep_archive_file.addfile(member, package_json_file_obj)
+
+        repo_name = get_js_hosted_repo_name()
+        nexus.upload_artifact(repo_name, "npm", modified_dep_archive)

--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -1,12 +1,24 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import base64
+import copy
 import json
 import logging
 import os
 
 from cachito.errors import CachitoError
-from cachito.workers.pkg_managers.general_js import download_dependencies
+from cachito.workers.pkg_managers.general_js import (
+    download_dependencies,
+    get_npm_component_info_from_nexus,
+    upload_non_registry_dependency,
+)
 
-__all__ = ["get_package_and_deps", "resolve_npm"]
+__all__ = [
+    "convert_hex_sha512_to_npm",
+    "convert_integrity_to_hex_checksum",
+    "convert_to_nexus_hosted",
+    "get_package_and_deps",
+    "resolve_npm",
+]
 
 log = logging.getLogger(__name__)
 
@@ -24,36 +36,52 @@ def _get_deps(package_lock_deps, _name_to_deps=None):
     a list. If it were a list, there'd be a time complexity of O(n) every time a dependency is to be
     inserted.
 
+    If dependencies not from the NPM registry are encountered and their locations are not
+    supported, then a ``CachitoError`` exception will be raised. If the location is supported,
+    the input ``package_lock_deps`` will be modifed to use a reference to Nexus instead for that
+    dependency.
+
     :param dict package_lock_deps: the value of a "dependencies" key in a package-lock.json file
     :param dict _name_to_deps: the current mapping of dependencies; this is not meant to be set
         by the caller
-    :return: the mapping of dependencies where each key is a dependecy name and the values are
-        dictionaries describing the dependency versions
-    :rtype: dict
-    :raise CachitoError: if the lock file contains a dependency not from the registry
+    :return: a tuple with the first item as the mapping of dependencies where each key is a
+        dependecy name and the values are dictionaries describing the dependency versions; the
+        second item is a list of tuples for non-registry dependency replacements, where the first
+        item is the dependency name and the second item is the version of the dependency in Nexus
+    :rtype: (dict, list)
+    :raise CachitoError: if the lock file contains a dependency from an unsupported location
     """
     if _name_to_deps is None:
         _name_to_deps = {}
 
+    nexus_replacements = []
     for name, info in package_lock_deps.items():
-        # Note that if a dependency has bundled dependencies, they will not have the "resolved" key
-        # set. This is okay since they are included in the dependency that bundled them. This will
-        # be marked below so that any function that uses the results of this function will know
-        # not to download these dependencies explicitly.
+        nexus_replacement = None
+        version_in_nexus = None
+        # Note that a bundled dependency will not have the "resolved" key, but those are supported
+        # since they are properly cached in the parent dependency in Nexus
         if not info.get("bundled", False) and "resolved" not in info:
-            log.error("The dependency %r is not from the npm registry", info)
-            raise CachitoError(
-                "The lock file contains a dependency not from the npm registry. "
-                "This is not yet supported."
-            )
+            log.info("The dependency %r is not from the npm registry", info)
+            # If the non-registry isn't supported, convert_to_nexus_hosted will raise a
+            # CachitoError exception
+            nexus_replacement = convert_to_nexus_hosted(name, info)
+            version_in_nexus = nexus_replacement["version"]
+            nexus_replacements.append((name, version_in_nexus))
 
         dep = {
             "bundled": info.get("bundled", False),
             "dev": info.get("dev", False),
             "name": name,
+            "version_in_nexus": version_in_nexus,
             "type": "npm",
             "version": info["version"],
         }
+        if nexus_replacement:
+            # Replace the original dependency in the npm-shrinkwrap.json or package-lock.json file
+            # with the dependency in the Nexus hosted repo
+            info.clear()
+            info.update(nexus_replacement)
+
         _name_to_deps.setdefault(name, [])
         for d in _name_to_deps[name]:
             if d["version"] == dep["version"]:
@@ -70,28 +98,183 @@ def _get_deps(package_lock_deps, _name_to_deps=None):
             _name_to_deps[name].append(dep)
 
         if "dependencies" in info:
-            _get_deps(info["dependencies"], _name_to_deps)
+            _, returned_nexus_replacements = _get_deps(info["dependencies"], _name_to_deps)
+            # If any of the dependencies were non-registry dependencies, replace the requires to be
+            # the version in Nexus
+            for name, version in returned_nexus_replacements:
+                info["requires"][name] = version
 
-    return _name_to_deps
+    return _name_to_deps, nexus_replacements
 
 
-def get_package_and_deps(package_lock_path):
+def convert_hex_sha512_to_npm(hex_sha512):
+    """
+    Convert the input sha512 checksum in hex to the format that an npm lock file uses.
+
+    This is useful for converting sha512 checksums from Nexus.
+
+    :param str hex_sha512: the sha512 checksum in hex
+    :return: the sha512 checksum in npm package-lock.json file format
+    :rtype: str
+    """
+    bytes_sha512 = bytes.fromhex(hex_sha512)
+    base64_sha512 = base64.b64encode(bytes_sha512).decode("utf-8")
+    return f"sha512-{base64_sha512}"
+
+
+def convert_integrity_to_hex_checksum(integrity):
+    """
+    Convert the input integrity value of a dependency to a hex checksum.
+
+    The integrity is a key in an npm lock file that contains the checksum of the dependency in the
+    format of ``<algorithm>-<base64 of the binary hash>``.
+
+    :param str integrity: the integrity from the npm lock file
+    :return: a tuple where the first item is the algorithm used and second is the hex value of
+        the checksum
+    :rtype: (str, str)
+    """
+    algorithm, checksum = integrity.split("-", 1)
+    return algorithm, base64.b64decode(checksum).hex()
+
+
+def convert_to_nexus_hosted(dep_name, dep_info):
+    """
+    Convert the input dependency not from the NPM registry to a Nexus hosted dependency.
+
+    :param str dep_name: the name of the dependency
+    :param dict dep_info: the dependency info from the npm lock file (e.g. package-lock.json)
+    :return: the dependency information of the Nexus hosted version to use in the npm lock file
+        instead of the original
+    :raise CachitoError: if the dependency is from an unsupported location or has an unexpected
+        format in the lock file
+    """
+    git_prefixes = {
+        "git://",
+        "git+http://",
+        "git+https://",
+        "git+ssh://",
+        "github:",
+        "bitbucket:",
+        "gitlab:",
+    }
+    http_prefixes = {"http://", "https://"}
+    # The version value for a dependency outside of the npm registry is the identifier to use for
+    # commands such as `npm pack` or `npm install`
+    # Examples of version values:
+    #   git+https://github.com/ReactiveX/rxjs.git#dfa239d41b97504312fa95e13f4d593d95b49c4b
+    #   github:ReactiveX/rxjs#78032157f5c1655436829017bbda787565b48c30
+    #   https://github.com/jsplumb/jsplumb/archive/2.10.2.tar.gz
+    dep_identifier = dep_info["version"]
+    if any(dep_identifier.startswith(prefix) for prefix in git_prefixes):
+        try:
+            _, commit_hash = dep_identifier.rsplit("#", 1)
+        except ValueError:
+            msg = (
+                f"The dependency {dep_identifier} in the npm lock file was in an unexpected format"
+            )
+            log.error(msg)
+            raise CachitoError(msg)
+        # When the dependency is uploaded to the Nexus hosted repository, it will be in the format
+        # of `<version>-external-<commit hash>`
+        version_suffix = f"-external-{commit_hash}"
+    elif any(dep_identifier.startswith(prefix) for prefix in http_prefixes):
+        if "integrity" not in dep_info:
+            msg = f"The dependency {dep_identifier} is missing the integrity value in the lock file"
+            log.error(msg)
+            raise CachitoError(msg)
+
+        algorithm, checksum = convert_integrity_to_hex_checksum(dep_info["integrity"])
+        # When the dependency is uploaded to the Nexus hosted repository, it will be in the format
+        # of `<version>-external-<checksum algorithm>-<hex checksum>`
+        version_suffix = f"-external-{algorithm}-{checksum}"
+    else:
+        raise CachitoError(f"The dependency {dep_identifier} is hosted in an unsupported location")
+
+    component_info = get_npm_component_info_from_nexus(dep_name, f"*{version_suffix}")
+    if not component_info:
+        upload_non_registry_dependency(dep_identifier, version_suffix)
+        component_info = get_npm_component_info_from_nexus(
+            dep_name, f"*{version_suffix}", max_attempts=5
+        )
+        if not component_info:
+            raise CachitoError(
+                f"The dependency {dep_identifier} was uploaded to Nexus but is not accessible"
+            )
+
+    converted_dep_info = copy.deepcopy(dep_info)
+    # The "from" value is the original value from package.json for some locations
+    converted_dep_info.pop("from", None)
+    converted_dep_info.update(
+        {
+            "integrity": convert_hex_sha512_to_npm(
+                component_info["assets"][0]["checksum"]["sha512"]
+            ),
+            "resolved": component_info["assets"][0]["downloadUrl"],
+            "version": component_info["version"],
+        }
+    )
+    return converted_dep_info
+
+
+def get_package_and_deps(package_json_path, package_lock_path):
     """
     Get the main package and dependencies based on the lock file.
 
+    If the lockfile contains non-registry dependencies, the lock file will be modified to use ones
+    in Nexus. Non-registry dependencies will have the "version_in_nexus" key set.
+
+    :param str package_json_path: the path to the package.json file
     :param str package_lock_path: the path to the lock file
-    :return: the dictionary of the main package and the list of dependencies
-    :rtype: (dict, list)
+    :return: a dictionary that has the keys "deps" which is the list of dependencies,
+        "lock_file" which is the lock file if it was modified, "package" which is the
+        dictionary describing the main package, and "package.json" which is the package.json file if
+        it was modified.
+    :rtype: dict
     """
     with open(package_lock_path, "r") as f:
         package_lock = json.load(f)
 
-    name_to_deps = _get_deps(package_lock.get("dependencies", {}))
+    package_lock_original = copy.deepcopy(package_lock)
+    name_to_deps, top_level_replacements = _get_deps(package_lock.get("dependencies", {}))
     # Convert the name_to_deps mapping to a list now that it's fully populated
     deps = [dep_info for deps_info in name_to_deps.values() for dep_info in deps_info]
     package = {"name": package_lock["name"], "type": "npm", "version": package_lock["version"]}
 
-    return package, deps
+    rv = {
+        "deps": deps,
+        "lock_file": None,
+        "package": package,
+        "package.json": None,
+    }
+
+    # If top level replacements are returned, the package.json may need to be updated to use
+    # the replaced dependencies in the lock file. If these updates don't occur, running
+    # `npm install` causes the lock file to be updated since it's assumed that it's out of date.
+    if top_level_replacements:
+        with open(package_json_path, "r") as f:
+            package_json = json.load(f)
+
+        package_json_original = copy.deepcopy(package_json)
+        for dep_name, dep_version in top_level_replacements:
+            for dep_type in ("dependencies", "devDependencies"):
+                if dep_name in package_json.get(dep_type, {}):
+                    log.info(
+                        "Replacing the version of %s in %s from %s to %s in package.json",
+                        dep_name,
+                        dep_type,
+                        package_json[dep_type][dep_name],
+                        dep_version,
+                    )
+                    package_json[dep_type][dep_name] = dep_version
+
+        if package_json != package_json_original:
+            rv["package.json"] = package_json
+
+    if package_lock != package_lock_original:
+        rv["lock_file"] = package_lock
+
+    return rv
 
 
 def resolve_npm(app_source_path, request):
@@ -100,10 +283,12 @@ def resolve_npm(app_source_path, request):
 
     :param str app_source_path: the full path to the application source code
     :param dict request: the Cachito request this is for
-    :return: a tuple of the npm package itself and the list of dictionaries representing the
-        dependencies
-    :rtype: (dict, list)
-    :raises CachitoError: if fetching the dependencies fails
+    :return: a dictionary that has the keys "deps" which is the list of dependencies,
+        "lock_file" which is the lock file if it was modified, "package" which is the
+        dictionary describing the main package, and "package.json" which is the package.json file if
+        it was modified.
+    :rtype: dict
+    :raises CachitoError: if fetching the dependencies fails or required files are missing
     """
     # npm-shrinkwrap.json and package-lock.json share the same format but serve slightly
     # different purposes. See the following documentation for more information:
@@ -118,19 +303,25 @@ def resolve_npm(app_source_path, request):
             "package manager"
         )
 
+    package_json_path = os.path.join(app_source_path, "package.json")
+    if not os.path.exists(package_json_path):
+        raise CachitoError("The package.json file must be present for the npm package manager")
+
     try:
-        package, deps = get_package_and_deps(package_lock_path)
+        package_and_deps_info = get_package_and_deps(package_json_path, package_lock_path)
     except KeyError:
         msg = f"The lock file {lock_file} has an unexpected format"
         log.exception(msg)
         raise CachitoError(msg)
+
     # By downloading the dependencies, it stores the tarballs in the bundle and also stages the
     # content in the npm repository for the request
-    download_dependencies(request["id"], deps)
+    download_dependencies(request["id"], package_and_deps_info["deps"])
 
     # Remove all the "bundled" keys since that is an implementation detail that should not be
     # exposed outside of this function
-    for dep in deps:
+    for dep in package_and_deps_info["deps"]:
         dep.pop("bundled")
+        dep.pop("version_in_nexus")
 
-    return package, deps
+    return package_and_deps_info

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import json
+import io
+import os
+import tarfile
+import textwrap
 from unittest import mock
 
 import pytest
-import textwrap
 
 from cachito.errors import CachitoError
 from cachito.workers.errors import NexusScriptError
@@ -17,9 +21,34 @@ def test_download_dependencies(mock_run_cmd, mock_rbd, mock_gawnf, mock_td):
     mock_td.return_value.__enter__.return_value = "/tmp/cachito-agfdsk"
 
     deps = [
-        {"bundled": False, "dev": True, "name": "@angular-devkit/architect", "version": "0.803.26"},
-        {"bundled": False, "dev": False, "name": "@angular/animations", "version": "8.2.14"},
-        {"bundled": True, "dev": True, "name": "object-assign", "version": "4.1.1"},
+        {
+            "bundled": False,
+            "dev": True,
+            "name": "@angular-devkit/architect",
+            "version": "0.803.26",
+            "version_in_nexus": None,
+        },
+        {
+            "bundled": False,
+            "dev": False,
+            "name": "@angular/animations",
+            "version": "8.2.14",
+            "version_in_nexus": None,
+        },
+        {
+            "bundled": True,
+            "dev": True,
+            "name": "object-assign",
+            "version": "4.1.1",
+            "version_in_nexus": None,
+        },
+        {
+            "bundled": False,
+            "dev": False,
+            "name": "rxjs",
+            "version": "github:ReactiveX/rxjs#78032157f5c1655436829017bbda787565b48c30",
+            "version_in_nexus": "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+        },
     ]
     request_id = 1
     general_js.download_dependencies(request_id, deps)
@@ -32,6 +61,7 @@ def test_download_dependencies(mock_run_cmd, mock_rbd, mock_gawnf, mock_td):
         "pack",
         "@angular-devkit/architect@0.803.26",
         "@angular/animations@8.2.14",
+        "rxjs@6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
     ]
     assert mock_run_cmd.call_args[0][0] == expected_npm_pack
     run_cmd_env_vars = mock_run_cmd.call_args[0][1]["env"]
@@ -63,6 +93,30 @@ def test_finalize_nexus_for_js_request_failed(mock_exec_script):
     )
     with pytest.raises(CachitoError, match=expected):
         _, password = general_js.finalize_nexus_for_js_request(1)
+
+
+def test_find_package_json(tmpdir):
+    tarfile_path = os.path.join(tmpdir, "npm-package.tgz")
+    with tarfile.open(tarfile_path, "x:gz") as archive:
+        archive.addfile(tarfile.TarInfo("in/a/galaxy/far/far/away/package.json"))
+        archive.addfile(tarfile.TarInfo("in/too/deep/package.json"))
+        archive.addfile(tarfile.TarInfo("wrong_file.json"))
+        archive.addfile(tarfile.TarInfo("package/index.html"))
+        archive.addfile(tarfile.TarInfo("package2/package.json"))
+        archive.addfile(tarfile.TarInfo("package/package.json"))
+
+    assert general_js.find_package_json(tarfile_path) == "package2/package.json"
+
+
+def test_find_package_json_no_package_json(tmpdir):
+    tarfile_path = os.path.join(tmpdir, "random.tgz")
+    with tarfile.open(tarfile_path, "x:gz") as archive:
+        archive.addfile(tarfile.TarInfo("wrong_file.json"), b"{}")
+        archive.addfile(
+            tarfile.TarInfo("package/tom_hanks_quotes.html"),
+            b"<p>Life is like a box of chocolates. You never know what you're gonna get.<p>",
+        )
+    assert general_js.find_package_json(tarfile_path) is None
 
 
 @pytest.mark.parametrize("custom_ca_path", (None, "./registry-ca.pem"))
@@ -103,6 +157,10 @@ def test_generate_and_write_npmrc_file(mock_gen_npmrc):
     mock_open().write.assert_called_once_with(npmrc_content)
 
 
+def test_get_js_hosted_repo_name():
+    assert general_js.get_js_hosted_repo_name() == "cachito-js-hosted"
+
+
 def test_get_js_proxy_repo_name():
     assert general_js.get_js_proxy_repo_name(3) == "cachito-js-3"
 
@@ -113,6 +171,49 @@ def test_get_js_proxy_repo_url():
 
 def test_get_js_proxy_username():
     assert general_js.get_js_proxy_username(3) == "cachito-js-3"
+
+
+@pytest.mark.parametrize("group", ("@reactive", None))
+@mock.patch("cachito.workers.pkg_managers.general_js.nexus.get_component_info_from_nexus")
+def test_get_npm_component_info_from_nexus(mock_gcifn, group):
+    if group:
+        identifier = f"{group}/rxjs"
+    else:
+        identifier = "rxjs"
+
+    component = {
+        "id": "Y2FjaGl0by1qcy1ob3N0ZWQ6ZDQ4MTE3NTQxZGNiODllYzYxM2IyMzk3MzIwMWQ3YmE",
+        "repository": "cachito-js-hosted",
+        "format": "npm",
+        "group": group[1:] if group else None,
+        "name": "rxjs",
+        "version": "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+    }
+    mock_gcifn.return_value = component
+
+    rv = general_js.get_npm_component_info_from_nexus(
+        identifier, "6.5.5-external-78032157f5c1655436829017bbda787565b48c30", max_attempts=3
+    )
+
+    assert rv == component
+    if group:
+        mock_gcifn.assert_called_once_with(
+            "cachito-js-hosted",
+            "npm",
+            "rxjs",
+            "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+            "reactive",
+            3,
+        )
+    else:
+        mock_gcifn.assert_called_once_with(
+            "cachito-js-hosted",
+            "npm",
+            "rxjs",
+            "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+            None,
+            3,
+        )
 
 
 @mock.patch("cachito.workers.pkg_managers.general_js.nexus.execute_script")
@@ -136,3 +237,76 @@ def test_prepare_nexus_for_js_request_failed(mock_exec_script):
     expected = "Failed to prepare Nexus for Cachito to stage JavaScript content"
     with pytest.raises(CachitoError, match=expected):
         _, password = general_js.prepare_nexus_for_js_request(1)
+
+
+@mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
+@mock.patch("cachito.workers.pkg_managers.general_js.run_cmd")
+@mock.patch("cachito.workers.pkg_managers.general_js.find_package_json")
+@mock.patch("cachito.workers.pkg_managers.general_js.nexus.upload_artifact")
+def test_upload_non_registry_dependency(mock_ua, mock_fpj, mock_run_cmd, mock_td, tmpdir):
+    tarfile_path = os.path.join(tmpdir, "star-wars-5.0.0.tgz")
+    with tarfile.open(tarfile_path, "x:gz") as archive:
+        tar_info = tarfile.TarInfo("package/salutation.html")
+        content = b"<h1>Bonjour monsieur Solo!</h1>"
+        tar_info.size = len(content)
+        archive.addfile(tar_info, io.BytesIO(content))
+
+        tar_info = tarfile.TarInfo("package/package.json")
+        content = b'{"version": "5.0.0"}'
+        tar_info.size = len(content)
+        archive.addfile(tar_info, io.BytesIO(content))
+
+    mock_td.return_value.__enter__.return_value = str(tmpdir)
+    mock_run_cmd.return_value = "star-wars-5.0.0.tgz\n"
+    mock_fpj.return_value = "package/package.json"
+
+    general_js.upload_non_registry_dependency("star-wars@5.0.0", "-the-empire-strikes-back")
+
+    modified_tarfile_path = os.path.join(tmpdir, "modified-star-wars-5.0.0.tgz")
+    with tarfile.open(modified_tarfile_path, "r:*") as f:
+        # Verify that the archive has the original members in order
+        members = {m.path for m in f.getmembers()}
+        assert members == {"package/salutation.html", "package/package.json"}
+        # Verify that the archive had its version updated
+        new_version = json.load(f.extractfile("package/package.json"))["version"]
+        assert new_version == "5.0.0-the-empire-strikes-back"
+
+    mock_run_cmd.assert_called_once_with(["npm", "pack", "star-wars@5.0.0"], mock.ANY, mock.ANY)
+    mock_fpj.assert_called_once_with(tarfile_path)
+    mock_ua.assert_called_once_with("cachito-js-hosted", "npm", modified_tarfile_path)
+
+
+@mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
+@mock.patch("cachito.workers.pkg_managers.general_js.run_cmd")
+@mock.patch("cachito.workers.pkg_managers.general_js.find_package_json")
+def test_upload_non_registry_dependency_no_package_json(mock_fpj, mock_run_cmd, mock_td, tmpdir):
+    mock_td.return_value.__enter__.return_value = str(tmpdir)
+    mock_run_cmd.return_value = "star-wars-5.0.0.tgz\n"
+    mock_fpj.return_value = None
+
+    expected = "The dependency star-wars@5.0.0 does not have a package.json file"
+    with pytest.raises(CachitoError, match=expected):
+        general_js.upload_non_registry_dependency("star-wars@5.0.0", "-the-empire-strikes-back")
+
+
+@mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
+@mock.patch("cachito.workers.pkg_managers.general_js.run_cmd")
+@mock.patch("cachito.workers.pkg_managers.general_js.find_package_json")
+@mock.patch("cachito.workers.pkg_managers.general_js.nexus.upload_artifact")
+def test_upload_non_registry_dependency_invalid_package_json(
+    mock_ua, mock_fpj, mock_run_cmd, mock_td, tmpdir
+):
+    tarfile_path = os.path.join(tmpdir, "star-wars-5.0.0.tgz")
+    with tarfile.open(tarfile_path, "x:gz") as archive:
+        tar_info = tarfile.TarInfo("package/package.json")
+        content = b"Not JSON!"
+        tar_info.size = len(content)
+        archive.addfile(tar_info, io.BytesIO(content))
+
+    mock_td.return_value.__enter__.return_value = str(tmpdir)
+    mock_run_cmd.return_value = "star-wars-5.0.0.tgz\n"
+    mock_fpj.return_value = "package/package.json"
+
+    expected = "The dependency star-wars@5.0.0 does not have a valid package.json file"
+    with pytest.raises(CachitoError, match=expected):
+        general_js.upload_non_registry_dependency("star-wars@5.0.0", "-the-empire-strikes-back")

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -78,6 +78,7 @@ def package_and_deps():
             "name": "@angular-devkit/architect",
             "type": "npm",
             "version": "0.803.26",
+            "version_in_nexus": None,
         },
         {
             "bundled": False,
@@ -85,16 +86,43 @@ def package_and_deps():
             "name": "@angular/animations",
             "type": "npm",
             "version": "8.2.14",
+            "version_in_nexus": None,
         },
-        {"bundled": False, "dev": True, "name": "rxjs", "type": "npm", "version": "6.4.0"},
-        {"bundled": False, "dev": False, "name": "rxjs", "type": "npm", "version": "6.5.5"},
-        {"bundled": False, "dev": False, "name": "tslib", "type": "npm", "version": "1.11.1"},
+        {
+            "bundled": False,
+            "dev": True,
+            "name": "rxjs",
+            "type": "npm",
+            "version": "6.4.0",
+            "version_in_nexus": None,
+        },
+        {
+            "bundled": False,
+            "dev": False,
+            "name": "rxjs",
+            "type": "npm",
+            "version": "6.5.5",
+            "version_in_nexus": None,
+        },
+        {
+            "bundled": False,
+            "dev": False,
+            "name": "tslib",
+            "type": "npm",
+            "version": "1.11.1",
+            "version_in_nexus": None,
+        },
     ]
-    return (package, deps)
+    return {
+        "deps": deps,
+        "lock_file": None,
+        "package": package,
+        "package.json": None,
+    }
 
 
 def test_get_deps(package_lock_deps):
-    name_to_deps = npm._get_deps(package_lock_deps)
+    name_to_deps, replacements = npm._get_deps(package_lock_deps)
 
     assert name_to_deps == {
         "@angular-devkit/architect": [
@@ -104,6 +132,7 @@ def test_get_deps(package_lock_deps):
                 "name": "@angular-devkit/architect",
                 "type": "npm",
                 "version": "0.803.26",
+                "version_in_nexus": None,
             }
         ],
         "@angular/animations": [
@@ -113,19 +142,352 @@ def test_get_deps(package_lock_deps):
                 "name": "@angular/animations",
                 "type": "npm",
                 "version": "8.2.14",
+                "version_in_nexus": None,
             }
         ],
         "rxjs": [
-            {"bundled": False, "dev": True, "name": "rxjs", "type": "npm", "version": "6.4.0"},
-            {"bundled": False, "dev": False, "name": "rxjs", "type": "npm", "version": "6.5.5"},
+            {
+                "bundled": False,
+                "dev": True,
+                "name": "rxjs",
+                "type": "npm",
+                "version": "6.4.0",
+                "version_in_nexus": None,
+            },
+            {
+                "bundled": False,
+                "dev": False,
+                "name": "rxjs",
+                "type": "npm",
+                "version": "6.5.5",
+                "version_in_nexus": None,
+            },
         ],
         "tslib": [
-            {"bundled": False, "dev": False, "name": "tslib", "type": "npm", "version": "1.11.1"}
+            {
+                "bundled": False,
+                "dev": False,
+                "name": "tslib",
+                "type": "npm",
+                "version": "1.11.1",
+                "version_in_nexus": None,
+            }
         ],
     }
+    assert replacements == []
 
 
-def test_get_deps_non_registry_dep():
+@mock.patch("cachito.workers.pkg_managers.npm.convert_to_nexus_hosted")
+def test_get_deps_non_registry_dep(mock_ctnh, package_lock_deps):
+    # Set the rxjs dependencies to be directly from GitHub
+    package_lock_deps["@angular-devkit/architect"]["dependencies"]["rxjs"] = {
+        "version": "github:ReactiveX/rxjs#dfa239d41b97504312fa95e13f4d593d95b49c4b",
+        "from": "github:ReactiveX/rxjs#dfa239d41b97504312fa95e13f4d593d95b49c4b",
+        "requires": {"tslib": "^1.9.0"},
+    }
+    nexus_hosted_info = {
+        "version": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+        "resolved": (
+            "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
+            "rxjs-6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+        ),
+        "integrity": (
+            "sha512-vvAdzoVTdbr5Lq7BI2+l4R3dM4Mw7305wNKLgij8ru7sx3Fuo1W2XrsoTXWfPtIk+kxiBXxCoc8UX"
+            "1Vb45kbRQ=="
+        ),
+        "requires": {"tslib": "^1.9.0"},
+    }
+
+    package_lock_deps["rxjs"] = {
+        "version": "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "from": "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "requires": {"tslib": "^1.9.0"},
+    }
+    nexus_hosted_info_two = {
+        "version": "6.5.2-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "resolved": (
+            "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
+            "rxjs-6.5.2-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5.tgz"
+        ),
+        "integrity": (
+            "sha512-AvAdzoVTdVT5Lq7BI2+l5R3dM4Mw7305wNKLgij8rh7sx3Fuo1W2XrsoTXWfPtIk+kxiBXxCoc8UX"
+            "1Vb45kbRP=="
+        ),
+        "requires": {"tslib": "^1.9.0"},
+    }
+
+    # Python 3 iterates through a dictionary in alphabetical order, so this order will always be
+    # correct
+    mock_ctnh.side_effect = [copy.deepcopy(nexus_hosted_info), copy.deepcopy(nexus_hosted_info_two)]
+
+    name_to_deps, replacements = npm._get_deps(package_lock_deps)
+
+    assert name_to_deps == {
+        "@angular-devkit/architect": [
+            {
+                "bundled": False,
+                "dev": True,
+                "name": "@angular-devkit/architect",
+                "type": "npm",
+                "version": "0.803.26",
+                "version_in_nexus": None,
+            }
+        ],
+        "@angular/animations": [
+            {
+                "bundled": False,
+                "dev": False,
+                "name": "@angular/animations",
+                "type": "npm",
+                "version": "8.2.14",
+                "version_in_nexus": None,
+            }
+        ],
+        "rxjs": [
+            {
+                "bundled": False,
+                "dev": False,
+                "name": "rxjs",
+                "type": "npm",
+                "version": "github:ReactiveX/rxjs#dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                "version_in_nexus": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+            },
+            {
+                "bundled": False,
+                "dev": False,
+                "name": "rxjs",
+                "type": "npm",
+                "version": "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+                "version_in_nexus": "6.5.2-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+            },
+        ],
+        "tslib": [
+            {
+                "bundled": False,
+                "dev": False,
+                "name": "tslib",
+                "type": "npm",
+                "version": "1.11.1",
+                "version_in_nexus": None,
+            }
+        ],
+    }
+    # Verify that only the top level replacements are returned
+    assert replacements == [("rxjs", "6.5.2-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5")]
+    # Ensure the lock file was updated with the Nexus hosted dependency
+    assert (
+        package_lock_deps["@angular-devkit/architect"]["dependencies"]["rxjs"] == nexus_hosted_info
+    )
+    assert package_lock_deps["rxjs"] == nexus_hosted_info_two
+    assert package_lock_deps["@angular-devkit/architect"]["requires"] == {
+        "@angular-devkit/core": "8.3.26",
+        "rxjs": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+    }
+
+    assert mock_ctnh.call_count == 2
+
+
+def test_convert_hex_sha512_to_npm():
+    checksum = (
+        "325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342b5507481408832bfaac8e48f344"
+        "dc650c8df0f8182c0271ed9fa233aa32c329839"
+    )
+    rv = npm.convert_hex_sha512_to_npm(checksum)
+
+    expected = (
+        "sha512-Ml8Hhh4KuIjZBgaxB0/elW/TlU3MTG5Bjb/52KqDQrVQdIFAiDK/qsjkjzRNxlDI3w+BgsAnHtn6Izqj"
+        "LDKYOQ=="
+    )
+    assert rv == expected
+
+
+def convert_integrity_to_hex_checksum():
+    integrity = (
+        "sha512-Ml8Hhh4KuIjZBgaxB0/elW/TlU3MTG5Bjb/52KqDQrVQdIFAiDK/qsjkjzRNxlDI3w+BgsAnHtn6Izqj"
+        "LDKYOQ=="
+    )
+
+    rv = npm.convert_integrity_to_hex_checksum(integrity)
+
+    expected = (
+        "325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342b5507481408832bfaac8e48f344"
+        "dc650c8df0f8182c0271ed9fa233aa32c329839"
+    )
+    assert rv == expected
+
+
+@pytest.mark.parametrize("exists", (False, True))
+@mock.patch("cachito.workers.pkg_managers.npm.get_npm_component_info_from_nexus")
+@mock.patch("cachito.workers.pkg_managers.npm.upload_non_registry_dependency")
+def test_convert_to_nexus_hosted_github(mock_unrd, mock_gncifn, exists):
+    checksum = (
+        "325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342b5507481408832bfaac8e48f344"
+        "dc650c8df0f8182c0271ed9fa233aa32c329839"
+    )
+    # The information returned from Nexus of the uploaded component
+    nexus_component_info = {
+        "assets": [
+            {
+                "checksum": {"sha512": checksum},
+                "downloadUrl": (
+                    "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
+                    "rxjs-6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+                ),
+            }
+        ],
+        "version": "6.5.5-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+    }
+    if exists:
+        mock_gncifn.return_value = nexus_component_info
+    else:
+        mock_gncifn.side_effect = [None, nexus_component_info]
+
+    dep_name = "rxjs"
+    # The information from the lock file
+    dep_info = {
+        "version": "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "from": "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "requires": {"tslib": "^1.9.0"},
+    }
+    new_dep_info = npm.convert_to_nexus_hosted(dep_name, dep_info)
+
+    # Verify the information to update the lock file with is correct
+    assert new_dep_info == {
+        "integrity": (
+            "sha512-Ml8Hhh4KuIjZBgaxB0/elW/TlU3MTG5Bjb/52KqDQrVQdIFAiDK/qsjkjzRNxlDI3w+BgsAnHtn6I"
+            "zqjLDKYOQ=="
+        ),
+        "requires": {"tslib": "^1.9.0"},
+        "resolved": (
+            "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/rxjs-6.5.5-"
+            "external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+        ),
+        "version": "6.5.5-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+    }
+    if exists:
+        mock_gncifn.assert_called_once_with(
+            "rxjs", "*-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5"
+        )
+        # Verify no upload occurs when the component already exists in Nexus
+        mock_unrd.assert_not_called()
+    else:
+        assert mock_gncifn.call_count == 2
+        mock_gncifn.assert_has_calls(
+            [
+                mock.call("rxjs", "*-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5"),
+                mock.call(
+                    "rxjs", "*-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5", max_attempts=5
+                ),
+            ]
+        )
+        mock_unrd.assert_called_once_with(
+            "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+            "-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        )
+
+
+@mock.patch("cachito.workers.pkg_managers.npm.get_npm_component_info_from_nexus")
+def test_convert_to_nexus_hosted_http(mock_gncifn):
+    checksum = (
+        "325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342b5507481408832bfaac8e48f344"
+        "dc650c8df0f8182c0271ed9fa233aa32c329839"
+    )
+    nexus_component_info = {
+        "assets": [
+            {
+                "checksum": {"sha512": checksum},
+                "downloadUrl": (
+                    "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
+                    "rxjs-6.5.5-external-sha512-325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418d"
+                    "bff9d8aa8342b5507481408832bfaac8e48f344.tgz"
+                ),
+            }
+        ],
+        "version": (
+            "6.5.5-external-sha512-325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342"
+            "b5507481408832bfaac8e48f344"
+        ),
+    }
+    mock_gncifn.return_value = nexus_component_info
+
+    dep_name = "rxjs"
+    dep_info = {
+        "version": "https://github.com/ReactiveX/rxjs/archive/6.5.5.tar.gz",
+        "requires": {"tslib": "^1.9.0"},
+        "integrity": (
+            "sha512-Ml8Hhh4KuIjZBgaxB0/elW/TlU3MTG5Bjb/52KqDQrVQdIFAiDK/qsjkjzRNxlDI3w+BgsAnHtn6I"
+            "zqjLDKYOQ=="
+        ),
+    }
+    new_dep_info = npm.convert_to_nexus_hosted(dep_name, dep_info)
+
+    assert new_dep_info == {
+        "integrity": (
+            "sha512-Ml8Hhh4KuIjZBgaxB0/elW/TlU3MTG5Bjb/52KqDQrVQdIFAiDK/qsjkjzRNxlDI3w+BgsAnHtn6I"
+            "zqjLDKYOQ=="
+        ),
+        "requires": {"tslib": "^1.9.0"},
+        "resolved": (
+            "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/rxjs-6.5.5-"
+            "external-sha512-325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342b55074"
+            "81408832bfaac8e48f344.tgz"
+        ),
+        "version": (
+            "6.5.5-external-sha512-325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8"
+            "aa8342b5507481408832bfaac8e48f344"
+        ),
+    }
+    mock_gncifn.assert_called_once_with(
+        "rxjs",
+        (
+            "*-external-sha512-325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342b5507"
+            "481408832bfaac8e48f344dc650c8df0f8182c0271ed9fa233aa32c329839"
+        ),
+    )
+
+
+def test_convert_to_nexus_hosted_http_integrity_missing():
+    dep_identifier = "https://github.com/ReactiveX/rxjs/archive/6.5.5.tar.gz"
+    dep_name = "rxjs"
+    dep_info = {
+        "version": dep_identifier,
+        "requires": {"tslib": "^1.9.0"},
+    }
+    expected = f"The dependency {dep_identifier} is missing the integrity value in the lock file"
+    with pytest.raises(CachitoError, match=expected):
+        npm.convert_to_nexus_hosted(dep_name, dep_info)
+
+
+def test_convert_to_nexus_hosted_invalid_location():
+    dep_identifier = "file:rxjs-6.5.5.tar.gz"
+    dep_name = "rxjs"
+    dep_info = {
+        "version": dep_identifier,
+        "requires": {"tslib": "^1.9.0"},
+    }
+    expected = f"The dependency {dep_identifier} is hosted in an unsupported location"
+    with pytest.raises(CachitoError, match=expected):
+        npm.convert_to_nexus_hosted(dep_name, dep_info)
+
+
+@mock.patch("cachito.workers.pkg_managers.npm.get_npm_component_info_from_nexus")
+@mock.patch("cachito.workers.pkg_managers.npm.upload_non_registry_dependency")
+def test_convert_to_nexus_hosted_github_not_in_nexus(mock_unrd, mock_gncifn):
+    mock_gncifn.return_value = None
+
+    dep_identifier = "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5"
+    dep_name = "rxjs"
+    dep_info = {
+        "version": dep_identifier,
+        "from": "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "requires": {"tslib": "^1.9.0"},
+    }
+    expected = f"The dependency {dep_identifier} was uploaded to Nexus but is not accessible"
+    with pytest.raises(CachitoError, match=expected):
+        npm.convert_to_nexus_hosted(dep_name, dep_info)
+
+
+def test_get_deps_unsupported_non_registry_dep():
     package_lock_deps = {
         "@angular/animations": {
             "version": "8.2.14",
@@ -137,13 +499,14 @@ def test_get_deps_non_registry_dep():
             "requires": {"tslib": "^1.9.0"},
         },
         "tslib": {
-            "version": "github:microsoft/tslib#c1f87f79190d61e1e4ca24af03894771cdf1aef9",
-            "from": "github:microsoft/tslib",
+            "version": "file:tslib.tar.gz",
+            "integrity": (
+                "sha512-ZETBuz/jo9ivHHolRRfYZgK5Zd2F5KZ/Yk7iygP8y8YEFLe5ZHCVY5zJMHiP3WeA8M/yvPKN7"
+                "XJpM03KH7FtPw=="
+            ),
         },
     }
-    expected = (
-        "The lock file contains a dependency not from the npm registry. This is not yet supported."
-    )
+    expected = "The dependency file:tslib.tar.gz is hosted in an unsupported location"
     with pytest.raises(CachitoError, match=expected):
         npm._get_deps(package_lock_deps, {})
 
@@ -152,15 +515,144 @@ def test_get_package_and_deps(package_lock_deps, package_and_deps):
     package_lock = {"name": "han_solo", "version": "5.0.0", "dependencies": package_lock_deps}
     mock_open = mock.mock_open(read_data=json.dumps(package_lock))
     with mock.patch("cachito.workers.pkg_managers.npm.open", mock_open):
-        package, deps = npm.get_package_and_deps(
-            "/tmp/cachito-bundles/1/temp/app/package-lock.json"
+        deps_info = npm.get_package_and_deps(
+            "/tmp/cachito-bundles/1/temp/app/package.json",
+            "/tmp/cachito-bundles/1/temp/app/package-lock.json",
         )
 
-    deps = sorted(deps, key=operator.itemgetter("name", "version"))
+    deps_info["deps"].sort(key=operator.itemgetter("name", "version"))
+    mock_open.assert_called_once()
+    assert deps_info == package_and_deps
 
-    expected_package, expected_deps = package_and_deps
-    assert package == expected_package
-    assert deps == expected_deps
+
+def test_get_package_and_deps_dep_replacements(package_lock_deps, package_and_deps):
+    package_lock = {
+        "name": "star-wars",
+        "version": "5.0.0",
+        "dependencies": {
+            "rxjs": {
+                "version": "github:ReactiveX/rxjs#dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                "from": "github:ReactiveX/rxjs#dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                "requires": {"tslib": "^1.9.0"},
+            },
+            "tslib": {
+                "version": "1.11.1",
+                "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                "integrity": (
+                    "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/"
+                    "xefmvJGd1WUmfpT/g6AJGA=="
+                ),
+            },
+        },
+    }
+    package_json = {
+        "dependencies": {
+            "rxjs": {"version": "github:ReactiveX/rxjs#dfa239d41b97504312fa95e13f4d593d95b49c4b"},
+            "tslib": {"version": "1.11.1"},
+        }
+    }
+
+    def _mock_get_deps(_deps):
+        _deps["rxjs"] = {
+            "version": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+            "resolved": (
+                "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
+                "rxjs-6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+            ),
+            "integrity": (
+                "sha512-vvAdzoVTdbr5Lq7BI2+l4R3dM4Mw7305wNKLgij8ru7sx3Fuo1W2XrsoTXWfPtIk+kxiBXxCoc8"
+                "UX1Vb45kbRQ=="
+            ),
+            "requires": {"tslib": "^1.9.0"},
+        }
+        name_to_deps = {
+            "rxjs": [
+                {
+                    "bundled": False,
+                    "dev": False,
+                    "name": "rxjs",
+                    "version": "6.5.5",
+                    "version_in_nexus": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                },
+            ],
+            "tslib": [
+                {
+                    "bundled": False,
+                    "dev": False,
+                    "name": "rxjs",
+                    "version": "1.11.1",
+                    "version_in_nexus": None,
+                },
+            ],
+        }
+        replacements = [("rxjs", "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b")]
+
+        return name_to_deps, replacements
+
+    with mock.patch("cachito.workers.pkg_managers.npm._get_deps", new=_mock_get_deps):
+        with mock.patch("cachito.workers.pkg_managers.npm.open") as mock_open:
+            mock_open.side_effect = [
+                mock.mock_open(read_data=json.dumps(package_lock)).return_value,
+                mock.mock_open(read_data=json.dumps(package_json)).return_value,
+            ]
+            deps_info = npm.get_package_and_deps(
+                "/tmp/cachito-bundles/1/temp/app/package.json",
+                "/tmp/cachito-bundles/1/temp/app/package-lock.json",
+            )
+
+    assert deps_info == {
+        "deps": [
+            {
+                "bundled": False,
+                "dev": False,
+                "name": "rxjs",
+                "version": "6.5.5",
+                "version_in_nexus": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+            },
+            {
+                "bundled": False,
+                "dev": False,
+                "name": "rxjs",
+                "version": "1.11.1",
+                "version_in_nexus": None,
+            },
+        ],
+        # Verify that the lock file was detected as having been modified
+        "lock_file": {
+            "dependencies": {
+                "rxjs": {
+                    "integrity": (
+                        "sha512-vvAdzoVTdbr5Lq7BI2+l4R3dM4Mw7305wNKLgij8ru7sx3Fuo1W2XrsoTXWfPtIk+k"
+                        "xiBXxCoc8UX1Vb45kbRQ=="
+                    ),
+                    "requires": {"tslib": "^1.9.0"},
+                    "resolved": (
+                        "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
+                        "rxjs-6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+                    ),
+                    "version": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                },
+                "tslib": {
+                    "integrity": (
+                        "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9Qp"
+                        "nUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                    ),
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "version": "1.11.1",
+                },
+            },
+            "name": "star-wars",
+            "version": "5.0.0",
+        },
+        "package": {"name": "star-wars", "type": "npm", "version": "5.0.0"},
+        "package.json": {
+            "dependencies": {
+                # Verify that package.json was updated with the hosted version of rxjs
+                "rxjs": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                "tslib": {"version": "1.11.1"},
+            }
+        },
+    }
 
 
 @pytest.mark.parametrize("shrink_wrap, package_lock", ((True, False), (True, True), (False, True)))
@@ -168,27 +660,31 @@ def test_get_package_and_deps(package_lock_deps, package_and_deps):
 @mock.patch("cachito.workers.pkg_managers.npm.get_package_and_deps")
 @mock.patch("cachito.workers.pkg_managers.npm.download_dependencies")
 def test_resolve_npm(mock_dd, mock_gpad, mock_exists, shrink_wrap, package_lock, package_and_deps):
-    mock_exists.side_effect = [shrink_wrap, package_lock]
+    package_json = True
+    if shrink_wrap:
+        mock_exists.side_effect = [shrink_wrap, package_json]
+    else:
+        mock_exists.side_effect = [shrink_wrap, package_lock, package_json]
     mock_gpad.return_value = package_and_deps
-    expected_package, expected_deps = package_and_deps
-    # Note that the deps returned by the get_package_and_deps function are modified as part of the
-    # resolve_npm function. This is why a deep copy is necessary.
-    expected_deps = copy.deepcopy(expected_deps)
+    # Note that the dictionary returned by the get_package_and_deps function is modified as part of
+    # the resolve_npm function. This is why a deep copy is necessary.
+    expected_deps_info = copy.deepcopy(package_and_deps)
     # Remove the "bundled" key as does the resolve_npm function to get expected returned
     # dependencies
-    for dep in expected_deps:
+    for dep in expected_deps_info["deps"]:
         dep.pop("bundled")
+        dep.pop("version_in_nexus")
 
     src_path = "/tmp/cachito-bundles/temp/1/app"
-    package, deps = npm.resolve_npm(src_path, {"id": 1})
+    deps_info = npm.resolve_npm(src_path, {"id": 1})
 
-    assert package == expected_package
-    assert deps == expected_deps
+    assert deps_info == expected_deps_info
+    package_json_path = os.path.join(src_path, "package.json")
     if shrink_wrap:
         lock_file_path = os.path.join(src_path, "npm-shrinkwrap.json")
     elif package_lock:
         lock_file_path = os.path.join(src_path, "package-lock.json")
-    mock_gpad.assert_called_once_with(lock_file_path)
+    mock_gpad.assert_called_once_with(package_json_path, lock_file_path)
     # We can't verify the actual correct deps value was passed in since the deps that were passed
     # in were mutated and mock does not keep a deepcopy of the function arguments.
     mock_dd.assert_called_once_with(1, mock.ANY)


### PR DESCRIPTION
This is limited to popular SCM services such as GitHub, Git repos, and HTTP(S) URLS.