### PR TITLE
Fix repo reuse for disconnected refs

### DIFF
--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -110,7 +110,9 @@ class Git(SCM):
 
             repo = git.Repo(os.path.join(temp_dir, "app"))
             try:
-                repo.remote().fetch()
+                # The reference must be specified to handle commits which are not part
+                # of a branch.
+                repo.remote().fetch(refspec=self.ref)
             except:  # noqa E722
                 log.exception("Failed to fetch from remote %s", self.url)
                 raise CachitoError("Failed to fetch from the remote Git repository")

--- a/tests/test_workers/test_scm.py
+++ b/tests/test_workers/test_scm.py
@@ -141,7 +141,7 @@ def test_update_and_archive(mock_repo, mock_temp_dir, mock_tarfile_open):
 
     repo = mock_repo.return_value
     # Verify the changes are pulled.
-    repo.remote.return_value.fetch.assert_called_once()
+    repo.remote.return_value.fetch.assert_called_once_with(refspec=ref)
     # Verify the repo is reset to specific ref
     repo.commit.assert_called_once_with(ref)
     assert repo.commit.return_value == repo.head.reference


### PR DESCRIPTION
Cachito tries to reuse a previous "snapshot" of the git repo instead of
doing a fresh clone.  This is prevents Cachito from wastefully
re-downloading the whole repository.  In order to do this, Cachito runs
"git fetch origin" on the previous "snapshot". This, however, only pulls
commits from branches, ignoring all other commits.  With this change
Cachito fetches the exact git commit from the remote.

* CLOUDBLD-1190

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>