### PR TITLE
Make the external version format consistent with git commits and HTTP

### DIFF
--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -176,8 +176,8 @@ def convert_to_nexus_hosted(dep_name, dep_info):
             log.error(msg)
             raise CachitoError(msg)
         # When the dependency is uploaded to the Nexus hosted repository, it will be in the format
-        # of `<version>-external-<commit hash>`
-        version_suffix = f"-external-{commit_hash}"
+        # of `<version>-gitcommit-<commit hash>`
+        version_suffix = f"-external-gitcommit-{commit_hash}"
     elif any(dep_identifier.startswith(prefix) for prefix in http_prefixes):
         if "integrity" not in dep_info:
             msg = f"The dependency {dep_identifier} is missing the integrity value in the lock file"

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -25,10 +25,10 @@ def components_search_results():
                     {
                         "downloadUrl": (
                             "http://nexus/repository/cachito-js-hosted/rxjs/-/rxjs-7.0.0-beta.0"
-                            "-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+                            "-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
                         ),
                         "path": (
-                            "rxjs/-/rxjs-7.0.0-beta.0-external-"
+                            "rxjs/-/rxjs-7.0.0-beta.0-external-gitcommit-"
                             "dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
                         ),
                         "id": "Y2FjaGl0by1qcy1ob3N0ZWQ6Mjk0YzYzMzJiNDlhNmQ0NTY3MmM5YmNhZDg0YWI2ZTM",
@@ -54,15 +54,16 @@ def components_search_results():
                 "format": "npm",
                 "group": "reactivex",
                 "name": "rxjs",
-                "version": "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+                "version": "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
                 "assets": [
                     {
                         "downloadUrl": (
                             "http://nexus/repository/cachito-js-hosted/@reactivex/rxjs/-/"
-                            "rxjs-6.5.5-external-78032157f5c1655436829017bbda787565b48c30.tgz"
+                            "rxjs-6.5.5-external-gitcommit-"
+                            "78032157f5c1655436829017bbda787565b48c30.tgz"
                         ),
                         "path": (
-                            "@reactivex/rxjs/-/rxjs-6.5.5-external-"
+                            "@reactivex/rxjs/-/rxjs-6.5.5-external-gitcommit-"
                             "78032157f5c1655436829017bbda787565b48c30.tgz"
                         ),
                         "id": "Y2FjaGl0by1qcy1ob3N0ZWQ6Yzc1NDU1NzlhN2ExNTM5MDI5YmRiOTI4YzdkNGFiZDQ",
@@ -267,7 +268,7 @@ def test_get_component_info_from_nexus(mock_search_components, components_search
     repository = "cachito-js-proxy"
     component_format = "npm"
     name = "rxjs"
-    version = "6.5.5-external-78032157f5c1655436829017bbda787565b48c30"
+    version = "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30"
     group = "reactive"
     components_search_results["items"].pop(0)
     mock_search_components.return_value = components_search_results["items"]

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -27,7 +27,7 @@ def test_download_dependencies(mock_gwc, mock_move, mock_run_cmd, mock_gawnf, mo
         """\
         angular-devkit-architect-0.803.26.tgz
         angular-animations-8.2.14.tgz
-        rxjs-6.5.5-external-78032157f5c1655436829017bbda787565b48c30.tgz
+        rxjs-6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30.tgz
         """
     )
     deps = [
@@ -57,7 +57,7 @@ def test_download_dependencies(mock_gwc, mock_move, mock_run_cmd, mock_gawnf, mo
             "dev": False,
             "name": "rxjs",
             "version": "github:ReactiveX/rxjs#78032157f5c1655436829017bbda787565b48c30",
-            "version_in_nexus": "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+            "version_in_nexus": "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
         },
     ]
     request_id = 1
@@ -73,7 +73,7 @@ def test_download_dependencies(mock_gwc, mock_move, mock_run_cmd, mock_gawnf, mo
         "pack",
         "@angular-devkit/architect@0.803.26",
         "@angular/animations@8.2.14",
-        "rxjs@6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+        "rxjs@6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
     ]
     assert mock_run_cmd.call_args[0][0] == expected_npm_pack
     run_cmd_env_vars = mock_run_cmd.call_args[0][1]["env"]
@@ -89,10 +89,11 @@ def test_download_dependencies(mock_gwc, mock_move, mock_run_cmd, mock_gawnf, mo
         f"{npm_dir_path}/@angular/animations/angular-animations-8.2.14.tgz"
     )
     dep3_source_path = RequestBundleDir(
-        f"{npm_dir_path}/rxjs-6.5.5-external-78032157f5c1655436829017bbda787565b48c30.tgz"
+        f"{npm_dir_path}/rxjs-6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30.tgz"
     )
     dep3_dest_path = RequestBundleDir(
-        f"{npm_dir_path}/rxjs/rxjs-6.5.5-external-78032157f5c1655436829017bbda787565b48c30.tgz"
+        f"{npm_dir_path}/rxjs/rxjs-6.5.5-external-gitcommit-"
+        "78032157f5c1655436829017bbda787565b48c30.tgz"
     )
     mock_move.assert_has_calls(
         [
@@ -220,12 +221,14 @@ def test_get_npm_component_info_from_nexus(mock_gcifn, group):
         "format": "npm",
         "group": group[1:] if group else None,
         "name": "rxjs",
-        "version": "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+        "version": "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
     }
     mock_gcifn.return_value = component
 
     rv = general_js.get_npm_component_info_from_nexus(
-        identifier, "6.5.5-external-78032157f5c1655436829017bbda787565b48c30", max_attempts=3
+        identifier,
+        "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
+        max_attempts=3,
     )
 
     assert rv == component
@@ -234,7 +237,7 @@ def test_get_npm_component_info_from_nexus(mock_gcifn, group):
             "cachito-js-hosted",
             "npm",
             "rxjs",
-            "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+            "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
             "reactive",
             3,
         )
@@ -243,7 +246,7 @@ def test_get_npm_component_info_from_nexus(mock_gcifn, group):
             "cachito-js-hosted",
             "npm",
             "rxjs",
-            "6.5.5-external-78032157f5c1655436829017bbda787565b48c30",
+            "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
             None,
             3,
         )

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -186,10 +186,10 @@ def test_get_deps_non_registry_dep(mock_ctnh, package_lock_deps):
         "requires": {"tslib": "^1.9.0"},
     }
     nexus_hosted_info = {
-        "version": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+        "version": "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b",
         "resolved": (
             "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
-            "rxjs-6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+            "rxjs-6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
         ),
         "integrity": (
             "sha512-vvAdzoVTdbr5Lq7BI2+l4R3dM4Mw7305wNKLgij8ru7sx3Fuo1W2XrsoTXWfPtIk+kxiBXxCoc8UX"
@@ -204,10 +204,10 @@ def test_get_deps_non_registry_dep(mock_ctnh, package_lock_deps):
         "requires": {"tslib": "^1.9.0"},
     }
     nexus_hosted_info_two = {
-        "version": "6.5.2-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "version": "6.5.2-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
         "resolved": (
             "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
-            "rxjs-6.5.2-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5.tgz"
+            "rxjs-6.5.2-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5.tgz"
         ),
         "integrity": (
             "sha512-AvAdzoVTdVT5Lq7BI2+l5R3dM4Mw7305wNKLgij8rh7sx3Fuo1W2XrsoTXWfPtIk+kxiBXxCoc8UX"
@@ -250,7 +250,9 @@ def test_get_deps_non_registry_dep(mock_ctnh, package_lock_deps):
                 "name": "rxjs",
                 "type": "npm",
                 "version": "github:ReactiveX/rxjs#dfa239d41b97504312fa95e13f4d593d95b49c4b",
-                "version_in_nexus": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                "version_in_nexus": (
+                    "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b"
+                ),
             },
             {
                 "bundled": False,
@@ -258,7 +260,9 @@ def test_get_deps_non_registry_dep(mock_ctnh, package_lock_deps):
                 "name": "rxjs",
                 "type": "npm",
                 "version": "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
-                "version_in_nexus": "6.5.2-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+                "version_in_nexus": (
+                    "6.5.2-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5"
+                ),
             },
         ],
         "tslib": [
@@ -273,7 +277,9 @@ def test_get_deps_non_registry_dep(mock_ctnh, package_lock_deps):
         ],
     }
     # Verify that only the top level replacements are returned
-    assert replacements == [("rxjs", "6.5.2-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5")]
+    assert replacements == [
+        ("rxjs", "6.5.2-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5")
+    ]
     # Ensure the lock file was updated with the Nexus hosted dependency
     assert (
         package_lock_deps["@angular-devkit/architect"]["dependencies"]["rxjs"] == nexus_hosted_info
@@ -281,7 +287,7 @@ def test_get_deps_non_registry_dep(mock_ctnh, package_lock_deps):
     assert package_lock_deps["rxjs"] == nexus_hosted_info_two
     assert package_lock_deps["@angular-devkit/architect"]["requires"] == {
         "@angular-devkit/core": "8.3.26",
-        "rxjs": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+        "rxjs": "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b",
     }
 
     assert mock_ctnh.call_count == 2
@@ -331,11 +337,11 @@ def test_convert_to_nexus_hosted_github(mock_unrd, mock_gncifn, exists):
                 "checksum": {"sha512": checksum},
                 "downloadUrl": (
                     "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
-                    "rxjs-6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+                    "rxjs-6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
                 ),
             }
         ],
-        "version": "6.5.5-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "version": "6.5.5-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
     }
     if exists:
         mock_gncifn.return_value = nexus_component_info
@@ -360,13 +366,13 @@ def test_convert_to_nexus_hosted_github(mock_unrd, mock_gncifn, exists):
         "requires": {"tslib": "^1.9.0"},
         "resolved": (
             "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/rxjs-6.5.5-"
-            "external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+            "external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
         ),
-        "version": "6.5.5-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+        "version": "6.5.5-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
     }
     if exists:
         mock_gncifn.assert_called_once_with(
-            "rxjs", "*-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5"
+            "rxjs", "*-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5"
         )
         # Verify no upload occurs when the component already exists in Nexus
         mock_unrd.assert_not_called()
@@ -374,15 +380,17 @@ def test_convert_to_nexus_hosted_github(mock_unrd, mock_gncifn, exists):
         assert mock_gncifn.call_count == 2
         mock_gncifn.assert_has_calls(
             [
-                mock.call("rxjs", "*-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5"),
+                mock.call("rxjs", "*-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5"),
                 mock.call(
-                    "rxjs", "*-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5", max_attempts=5
+                    "rxjs",
+                    "*-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+                    max_attempts=5,
                 ),
             ]
         )
         mock_unrd.assert_called_once_with(
             "github:ReactiveX/rxjs#8cc6491771fcbf44984a419b7f26ff442a5d58f5",
-            "-external-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
+            "-external-gitcommit-8cc6491771fcbf44984a419b7f26ff442a5d58f5",
         )
 
 
@@ -554,10 +562,10 @@ def test_get_package_and_deps_dep_replacements(package_lock_deps, package_and_de
 
     def _mock_get_deps(_deps):
         _deps["rxjs"] = {
-            "version": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+            "version": "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b",
             "resolved": (
                 "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
-                "rxjs-6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+                "rxjs-6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
             ),
             "integrity": (
                 "sha512-vvAdzoVTdbr5Lq7BI2+l4R3dM4Mw7305wNKLgij8ru7sx3Fuo1W2XrsoTXWfPtIk+kxiBXxCoc8"
@@ -572,7 +580,9 @@ def test_get_package_and_deps_dep_replacements(package_lock_deps, package_and_de
                     "dev": False,
                     "name": "rxjs",
                     "version": "6.5.5",
-                    "version_in_nexus": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                    "version_in_nexus": (
+                        "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b"
+                    ),
                 },
             ],
             "tslib": [
@@ -585,7 +595,9 @@ def test_get_package_and_deps_dep_replacements(package_lock_deps, package_and_de
                 },
             ],
         }
-        replacements = [("rxjs", "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b")]
+        replacements = [
+            ("rxjs", "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b")
+        ]
 
         return name_to_deps, replacements
 
@@ -607,7 +619,9 @@ def test_get_package_and_deps_dep_replacements(package_lock_deps, package_and_de
                 "dev": False,
                 "name": "rxjs",
                 "version": "6.5.5",
-                "version_in_nexus": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                "version_in_nexus": (
+                    "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b"
+                ),
             },
             {
                 "bundled": False,
@@ -628,9 +642,9 @@ def test_get_package_and_deps_dep_replacements(package_lock_deps, package_and_de
                     "requires": {"tslib": "^1.9.0"},
                     "resolved": (
                         "https://nexus.domain.local/repository/cachito-js-hosted/rxjs/-/"
-                        "rxjs-6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
+                        "rxjs-6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b.tgz"
                     ),
-                    "version": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                    "version": "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b",
                 },
                 "tslib": {
                     "integrity": (
@@ -648,7 +662,7 @@ def test_get_package_and_deps_dep_replacements(package_lock_deps, package_and_de
         "package.json": {
             "dependencies": {
                 # Verify that package.json was updated with the hosted version of rxjs
-                "rxjs": "6.5.5-external-dfa239d41b97504312fa95e13f4d593d95b49c4b",
+                "rxjs": "6.5.5-external-gitcommit-dfa239d41b97504312fa95e13f4d593d95b49c4b",
                 "tslib": {"version": "1.11.1"},
             }
         },


### PR DESCRIPTION
This makes it so that external npm dependencies are always in the format of <version>-external-<type>-<identifier>.