### PR TITLE
Miscellaneous fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,32 @@ a web server that supplies the `REMOTE_USER` environment variable when the user 
 properly authenticated. A common deployment option is using httpd (Apache web server)
 with the `mod_auth_gssapi` module.
 
+## Nexus
+
+### Nexus For npm
+
+The npm package manager functionality relies on
+[Nexus Repository Manager 3](https://help.sonatype.com/repomanager3) to store npm dependencies. The
+Nexus instance will have an npm group repository (e.g. `cachito-js`) which points to an npm hosted
+repository (e.g. `cachito-js-hosted`) and an npm proxy repository (e.g. `cachito-js-proxy`) that
+points to registry.npmjs.org. The hosted repository will contain all non-registry dependencies and
+the proxy repository will contain all dependencies from the npm registry. The union of these two
+repositories gives the set of all the npm dependencies ever encountered by Cachito.
+
+On each request, Cachito will create a proxy repository to the npm group repository
+(e.g. `cachito-js`). Cachito will populate this proxy repository to contain the subset of
+dependencies declared in the repository's lock file. Once populated, Cachito will block the
+repository from getting additional content. This prevents the consumer of the repository from
+installing something that was not declared in the lock file. This is further enforced by locking
+down the repository to a single user created for the request, which the consumer will use. Please
+keep in mind that for this to function properly, anonymous access needs to be disabled on the Nexus
+instance or at least not set to have read access on all repositories.
+
+These repositories and users created per request are deleted when the request is marked as stale
+or the request fails.
+
+Refer to the Configuring Workers section to see how to configure Cachito to use Nexus.
+
 ## Package Managers
 
 ### npm

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -303,7 +303,9 @@ def patch_request(request_id):
     if "state" in payload and "state_reason" in payload:
         new_state = payload["state"]
         delete_bundle = new_state == "stale"
-        cleanup_nexus = new_state == "stale" and any(p.name == "npm" for p in request.pkg_managers)
+        cleanup_nexus = new_state in ("stale", "failed") and any(
+            p.name == "npm" for p in request.pkg_managers
+        )
         delete_bundle_temp = new_state in ("complete", "failed")
         new_state_reason = payload["state_reason"]
         # This is to protect against a Celery task getting executed twice and setting the

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -17,11 +17,11 @@ class Config(object):
     # When publishing a message, don't continuously retry or else the HTTP connection times out
     broker_transport_options = {"max_retries": 10}
     # Refer to README.md for information on all the Cachito configuration options
+    cachito_api_timeout = 60
     cachito_auth_type = None
     cachito_deps_patch_batch_size = 50
-    cachito_log_level = "INFO"
     cachito_download_timeout = 120
-    cachito_api_timeout = 60
+    cachito_log_level = "INFO"
     cachito_js_download_batch_size = 30
     cachito_nexus_ca_cert = "/etc/cachito/nexus_ca.pem"
     cachito_nexus_timeout = 60

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -16,24 +16,17 @@ class Config(object):
 
     # When publishing a message, don't continuously retry or else the HTTP connection times out
     broker_transport_options = {"max_retries": 10}
+    # Refer to README.md for information on all the Cachito configuration options
     cachito_auth_type = None
+    cachito_deps_patch_batch_size = 50
     cachito_log_level = "INFO"
-    # The timeout when downloading application source archives from sources such as GitHub
     cachito_download_timeout = 120
-    # The timeout when making a Cachito API request
     cachito_api_timeout = 60
-    # The number of JavaScript dependencies to download at once using `npm pack`
     cachito_js_download_batch_size = 30
-    # The path to the CA certificate that signed the Nexus server's SSL certificate
     cachito_nexus_ca_cert = "/etc/cachito/nexus_ca.pem"
-    # The timeout when making a Nexus API request
     cachito_nexus_timeout = 60
-    # The username of the unprivileged Nexus user that has read access to the main Cachito managed
-    # Nexus repositories (e.g. cachito-js)
     cachito_nexus_unprivileged_username = "cachito_unprivileged"
-    # The username of the privileged Nexus user
     cachito_nexus_username = "cachito"
-    # Configurable number of days before which a request becomes stale
     cachito_request_lifetime = 1
     include = [
         "cachito.workers.tasks.general",
@@ -69,8 +62,6 @@ class Config(object):
     # Don't allow the worker to fetch more messages than it can handle at a time. This is so that
     # other tasks aren't starved when processing a large archive.
     worker_prefetch_multiplier = 1
-    # Configurable batch size of the json payload so that the cachito API request doesn't time out
-    cachito_deps_patch_batch_size = 50
 
 
 class ProductionConfig(Config):


### PR DESCRIPTION
* Describe how Nexus should be configured for npm
* Clean up Nexus also when the npm request is set to failed
* Stop duplicating descriptions for configuration options
* Alphabetize the configuration options in cachito/workers/config.py