### PR TITLE
Allow the Nexus repository names to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Custom configuration for the Celery workers are listed below:
   `cachito_nexus_username` for uploading content if you are using the two Nexus instance approach as
   described in the "Nexus For npm" section. If this is set, `cachito_nexus_hoster_password` must
   also be set.
+* `cachito_nexus_js_hosted_repo_name` - the name of the Nexus hosted repository for JavaScript
+  package managers. This defaults to `cachito-js-hosted`.
 * `cachito_nexus_npm_proxy_repo_url` - the URL to the `cachito-js` repository which is a Nexus group
   that points to the `cachito-js-hosted` hosted repository and the `cachito-js-proxy` proxy
   repository. This defaults to `http://localhost:8081/repository/cachito-js/`. This only needs to
@@ -159,6 +161,8 @@ Custom configuration for the Celery workers are listed below:
   to the main Cachito repositories (e.g. `cachito-js`). This is needed if the Nexus instance that
   hosts the main Cachito repositories has anonymous access disabled. This is the case if Cachito
   utilizes just a single Nexus instance.
+* `cachito_nexus_request_repo_prefix` - the prefix of Nexus proxy repositories made for each
+  request for applicable package managers (e.g. `cachito-js-1`). This defaults to `cachito-`.
 * `cachito_nexus_timeout` - the timeout when making a Nexus API request. The default is `60`
   seconds.
 * `cachito_nexus_url` - the base URL to the Nexus Repository Manager 3 instance used by Cachito.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ Custom configuration for the Celery workers are listed below:
   `cachito_nexus_username` for uploading content if you are using the two Nexus instance approach as
   described in the "Nexus For npm" section. If this is set, `cachito_nexus_hoster_password` must
   also be set.
+* `cachito_nexus_npm_proxy_repo_url` - the URL to the `cachito-js` repository which is a Nexus group
+  that points to the `cachito-js-hosted` hosted repository and the `cachito-js-proxy` proxy
+  repository. This defaults to `http://localhost:8081/repository/cachito-js/`. This only needs to
+  change if you are using the two Nexus instance approach as described in the "Nexus For npm"
+  section or you use a different name for the repository.
 * `cachito_nexus_password` - the password of the Nexus service account used by Cachito.
 * `cachito_nexus_proxy_password` - the password of the unprivileged user that has read access
   to the main Cachito repositories (e.g. `cachito-js`). This is needed if the Nexus instance that
@@ -154,11 +159,6 @@ Custom configuration for the Celery workers are listed below:
   to the main Cachito repositories (e.g. `cachito-js`). This is needed if the Nexus instance that
   hosts the main Cachito repositories has anonymous access disabled. This is the case if Cachito
   utilizes just a single Nexus instance.
-* `cachito_nexus_npm_proxy_repo_url` - the URL to the `cachito-js` repository which is a Nexus group
-  that points to the `cachito-js-hosted` hosted repository and the `cachito-js-proxy` proxy
-  repository. This defaults to `http://localhost:8081/repository/cachito-js/`. This only needs to
-  change if you are using the two Nexus instance approach as described in the "Nexus For npm"
-  section or you use a different name for the repository.
 * `cachito_nexus_timeout` - the timeout when making a Nexus API request. The default is `60`
   seconds.
 * `cachito_nexus_url` - the base URL to the Nexus Repository Manager 3 instance used by Cachito.

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -27,9 +27,11 @@ class Config(object):
     cachito_nexus_hoster_password = None
     cachito_nexus_hoster_url = None
     cachito_nexus_hoster_username = None
+    cachito_nexus_js_hosted_repo_name = "cachito-js-hosted"
     cachito_nexus_npm_proxy_repo_url = "http://localhost:8081/repository/cachito-js/"
     cachito_nexus_proxy_password = None
     cachito_nexus_proxy_username = None
+    cachito_nexus_request_repo_prefix = "cachito-"
     cachito_nexus_timeout = 60
     cachito_nexus_username = "cachito"
     cachito_request_lifetime = 1

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -27,9 +27,9 @@ class Config(object):
     cachito_nexus_hoster_password = None
     cachito_nexus_hoster_url = None
     cachito_nexus_hoster_username = None
+    cachito_nexus_npm_proxy_repo_url = "http://localhost:8081/repository/cachito-js/"
     cachito_nexus_proxy_password = None
     cachito_nexus_proxy_username = None
-    cachito_nexus_npm_proxy_repo_url = "http://localhost:8081/repository/cachito-js/"
     cachito_nexus_timeout = 60
     cachito_nexus_username = "cachito"
     cachito_request_lifetime = 1

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -243,7 +243,8 @@ def get_js_hosted_repo_name():
     :return: the name of NPM hosted repository
     :rtype: str
     """
-    return "cachito-js-hosted"
+    config = get_worker_config()
+    return config.cachito_nexus_js_hosted_repo_name
 
 
 def get_js_proxy_repo_name(request_id):
@@ -254,7 +255,8 @@ def get_js_proxy_repo_name(request_id):
     :return: the name of npm proxy repository for the request
     :rtype: str
     """
-    return f"cachito-js-{request_id}"
+    config = get_worker_config()
+    return f"{config.cachito_nexus_request_repo_prefix}js-{request_id}"
 
 
 def get_js_proxy_repo_url(request_id):


### PR DESCRIPTION
This allows for multiple instances of Cachito to use the same Nexus instances.

The first commit fixes the alphabetical ordering of the configuration options.