### PR TITLE
Set render_as_batch=True when generating migrations

### DIFF
--- a/cachito/web/migrations/env.py
+++ b/cachito/web/migrations/env.py
@@ -78,6 +78,7 @@ def run_migrations_online():
             connection=connection,
             target_metadata=target_metadata,
             process_revision_directives=process_revision_directives,
+            render_as_batch=True,
             **current_app.extensions["migrate"].configure_args,
         )
 


### PR DESCRIPTION
Since we support SQLite, this makes generating those migrations easier.