### PR TITLE
Use npm instead of js in the proxy repository for npm requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Custom configuration for the Celery workers are listed below:
   hosts the main Cachito repositories has anonymous access disabled. This is the case if Cachito
   utilizes just a single Nexus instance.
 * `cachito_nexus_request_repo_prefix` - the prefix of Nexus proxy repositories made for each
-  request for applicable package managers (e.g. `cachito-js-1`). This defaults to `cachito-`.
+  request for applicable package managers (e.g. `cachito-npm-1`). This defaults to `cachito-`.
 * `cachito_nexus_timeout` - the timeout when making a Nexus API request. The default is `60`
   seconds.
 * `cachito_nexus_url` - the base URL to the Nexus Repository Manager 3 instance used by Cachito.

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -273,7 +273,7 @@ def test_execute_script(mock_requests):
     mock_requests.post.return_value.ok = True
 
     nexus.execute_script(
-        "js_cleanup", {"repository_name": "cachito-js-1", "username": "cachito-js-1"}
+        "js_cleanup", {"repository_name": "cachito-npm-1", "username": "cachito-npm-1"}
     )
 
     mock_requests.post.assert_called_once()
@@ -287,7 +287,7 @@ def test_execute_script_connection_error(mock_requests):
     expected = "Could not connect to the Nexus instance to execute the script js_cleanup"
     with pytest.raises(NexusScriptError, match=expected):
         nexus.execute_script(
-            "js_cleanup", {"repository_name": "cachito-js-1", "username": "cachito-js-1"}
+            "js_cleanup", {"repository_name": "cachito-npm-1", "username": "cachito-npm-1"}
         )
 
     mock_requests.post.assert_called_once()
@@ -301,7 +301,7 @@ def test_execute_script_failed(mock_requests):
     expected = "The Nexus script js_cleanup failed with: some error"
     with pytest.raises(NexusScriptError, match=expected):
         nexus.execute_script(
-            "js_cleanup", {"repository_name": "cachito-js-1", "username": "cachito-js-1"}
+            "js_cleanup", {"repository_name": "cachito-npm-1", "username": "cachito-npm-1"}
         )
 
     mock_requests.post.assert_called_once()

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -519,6 +519,18 @@ def test_get_deps_unsupported_non_registry_dep():
         npm._get_deps(package_lock_deps, {})
 
 
+def test_get_npm_proxy_repo_name():
+    assert npm.get_npm_proxy_repo_name(3) == "cachito-npm-3"
+
+
+def test_get_npm_proxy_repo_url():
+    assert npm.get_npm_proxy_repo_url(3).endswith("/repository/cachito-npm-3/")
+
+
+def test_get_npm_proxy_username():
+    assert npm.get_npm_proxy_username(3) == "cachito-npm-3"
+
+
 def test_get_package_and_deps(package_lock_deps, package_and_deps):
     package_lock = {"name": "han_solo", "version": "5.0.0", "dependencies": package_lock_deps}
     mock_open = mock.mock_open(read_data=json.dumps(package_lock))
@@ -701,7 +713,7 @@ def test_resolve_npm(mock_dd, mock_gpad, mock_exists, shrink_wrap, package_lock,
     mock_gpad.assert_called_once_with(package_json_path, lock_file_path)
     # We can't verify the actual correct deps value was passed in since the deps that were passed
     # in were mutated and mock does not keep a deepcopy of the function arguments.
-    mock_dd.assert_called_once_with(1, mock.ANY)
+    mock_dd.assert_called_once_with(1, mock.ANY, mock.ANY)
 
 
 @mock.patch("cachito.workers.pkg_managers.npm.os.path.exists")

--- a/tests/test_workers/test_tasks/test_npm.py
+++ b/tests/test_workers/test_tasks/test_npm.py
@@ -11,7 +11,7 @@ from cachito.workers.tasks import npm
 def test_cleanup_npm_request(mock_exec_script):
     npm.cleanup_npm_request(3)
 
-    expected_payload = {"repository_name": "cachito-js-3", "username": "cachito-js-3"}
+    expected_payload = {"repository_name": "cachito-npm-3", "username": "cachito-npm-3"}
     mock_exec_script.assert_called_once_with("js_cleanup", expected_payload)
 
 
@@ -66,24 +66,29 @@ def test_fetch_npm_source(
         "package": package,
         "package.json": package_json,
     }
-    username = f"cachito-js-{request_id}"
+    username = f"cachito-npm-{request_id}"
     password = "asjfhjsdfkwe"
-    mock_fnfjr.return_value = (username, password)
+    mock_fnfjr.return_value = password
     mock_gcc.return_value = ca_file
     mock_gnc.return_value = "some npmrc"
 
     npm.fetch_npm_source(request_id)
 
     assert mock_srs.call_count == 3
-    mock_pnfjr.assert_called_once_with(request_id)
+    mock_pnfjr.assert_called_once_with("cachito-npm-6")
     lock_file_path = str(mock_rbd().source_dir)
     mock_rn.assert_called_once_with(lock_file_path, request)
     if ca_file:
         mock_gnc.assert_called_once_with(
-            request_id, username, password, custom_ca_path="./registry-ca.pem"
+            "http://nexus:8081/repository/cachito-npm-6/",
+            username,
+            password,
+            custom_ca_path="./registry-ca.pem",
         )
     else:
-        mock_gnc.assert_called_once_with(request_id, username, password, custom_ca_path=None)
+        mock_gnc.assert_called_once_with(
+            "http://nexus:8081/repository/cachito-npm-6/", username, password, custom_ca_path=None
+        )
 
     expected_config_files = []
     if ca_file:
@@ -181,4 +186,4 @@ def test_fetch_npm_source_resolve_fails(mock_rn, mock_pnfjr, mock_srs, mock_rbd)
         npm.fetch_npm_source(request_id)
 
     assert mock_srs.call_count == 2
-    mock_pnfjr.assert_called_once_with(request_id)
+    mock_pnfjr.assert_called_once_with("cachito-npm-6")


### PR DESCRIPTION
In the future, if a package manager such as yarn is added, we would want that to be a separate repo name in the event a Git repo contains both npm and yarn.