### PR TITLE
Add an allow list of npm file dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ Custom configuration for the Celery workers are listed below:
   following privileges are required: `nx-repository-admin-*-*-*`, `nx-repository-view-npm-*-*`,
   `nx-roles-all`, `nx-script-*-*`, `nx-users-all` and `nx-userschangepw`. This defaults to
   `cachito`.
+* `cachito_npm_file_deps_allowlist` - the npm "file" dependencies that are allowed in the lock file
+  for the "npm" package manager. This configuration is a dictionary with the keys as package names
+  and the values as lists of dependency names. This defaults to `{}`.
 * `cachito_request_lifetime` - the number of days before a request that is in the `complete` state
   or that is stuck in the `in_progress` state will be marked as stale by the `cachito-cleanup`
   script. This defaults to `1`.

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -45,6 +45,7 @@ class Config(object):
     cachito_nexus_request_repo_prefix = "cachito-"
     cachito_nexus_timeout = 60
     cachito_nexus_username = "cachito"
+    cachito_npm_file_deps_allowlist = {}
     cachito_request_lifetime = 1
     include = [
         "cachito.workers.tasks.general",
@@ -108,6 +109,7 @@ class TestingConfig(DevelopmentConfig):
         "gomod": {"GO111MODULE": "on"},
         "npm": {"CHROMEDRIVER_SKIP_DOWNLOAD": "true", "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": "true"},
     }
+    cachito_npm_file_deps_allowlist = {"han_solo": ["millennium-falcon"]}
 
 
 def configure_celery(celery_app):

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -99,6 +99,9 @@ def download_dependencies(request_id, deps, proxy_repo_url):
             if dep["bundled"]:
                 log.debug("Not downloading %s since it is a bundled dependency", dep_identifier)
                 continue
+            elif dep["version"].startswith("file:"):
+                log.debug("Not downloading %s since it is a file dependency", dep_identifier)
+                continue
 
             if counter % batch_size == 0:
                 deps_batches.append([])

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -72,6 +72,13 @@ def test_download_dependencies(
             "version": "github:ReactiveX/rxjs#78032157f5c1655436829017bbda787565b48c30",
             "version_in_nexus": "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
         },
+        {
+            "bundled": False,
+            "dev": False,
+            "name": "jsplumb",
+            "version": "file:../jsplumb-2.10.2.tgz",
+            "version_in_nexus": None,
+        },
     ]
     request_id = 1
     request_bundle_dir = bundles_dir.mkdir("temp").mkdir(str(request_id))


### PR DESCRIPTION
One project that Cachito must support is a plugin for Kui, which must specify its configuration via an npm dependency. This project wants to use a file dependency for this to avoid a separate repository. Since this is a special case, this should be allowed.

Resolves CLOUDBLD-1533