### PR TITLE
Allow using a separate Nexus instance for the permanently stored content

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,35 @@ Custom configuration for the Celery workers are listed below:
 * `cachito_nexus_ca_cert` - the CA certificate that signed the SSL certificate used by the Nexus
   instance. This defaults to `/etc/cachito/nexus_ca.pem`. If this file does not exist, Cachito will
   not provide the CA certificate in the package manager configuration.
+* `cachito_nexus_hoster_password` - the password of the Nexus service account used by Cachito for
+  the Nexus instance that has the hosted repositories. This is used instead of
+  `cachito_nexus_password` for uploading content if you are using the two Nexus instance approach as
+  described in the "Nexus For npm" section. If this is set, `cachito_nexus_hoster_username` must
+  also be set.
+* `cachito_nexus_hoster_url` - the URL to the Nexus instance that has the hosted repositories. This
+  is used instead of `cachito_nexus_url` for uploading content if you are using the two Nexus
+  instance approach as described in the "Nexus For npm" section.
+* `cachito_nexus_hoster_username` - the username of the Nexus service account used by Cachito for
+  the Nexus instance that has the hosted repositories. This is used instead of
+  `cachito_nexus_username` for uploading content if you are using the two Nexus instance approach as
+  described in the "Nexus For npm" section. If this is set, `cachito_nexus_hoster_password` must
+  also be set.
 * `cachito_nexus_password` - the password of the Nexus service account used by Cachito.
+* `cachito_nexus_proxy_password` - the password of the unprivileged user that has read access
+  to the main Cachito repositories (e.g. `cachito-js`). This is needed if the Nexus instance that
+  hosts the main Cachito repositories has anonymous access disabled. This is the case if Cachito
+  utilizes just a single Nexus instance.
+* `cachito_nexus_proxy_username` - the username of the unprivileged user that has read access
+  to the main Cachito repositories (e.g. `cachito-js`). This is needed if the Nexus instance that
+  hosts the main Cachito repositories has anonymous access disabled. This is the case if Cachito
+  utilizes just a single Nexus instance.
+* `cachito_nexus_npm_proxy_repo_url` - the URL to the `cachito-js` repository which is a Nexus group
+  that points to the `cachito-js-hosted` hosted repository and the `cachito-js-proxy` proxy
+  repository. This defaults to `http://localhost:8081/repository/cachito-js/`. This only needs to
+  change if you are using the two Nexus instance approach as described in the "Nexus For npm"
+  section or you use a different name for the repository.
 * `cachito_nexus_timeout` - the timeout when making a Nexus API request. The default is `60`
   seconds.
-* `cachito_nexus_unprivileged_password` - the password of the unprivileged user that has read access
-  to the main Cachito repositories (e.g. `cachito-js`).
-* `cachito_nexus_unprivileged_username` - the username of the unprivileged user that has read access
-  to the main Cachito repositories (e.g. `cachito-js`). This defaults to `cachito_unprivileged`.
 * `cachito_nexus_url` - the base URL to the Nexus Repository Manager 3 instance used by Cachito.
 * `cachito_nexus_username` - the username of the Nexus service account used by Cachito. The
   following privileges are required: `nx-repository-admin-*-*-*`, `nx-repository-view-npm-*-*`,
@@ -202,7 +224,13 @@ instance or at least not set to have read access on all repositories.
 These repositories and users created per request are deleted when the request is marked as stale
 or the request fails.
 
-Refer to the Configuring Workers section to see how to configure Cachito to use Nexus.
+Refer to the "Configuring Workers" section to see how to configure Cachito to use Nexus. Please
+note that you may choose to use two Nexus instances. One for hosting the permanent content and the
+other for the ephemeral repositories created per request. This is useful if your organization
+already has a shared Nexus instance but doesn't want Cachito to have near admin level access on it.
+In this case, you will need to configure the following additional settings that point to the
+Nexus instance that hosts the permanent content: `cachito_nexus_hoster_username`,
+`cachito_nexus_hoster_password`, and `cachito_nexus_hoster_url`.
 
 ## Package Managers
 

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -320,8 +320,9 @@ def prepare_nexus_for_js_request(request_id):
     # repository
     payload = {
         "repository_name": get_js_proxy_repo_name(request_id),
-        "http_password": config.cachito_nexus_unprivileged_password,
-        "http_username": config.cachito_nexus_unprivileged_username,
+        "http_password": config.cachito_nexus_proxy_password,
+        "http_username": config.cachito_nexus_proxy_username,
+        "npm_proxy_url": config.cachito_nexus_npm_proxy_repo_url,
     }
     script_name = "js_before_content_staged"
     try:

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -6,7 +6,7 @@ import os
 
 from cachito.errors import CachitoError
 from cachito.workers import nexus
-from cachito.workers.config import validate_nexus_config
+from cachito.workers.config import validate_npm_config
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import (
     update_request_with_config_files,
@@ -48,7 +48,7 @@ def fetch_npm_source(request_id, auto_detect=False):
     :param bool auto_detect: automatically detect if the archive uses npm
     :raise CachitoError: if the task fails
     """
-    validate_nexus_config()
+    validate_npm_config()
 
     bundle_dir = RequestBundleDir(request_id)
     log.debug("Checking if the application source uses npm")

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -87,6 +87,58 @@ def components_search_results():
     }
 
 
+@pytest.mark.parametrize(
+    "hoster_username, username, hoster_password, password, expected_username, expected_password",
+    (
+        (None, "cachito", None, "cachito", "cachito", "cachito"),
+        ("cachito-uploader", "cachito", None, "cachito", "cachito-uploader", "cachito"),
+        (
+            "cachito-uploader",
+            "cachito",
+            None,
+            "cachito-password",
+            "cachito-uploader",
+            "cachito-password",
+        ),
+        (None, "cachito", "cachito-password", "cachito", "cachito", "cachito-password"),
+    ),
+)
+@mock.patch("cachito.workers.nexus.get_worker_config")
+def test_get_nexus_hoster_credentials(
+    mock_gwc,
+    hoster_username,
+    username,
+    hoster_password,
+    password,
+    expected_username,
+    expected_password,
+):
+    mock_gwc.return_value.cachito_nexus_hoster_username = hoster_username
+    mock_gwc.return_value.cachito_nexus_hoster_password = hoster_password
+    mock_gwc.return_value.cachito_nexus_username = username
+    mock_gwc.return_value.cachito_nexus_password = password
+
+    rv_username, rv_password = nexus._get_nexus_hoster_credentials()
+
+    assert rv_username == expected_username
+    assert rv_password == expected_password
+
+
+@pytest.mark.parametrize(
+    "cachito_nexus_hoster_url, cachito_nexus_url, expected",
+    (
+        ("http://hoster", "http://managed", "http://hoster"),
+        (None, "http://managed", "http://managed"),
+    ),
+)
+@mock.patch("cachito.workers.nexus.get_worker_config")
+def test_get_nexus_hoster_url(mock_gwc, cachito_nexus_hoster_url, cachito_nexus_url, expected):
+    mock_gwc.return_value.cachito_nexus_hoster_url = cachito_nexus_hoster_url
+    mock_gwc.return_value.cachito_nexus_url = cachito_nexus_url
+
+    assert nexus._get_nexus_hoster_url() == expected
+
+
 @mock.patch("cachito.workers.requests.requests_session")
 @mock.patch("cachito.workers.nexus.open", mock.mock_open(read_data="println('Hello')"))
 def test_create_or_update_create(mock_requests):

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -260,6 +260,7 @@ def test_prepare_nexus_for_js_request(mock_exec_script):
         "repository_name": "cachito-js-1",
         "http_password": "cachito_unprivileged",
         "http_username": "cachito_unprivileged",
+        "npm_proxy_url": "http://localhost:8081/repository/cachito-js/",
     }
 
 


### PR DESCRIPTION
This is useful if your organization already has a shared Nexus instance but doesn't want Cachito to have near admin level access on it.

Resolves CLOUDBLD-1138