### PR TITLE
Add support for npm dependencies from private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,16 @@ registry in the event that the application needs to be built without Cachito and
 it manages.
 
 Cachito can also handle dependencies that are not from the npm registry such as those directly
-from GitHub, a Git repository, or an HTTP(S) URL. If the dependency location is not supported,
-Cachito will fail the request. When Cachito encounters a supported location, it will download the
+from GitHub, a Git repository, or an HTTP(S) URL. Please note that if the dependency is from a
+private repository, set the
+[.netrc](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) and
+`known_hosts` files for the Cachito workers. If the dependency location is not supported, Cachito
+will fail the request. When Cachito encounters a supported location, it will download the
 dependency, modify the version in the [package.json](https://docs.npmjs.com/files/package.json) to
 be unique, upload it to Nexus, modify the top level project's
 [package.json](https://docs.npmjs.com/files/package.json) and lock files to use the dependency from
-Nexus instead. The modified files will accessible at the `/api/v1/requests/<id>/configuration-files`
-API endpoint. If Cachito encounters this same dependency again in a future request, it will use it
-directly from Nexus rather than downloading it and uploading it again. This guarantees that any
-dependency used for a Cachito request can be used again in a future Cachito request.
+Nexus instead. The modified files will be accessible at the
+`/api/v1/requests/<id>/configuration-files` API endpoint. If Cachito encounters this same dependency
+again in a future request, it will use it directly from Nexus rather than downloading it and
+uploading it again. This guarantees that any dependency used for a Cachito request can be used again
+in a future Cachito request.

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -62,6 +62,9 @@ def download_dependencies(request_id, deps):
             "NPM_CONFIG_CACHE": os.path.join(temp_dir, "cache"),
             "NPM_CONFIG_USERCONFIG": npm_rc_file,
             "PATH": os.environ.get("PATH", ""),
+            # Have `npm pack` fail without a prompt if the SSH key from a protected source such
+            # as a private GitHub repo is not trusted
+            "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=yes",
         }
         bundle_dir = RequestBundleDir(request_id)
         bundle_dir.npm_deps_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
This documents how authentication works to private repositories and it keeps `npm pack` from prompting to trust unknown hosts.