### PR TITLE
Mark stuck in_progress requests as stale in the cachito-cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Custom configuration for the Celery workers are listed below:
   following privileges are required: `nx-repository-admin-*-*-*`, `nx-repository-view-npm-*-*`,
   `nx-roles-all`, `nx-script-*-*`, `nx-users-all` and `nx-userschangepw`. This defaults to
   `cachito`.
+* `cachito_request_lifetime` - the number of days before a request that is in the `complete` state
+  or that is stuck in the `in_progress` state will be marked as stale by the `cachito-cleanup`
+  script. This defaults to `1`.
 * `cachito_sources_dir` - the directory for long-term storage of app source archives. This
   configuration is required, and the directory must already exist and be writeable.
 

--- a/tests/test_workers/test_cleanup_job.py
+++ b/tests/test_workers/test_cleanup_job.py
@@ -1,10 +1,14 @@
-from unittest import mock
 from datetime import datetime
+from unittest import mock
 
+import pytest
+import requests
+
+from cachito.errors import CachitoError
 from cachito.workers.cleanup_job import main
 
 
-expected = {
+mock_complete = {
     "items": [
         {
             "dependencies": 309,
@@ -18,19 +22,50 @@ expected = {
             "state_reason": "Completed successfully",
             "updated": "2019-09-05T18:24:50.857861",
             "user": "mprahl@redhat.com",
-        }
+        },
     ],
     "meta": {
         "first": "https://cachito.stage.engineering.redhat.com/api/v1/requests"
-        "?page=1&per_page=20&verbose=False",
+        "?page=1&per_page=20&verbose=False&state=complete",
         "last": "https://cachito.stage.engineering.redhat.com/api/v1/requests"
-        "?page=1&per_page=20&verbose=False",
+        "?page=1&per_page=20&verbose=False&state=complete",
         "next": None,
         "page": 1,
         "pages": 1,
         "per_page": 20,
         "previous": None,
-        "total": 13,
+        "total": 1,
+    },
+}
+
+
+mock_in_progress = {
+    "items": [
+        {
+            "dependencies": 309,
+            "environment_variables": {},
+            "flags": [],
+            "id": 51,
+            "pkg_managers": ["gomod"],
+            "ref": "a7ac8d4c0b7fe90d51fb911511cbf6939655c877",
+            "repo": "https://github.com/kubernetes/kubernetes.git",
+            "state": "in_progress",
+            "state_reason": "The request was initiated",
+            "updated": "2019-09-05T18:24:50.857861",
+            "user": "mprahl@redhat.com",
+        },
+    ],
+    "meta": {
+        "first": "https://cachito.stage.engineering.redhat.com/api/v1/requests"
+        "?page=1&per_page=20&verbose=False&state=in_progress",
+        "last": "https://cachito.stage.engineering.redhat.com/api/v1/requests"
+        "?page=1&per_page=20&verbose=False&state=in_progress",
+        "next": None,
+        "page": 1,
+        "pages": 1,
+        "per_page": 20,
+        "previous": None,
+        "total": 1,
     },
 }
 
@@ -42,7 +77,7 @@ expected = {
 def test_cleanup_job_success(mock_requests, mock_auth_requests, mock_dt):
     mock_dt.utcnow = mock.Mock(return_value=datetime(2019, 9, 7))
     mock_dt.strptime = mock.Mock(return_value=datetime(2019, 9, 5))
-    mock_requests.return_value.json.return_value = expected
+    mock_requests.return_value.json.side_effect = [mock_complete, mock_in_progress]
     mock_auth_requests.return_value.ok = True
     main()
     calls = [
@@ -50,10 +85,15 @@ def test_cleanup_job_success(mock_requests, mock_auth_requests, mock_dt):
             "http://cachito.domain.local/api/v1/requests/50",
             json={"state": "stale", "state_reason": "The request has expired"},
             timeout=60,
-        )
+        ),
+        mock.call(
+            "http://cachito.domain.local/api/v1/requests/51",
+            json={"state": "stale", "state_reason": "The request has expired"},
+            timeout=60,
+        ),
     ]
-    assert mock_requests.call_count == 1
-    assert mock_auth_requests.call_count == 1
+    assert mock_requests.call_count == 2
+    assert mock_auth_requests.call_count == 2
     mock_auth_requests.assert_has_calls(calls)
 
 
@@ -64,7 +104,27 @@ def test_cleanup_job_success(mock_requests, mock_auth_requests, mock_dt):
 def test_cleanup_job_request_not_stale(mock_requests, mock_mark_as_stale, mock_dt):
     mock_dt.utcnow = mock.Mock(return_value=datetime(2019, 9, 5))
     mock_dt.strptime = mock.Mock(return_value=datetime(2019, 9, 5))
-    mock_requests.return_value.json.return_value = expected
+    mock_requests.return_value.json.side_effect = [mock_complete, mock_in_progress]
     main()
-    assert mock_requests.call_count == 1
+    assert mock_requests.call_count == 2
     assert not mock_mark_as_stale.called
+
+
+@mock.patch("cachito.workers.config.Config.cachito_request_lifetime", 1)
+@mock.patch("cachito.workers.cleanup_job.session.get")
+def test_cleanup_job_request_get_timeout(mock_requests):
+    mock_requests.side_effect = requests.ConnectionError()
+    expected = "The connection failed when querying .+"
+    with pytest.raises(CachitoError, match=expected):
+        main()
+    assert mock_requests.call_count == 1
+
+
+@mock.patch("cachito.workers.config.Config.cachito_request_lifetime", 1)
+@mock.patch("cachito.workers.cleanup_job.session.get")
+def test_cleanup_job_request_failed_get(mock_requests):
+    mock_requests.return_value.ok = False
+    expected = "Could not reach the Cachito API to find the requests to be marked as stale"
+    with pytest.raises(CachitoError, match=expected):
+        main()
+    assert mock_requests.call_count == 1


### PR DESCRIPTION
This also adds a timeout to the GET requests, additional logging, and error handling.