### PR TITLE
Allow workers to authenticate with SSL certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,13 @@ Custom configuration for the Celery workers are listed below:
   seconds.
 * `cachito_athens_url` - the URL to the Athens instance to use for caching gomod dependencies. This
   is only necessary for workers that process gomod requests.
+* `cachito_auth_cert` - the SSL certificate to be used for authentication. See
+  https://requests.readthedocs.io/en/master/user/advanced/#client-side-certificates for reference on
+  how to provide this certificate.
 * `cachito_auth_type` - the authentication type to use when accessing protected Cachito API
   endpoints. If this value is `None`, authentication will not be used. This defaults to `kerberos`
-  in production.
+  in production. The `cert` value is also valid and would use an SSL certificate for authentication.
+  This requires `cachito_auth_cert` to be provided.
 * `cachito_bundles_dir` - the directory for storing bundle archives which include the source archive
   and dependencies. This configuration is required, and the directory must already exist and be
   writeable.

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -171,6 +171,9 @@ def validate_celery_config(conf, **kwargs):
             "the other must also be set"
         )
 
+    if conf.get("cachito_auth_type") == "cert" and conf.get("cachito_auth_cert") is None:
+        raise ConfigError('cachito_auth_cert configuration must be set for "cert" authentication')
+
     if not isinstance(conf.get("cachito_default_environment_variables"), dict):
         raise ConfigError(
             'The configuration "cachito_default_environment_variables" must be a dictionary'


### PR DESCRIPTION
This can be used as an alternative to completely disabling
authentication requirements for environments without kerberos support

* See https://requests.readthedocs.io/en/master/user/advanced/#client-side-certificates

Signed-off-by: Athos Ribeiro <athos@redhat.com>