### PR TITLE
Response forbidden when requester is not a worker

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -5,7 +5,7 @@ import functools
 from celery import chain
 import flask
 from flask_login import current_user, login_required
-from werkzeug.exceptions import Unauthorized, InternalServerError
+from werkzeug.exceptions import Forbidden, InternalServerError
 
 from cachito.errors import ValidationError
 from cachito.web import db
@@ -219,7 +219,7 @@ def worker_required(func):
     """
     Decorate a function and assert that the current user is a worker.
 
-    :raise Unauthorized: if the user is not a worker
+    :raise Forbidden: if the user is not a worker
     """
 
     @functools.wraps(func)
@@ -227,7 +227,7 @@ def worker_required(func):
         allowed_users = flask.current_app.config["CACHITO_WORKER_USERNAMES"]
         # current_user.is_authenticated is only ever False when auth is disabled
         if current_user.is_authenticated and current_user.username not in allowed_users:
-            raise Unauthorized("This API endpoint is restricted to Cachito workers")
+            raise Forbidden("This API endpoint is restricted to Cachito workers")
         return func(*args, **kwargs)
 
     return wrapper

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1054,7 +1054,7 @@ def test_request_patch_invalid(
 
 def test_request_patch_not_authorized(auth_env, client, db):
     rv = client.patch("/api/v1/requests/1", json={}, environ_base=auth_env)
-    assert rv.status_code == 401
+    assert rv.status_code == 403
     assert rv.json["error"] == "This API endpoint is restricted to Cachito workers"
 
 
@@ -1161,5 +1161,5 @@ def test_request_post_config_invalid(
 
 def test_request_config_post_not_authorized(auth_env, client, db):
     rv = client.post("/api/v1/requests/1/configuration-files", json={}, environ_base=auth_env)
-    assert rv.status_code == 401
+    assert rv.status_code == 403
     assert rv.json["error"] == "This API endpoint is restricted to Cachito workers"


### PR DESCRIPTION
This change affects two endpoints, 1) patch a request and 2) add
configuration files to a specific request.

Fixes #117

Signed-off-by: Chenxiong Qi <cqi@redhat.com>