### PR TITLE
Set the correct null value for HTTP authentication in js_before_content_staged

### DIFF
--- a/cachito/workers/nexus_scripts/js_before_content_staged.groovy
+++ b/cachito/workers/nexus_scripts/js_before_content_staged.groovy
@@ -94,16 +94,14 @@ def createRequestRepo(String repositoryName, String npmProxyUrl, String httpUser
     }
 
     // This is the authentication required for this proxy to access the cachito-js NPM repository group
-    def authentication = httpclient.child('authentication')
     if (httpUsername && httpPassword) {
+      def authentication = httpclient.child('authentication')
       authentication.set('type', 'username')
       authentication.set('username', httpUsername)
       authentication.set('password', httpPassword)
     }
     else {
-      authentication.set('type', null)
-      authentication.set('username', null)
-      authentication.set('password', null)
+      httpclient.set('authentication', null)
     }
 
     if(exists) {


### PR DESCRIPTION
This will prevent an exception occurring in Nexus when HTTP authentication isn't needed to communicate with the `cachito-js` Nexus repository.