### PR TITLE
Add a configuration to set default environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Custom configuration for the Celery workers are listed below:
 * `cachito_bundles_dir` - the directory for storing bundle archives which include the source archive
   and dependencies. This configuration is required, and the directory must already exist and be
   writeable.
+* `cachito_default_environment_variables` - a dictionary where the keys are names of package
+  managers. The values are dictionaries where the keys are default environment variables to
+  set for that package manager and the values are the environment variable values. Check
+  `cachito/workers/config.py::Config` for the default value of this configuration.
 * `cachito_download_timeout` - the timeout when downloading application source archives from sources
   such as GitHub. The default is `120` seconds.
 * `cachito_js_download_batch_size` - the number of JavaScript dependencies to download at once using

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -2,6 +2,7 @@
 import logging
 
 from cachito.errors import CachitoError
+from cachito.workers.config import get_worker_config
 from cachito.workers.pkg_managers.general import (
     update_request_with_deps,
     update_request_with_packages,
@@ -40,5 +41,6 @@ def fetch_gomod_source(request_id, auto_detect=False, dep_replacements=None):
         raise
 
     env_vars = {"GOCACHE": "deps/gomod", "GOPATH": "deps/gomod"}
+    env_vars.update(get_worker_config().cachito_default_environment_variables.get("gomod", {}))
     update_request_with_packages(request_id, [module], "gomod", env_vars)
     update_request_with_deps(request_id, deps)

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -6,7 +6,7 @@ import os
 
 from cachito.errors import CachitoError
 from cachito.workers import nexus
-from cachito.workers.config import validate_npm_config
+from cachito.workers.config import get_worker_config, validate_npm_config
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import (
     update_request_with_config_files,
@@ -135,6 +135,6 @@ def fetch_npm_source(request_id, auto_detect=False):
         )
 
     update_request_with_config_files(request_id, npm_config_files)
-
-    update_request_with_packages(request_id, [package_and_deps_info["package"]], "npm")
+    env_vars = get_worker_config().cachito_default_environment_variables.get("npm", {})
+    update_request_with_packages(request_id, [package_and_deps_info["package"]], "npm", env_vars)
     update_request_with_deps(request_id, package_and_deps_info["deps"])

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -40,6 +40,8 @@ def test_fetch_gomod_source(
     sample_package,
     sample_env_vars,
 ):
+    # Add the default environment variable from the configuration
+    sample_env_vars["GO111MODULE"] = "on"
     mock_request = mock.Mock()
     mock_set_request_state.return_value = mock_request
     mock_exists.return_value = contains_go_mod

--- a/tests/test_workers/test_tasks/test_npm.py
+++ b/tests/test_workers/test_tasks/test_npm.py
@@ -118,7 +118,12 @@ def test_fetch_npm_source(
         )
 
     mock_urwcf.assert_called_once_with(request_id, expected_config_files)
-    mock_urwp.assert_called_once_with(request_id, [package], "npm")
+    mock_urwp.assert_called_once_with(
+        request_id,
+        [package],
+        "npm",
+        {"CHROMEDRIVER_SKIP_DOWNLOAD": "true", "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": "true"},
+    )
     mock_urwd.assert_called_once_with(request_id, deps)
 
 


### PR DESCRIPTION
These can be set for each package manager. Some defaults were added to npm to prevent certain post install scripts from reaching out to the internet.