### PR TITLE
Handle task scheduling failures from the REST API

### DIFF
--- a/cachito/errors.py
+++ b/cachito/errors.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-class ValidationError(ValueError):
-    """An error was encountered during validation."""
-
-
 class CachitoError(RuntimeError):
     """An error was encountered in Cachito."""
+
+
+class ValidationError(CachitoError, ValueError):
+    """An error was encountered during validation."""
 
 
 class ConfigError(CachitoError):

--- a/cachito/web/app.py
+++ b/cachito/web/app.py
@@ -6,7 +6,6 @@ from flask import current_app, Flask
 from flask.logging import default_handler
 from flask_login import LoginManager
 from flask_migrate import Migrate
-import kombu.exceptions
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import default_exceptions, InternalServerError
 
@@ -16,7 +15,7 @@ from cachito.web.docs import docs
 from cachito.web.api_v1 import api_v1
 from cachito.web import db
 from cachito.web.errors import json_error
-from cachito.errors import ValidationError
+from cachito.errors import CachitoError, ValidationError
 
 
 def healthcheck():
@@ -99,8 +98,8 @@ def create_app(config_obj=None):
 
     for code in default_exceptions.keys():
         app.register_error_handler(code, json_error)
+    app.register_error_handler(CachitoError, json_error)
     app.register_error_handler(ValidationError, json_error)
-    app.register_error_handler(kombu.exceptions.KombuError, json_error)
 
     return app
 

--- a/cachito/web/errors.py
+++ b/cachito/web/errors.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from flask import jsonify
-import kombu.exceptions
 from werkzeug.exceptions import HTTPException
 
-from cachito.errors import ValidationError
+from cachito.errors import CachitoError, ValidationError
 
 
 def json_error(error):
@@ -26,8 +25,9 @@ def json_error(error):
         msg = str(error)
         if isinstance(error, ValidationError):
             status_code = 400
-        elif isinstance(error, kombu.exceptions.KombuError):
-            msg = "Failed to connect to the broker to schedule a task"
+        elif isinstance(error, CachitoError):
+            # If a generic exception is raised, assume the service is unavailable
+            status_code = 503
 
         response = jsonify({"error": msg})
         response.status_code = status_code


### PR DESCRIPTION
If RabbitMQ is unavailable and a new request is submitted, Cachito will now fail the request and return an error to the user.

If RabbitMQ is unavailable when a request with the npm package manager is set to the "stale" or "failed" state, the PATCH request will still complete but a log message will state that the admin must clean this up manually.

Resolves CLOUDBLD-995.