### PR TITLE
Remove the auto-detect feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Custom configuration for the API:
 
 * `CACHITO_BUNDLES_DIR` - the root of the bundles directory that is also accessible by the
   workers. This is used to download the bundle archives created by the workers.
+* `CACHITO_DEFAULT_PACKAGE_MANAGERS` - the default package managers to use when no package managers
+  are specified on a request. This defaults to `["gomod"]`.
 * `CACHITO_MAX_PER_PAGE` - the maximum amount of items in a page for paginated results.
 * `CACHITO_PACKAGE_MANAGERS` - the list of enabled package managers. This defaults to `["gomod"]`.
 * `CACHITO_USER_REPRESENTATIVES` - the list of usernames that are allowed to submit requests on

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ environment variable to the path of the keytab. Additional Kerberos configuratio
 
 Custom configuration for the API:
 
-* `CACHITO_MAX_PER_PAGE` - the maximum amount of items in a page for paginated results.
 * `CACHITO_BUNDLES_DIR` - the root of the bundles directory that is also accessible by the
   workers. This is used to download the bundle archives created by the workers.
+* `CACHITO_MAX_PER_PAGE` - the maximum amount of items in a page for paginated results.
 * `CACHITO_PACKAGE_MANAGERS` - the list of enabled package managers. This defaults to `["gomod"]`.
 * `CACHITO_USER_REPRESENTATIVES` - the list of usernames that are allowed to submit requests on
   behalf of other users.

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -12,6 +12,7 @@ class Config(object):
 
     # Additional loggers to set to the level defined in CACHITO_LOG_LEVEL
     CACHITO_ADDITIONAL_LOGGERS = []
+    CACHITO_DEFAULT_PACKAGE_MANAGERS = ["gomod"]
     # This sets the level of the "flask.app" logger, which is accessed from current_app.logger
     CACHITO_LOG_LEVEL = "INFO"
     CACHITO_LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s %(module)s.%(funcName)s %(message)s"
@@ -75,6 +76,7 @@ def validate_cachito_config(config, cli=False):
     """
     # Validate the required config variables
     for config_var in (
+        "CACHITO_DEFAULT_PACKAGE_MANAGERS",
         "CACHITO_LOG_LEVEL",
         "CACHITO_MAX_PER_PAGE",
         "CACHITO_LOG_FORMAT",

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -473,6 +473,13 @@ components:
           items:
             type: string
             example: gomod
+          description: >
+            The list of package managers to use on the request. If this is not set, Cachito will
+            use the configured default package managers. In most deployments, this will be
+            ["gomod"]. To explicitly disable the use of any package managers, just provide an
+            empty array.
+          example:
+          - gomod
         ref:
           type: string
           example: "a7ac8d4c0b7fe90d51fb911511cbf6939655c877"

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -16,21 +16,14 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def fetch_gomod_source(request_id, auto_detect=False, dep_replacements=None):
+def fetch_gomod_source(request_id, dep_replacements=None):
     """
     Resolve and fetch gomod dependencies for a given request.
 
     :param int request_id: the Cachito request ID this is for
-    :param bool auto_detect: automatically detect if the archive uses Go modules
     :param list dep_replacements: dependency replacements with the keys "name" and "version"
     """
     bundle_dir = RequestBundleDir(request_id)
-    if auto_detect:
-        log.debug("Checking if the application source uses Go modules")
-        if not bundle_dir.go_mod_file.exists():
-            log.info("The application source does not use Go modules")
-            return
-
     log.info("Fetching gomod dependencies for request %d", request_id)
     request = set_request_state(request_id, "in_progress", "Fetching the gomod dependencies")
     try:

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -40,12 +40,11 @@ def cleanup_npm_request(request_id):
 
 
 @app.task
-def fetch_npm_source(request_id, auto_detect=False):
+def fetch_npm_source(request_id):
     """
     Resolve and fetch npm dependencies for a given request.
 
     :param int request_id: the Cachito request ID this is for
-    :param bool auto_detect: automatically detect if the archive uses npm
     :raise CachitoError: if the task fails
     """
     validate_npm_config()
@@ -56,10 +55,6 @@ def fetch_npm_source(request_id, auto_detect=False):
         if lock_file.exists():
             break
     else:
-        if auto_detect:
-            log.info("The application source does not use npm")
-            return
-
         raise CachitoError(
             "The npm-shrinkwrap.json or package-lock.json file must be present for the npm "
             "package manager"

--- a/tests/test_cachito_config.py
+++ b/tests/test_cachito_config.py
@@ -20,6 +20,7 @@ def test_validate_cachito_config_success(mock_isdir, app):
     "variable_name",
     (
         "CACHITO_BUNDLES_DIR",
+        "CACHITO_DEFAULT_PACKAGE_MANAGERS",
         "CACHITO_LOG_LEVEL",
         "CACHITO_MAX_PER_PAGE",
         "CACHITO_LOG_FORMAT",

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -4,24 +4,17 @@ from unittest import mock
 import pytest
 
 from cachito.workers import tasks
-from cachito.workers.paths import RequestBundleDir
 
 
 @pytest.mark.parametrize(
-    "auto_detect, contains_go_mod, dep_replacements, expect_state_update",
+    "dep_replacements, expect_state_update",
     (
-        (False, False, None, True),
-        (True, True, None, True),
-        (True, False, None, False),
-        (
-            True,
-            True,
-            False,
-            [{"name": "github.com/pkg/errors", "type": "gomod", "version": "v0.8.1"}],
-        ),
+        (None, True),
+        (None, False),
+        (False, [{"name": "github.com/pkg/errors", "type": "gomod", "version": "v0.8.1"}]),
     ),
 )
-@mock.patch("cachito.workers.tasks.gomod.RequestBundleDir.exists")
+@mock.patch("cachito.workers.tasks.gomod.RequestBundleDir")
 @mock.patch("cachito.workers.tasks.gomod.update_request_with_packages")
 @mock.patch("cachito.workers.tasks.gomod.update_request_with_deps")
 @mock.patch("cachito.workers.tasks.gomod.set_request_state")
@@ -31,9 +24,7 @@ def test_fetch_gomod_source(
     mock_set_request_state,
     mock_update_request_with_deps,
     mock_update_request_with_packages,
-    mock_exists,
-    auto_detect,
-    contains_go_mod,
+    mock_bundle_dir,
     dep_replacements,
     expect_state_update,
     sample_deps_replace,
@@ -42,9 +33,8 @@ def test_fetch_gomod_source(
 ):
     mock_request = mock.Mock()
     mock_set_request_state.return_value = mock_request
-    mock_exists.return_value = contains_go_mod
     mock_resolve_gomod.return_value = sample_package, sample_deps_replace
-    tasks.fetch_gomod_source(1, auto_detect, dep_replacements)
+    tasks.fetch_gomod_source(1, dep_replacements)
 
     if expect_state_update:
         mock_set_request_state.assert_called_once_with(
@@ -55,18 +45,6 @@ def test_fetch_gomod_source(
         )
         mock_update_request_with_deps.assert_called_once_with(1, sample_deps_replace)
 
-    bundle_dir = RequestBundleDir(1)
-
-    if auto_detect:
-        mock_exists.assert_called_once()
-        if contains_go_mod:
-            mock_resolve_gomod.assert_called_once_with(
-                str(bundle_dir.source_dir), mock_request, dep_replacements
-            )
-        else:
-            mock_resolve_gomod.assert_not_called()
-    else:
-        mock_resolve_gomod.assert_called_once_with(
-            str(bundle_dir.source_dir), mock_request, dep_replacements
-        )
-        mock_exists.assert_not_called()
+    mock_resolve_gomod.assert_called_once_with(
+        str(mock_bundle_dir().source_dir), mock_request, dep_replacements
+    )

--- a/tests/test_workers/test_tasks/test_npm.py
+++ b/tests/test_workers/test_tasks/test_npm.py
@@ -161,17 +161,6 @@ def test_fetch_npm_source_node_modules_exists(mock_rbd):
 
 @mock.patch("cachito.workers.tasks.npm.RequestBundleDir")
 @mock.patch("cachito.workers.tasks.npm.set_request_state")
-def test_fetch_npm_source_no_lock_auto_detect(mock_srs, mock_rbd):
-    mock_rbd.return_value.npm_shrinkwrap_file.exists.return_value = False
-    mock_rbd.return_value.npm_package_lock_file.exists.return_value = False
-
-    npm.fetch_npm_source(6, auto_detect=True)
-
-    mock_srs.assert_not_called()
-
-
-@mock.patch("cachito.workers.tasks.npm.RequestBundleDir")
-@mock.patch("cachito.workers.tasks.npm.set_request_state")
 @mock.patch("cachito.workers.tasks.npm.prepare_nexus_for_js_request")
 @mock.patch("cachito.workers.tasks.npm.resolve_npm")
 def test_fetch_npm_source_resolve_fails(mock_rn, mock_pnfjr, mock_srs, mock_rbd):


### PR DESCRIPTION
This is done to prevent requests that previously worked to fail if a new package manager is enabled. If no package manager is supplied in a request, a configurable default value is used. This configuration defaults to `["gomod"]`.