### PR TITLE
Vendor gomod dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ Custom configuration for the Celery workers are listed below:
   script. This defaults to `1`.
 * `cachito_sources_dir` - the directory for long-term storage of app source archives. This
   configuration is required, and the directory must already exist and be writeable.
+* `cachito_gomod_strict_vendor` - the bool to disable/enable the strict vendor mode. This defaults
+  to `False`. For a repo that has gomod dependencies, if the `vendor` directory exists and this config
+  option is set to `True`, Cachito will fail the request.
 
 To configure the workers to use a Kerberos keytab for authentication, set the `KRB5_CLIENT_KTNAME`
 environment variable to the path of the keytab. Additional Kerberos configuration can be made in
@@ -209,6 +212,11 @@ If you are planning to deploy Cachito with authentication enabled, you'll need t
 a web server that supplies the `REMOTE_USER` environment variable when the user is
 properly authenticated. A common deployment option is using httpd (Apache web server)
 with the `mod_auth_gssapi` module.
+
+## Flags
+
+* `gomod-vendor` - the flag to indicate the vendoring requirement for gomod dependencies. If present in the
+  Cachito request, Cachito will run `go mod vendor` instead of `go mod download` to gather dependencies.
 
 ## Nexus
 

--- a/cachito/web/migrations/versions/b46cf36806d7_add_gomod_vendor_flag.py
+++ b/cachito/web/migrations/versions/b46cf36806d7_add_gomod_vendor_flag.py
@@ -1,0 +1,41 @@
+"""Add the gomod-vendor flag
+
+Revision ID: b46cf36806d7
+Revises: 615c19a1cee1
+Create Date: 2020-05-19 10:33:19.638354
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b46cf36806d7"
+down_revision = "615c19a1cee1"
+branch_labels = None
+depends_on = None
+
+flag_table = sa.Table(
+    "flag",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer(), primary_key=True),
+    sa.Column("name", sa.String(), nullable=False),
+    sa.Column("active", sa.Boolean(), nullable=False, default=True),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    res = connection.execute(
+        flag_table.select().where(flag_table.c.name == "gomod-vendor")
+    ).fetchone()
+    if res is None:
+        connection.execute(flag_table.insert().values(name="gomod-vendor", active=True))
+    else:
+        connection.execute(
+            flag_table.update().where(flag_table.c.name == "gomod-vendor").values(active=True)
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    connection.execute(flag_table.update().values(name="gomod-vendor", active=False))

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -30,6 +30,7 @@ class Config(object):
     }
     cachito_deps_patch_batch_size = 50
     cachito_download_timeout = 120
+    cachito_gomod_strict_vendor = False
     cachito_log_level = "INFO"
     cachito_js_download_batch_size = 30
     cachito_nexus_ca_cert = "/etc/cachito/nexus_ca.pem"

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -67,10 +67,7 @@ class Config(object):
     # Route gomod tasks and npm tasks to separate queues. This is useful if workers are dedicated
     # to specific package managers.
     task_routes = {
-        "cachito.workers.tasks.gomod.*": {
-            "queue": "cachito_gomod",
-            "routing_key": "cachito.gomod",
-        },
+        "cachito.workers.tasks.gomod.*": {"queue": "cachito_gomod", "routing_key": "cachito.gomod"},
         "cachito.workers.tasks.npm.*": {"queue": "cachito_npm", "routing_key": "cachito.npm"},
     }
     # Only allow a single process so the concurrency is only based on the number of instances of the
@@ -200,11 +197,7 @@ def validate_nexus_config():
     :raise ConfigError: if the Celery configuration isn't configured for Nexus
     """
     conf = get_worker_config()
-    for nexus_conf in (
-        "cachito_nexus_password",
-        "cachito_nexus_url",
-        "cachito_nexus_username",
-    ):
+    for nexus_conf in ("cachito_nexus_password", "cachito_nexus_url", "cachito_nexus_username"):
         if not conf.get(nexus_conf):
             raise ConfigError(
                 f'The configuration "{nexus_conf}" must be set for this package manager'


### PR DESCRIPTION
A data migration is added for adding gomod-vendor flag. When the flag is set, it vendors the dependencies. Another cachito worker config is added to disable/enable cachito strict mode. If the strict mode is enabled and vendor directory exists, cachito requests are failed.