### PR TITLE
Remove setting pkg_managers using the PATCH API endpoint

### DIFF
--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -508,11 +508,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Package"
-        pkg_managers:
-          type: array
-          items:
-            type: string
-            example: gomod
         state:
           type: string
           example: complete

--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -106,21 +106,16 @@ def update_request_with_deps(request_id, deps):
             raise CachitoError(f"Setting the dependencies on request {request_id} failed")
 
 
-def update_request_with_packages(request_id, packages, pkg_manager=None, env_vars=None):
+def update_request_with_packages(request_id, packages, env_vars=None):
     """
     Update the request with the resolved packages and corresponding metadata.
 
     :param list packages: the list of packages that were resolved
     :param dict env_vars: mapping of environment variables to record
-    :param str pkg_manager: a package manager to add to the request if auto-detection was used
     :raise CachitoError: if the request to the Cachito API fails
     """
     log.info('Adding the packages "%r" to the request %d', packages, request_id)
     payload = {"packages": packages}
-
-    if pkg_manager:
-        log.info('Also adding the package manager "%s" to the request %d', pkg_manager, request_id)
-        payload["pkg_managers"] = [pkg_manager]
 
     if env_vars:
         log.info("Also adding environment variables to the request %d: %s", request_id, env_vars)

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -35,5 +35,5 @@ def fetch_gomod_source(request_id, dep_replacements=None):
 
     env_vars = {"GOCACHE": "deps/gomod", "GOPATH": "deps/gomod"}
     env_vars.update(get_worker_config().cachito_default_environment_variables.get("gomod", {}))
-    update_request_with_packages(request_id, [module], "gomod", env_vars)
+    update_request_with_packages(request_id, [module], env_vars)
     update_request_with_deps(request_id, deps)

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -139,5 +139,5 @@ def fetch_npm_source(request_id):
 
     update_request_with_config_files(request_id, npm_config_files)
     env_vars = get_worker_config().cachito_default_environment_variables.get("npm", {})
-    update_request_with_packages(request_id, [package_and_deps_info["package"]], "npm", env_vars)
+    update_request_with_packages(request_id, [package_and_deps_info["package"]], env_vars)
     update_request_with_deps(request_id, package_and_deps_info["deps"])

--- a/tests/test_workers/test_pkg_managers/test_general.py
+++ b/tests/test_workers/test_pkg_managers/test_general.py
@@ -33,14 +33,12 @@ def test_update_request_with_packages(mock_requests):
     packages = [
         {"name": "helloworld", "type": "gomod", "version": "v0.0.0-20200324130456-8aedc0ec8bb5"}
     ]
-    pkg_manager = "gomod"
     env_vars = {"GOCACHE": "deps/gomod", "GOPATH": "deps/gomod"}
     expected_json = {
         "environment_variables": env_vars,
         "packages": packages,
-        "pkg_managers": [pkg_manager],
     }
-    update_request_with_packages(1, packages, pkg_manager, env_vars)
+    update_request_with_packages(1, packages, env_vars)
     mock_requests.patch.assert_called_once_with(
         "http://cachito.domain.local/api/v1/requests/1", json=expected_json, timeout=60
     )

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -43,7 +43,7 @@ def test_fetch_gomod_source(
             1, "in_progress", "Fetching the gomod dependencies"
         )
         mock_update_request_with_packages.assert_called_once_with(
-            1, [sample_package], "gomod", sample_env_vars
+            1, [sample_package], sample_env_vars
         )
         mock_update_request_with_deps.assert_called_once_with(1, sample_deps_replace)
 

--- a/tests/test_workers/test_tasks/test_npm.py
+++ b/tests/test_workers/test_tasks/test_npm.py
@@ -126,7 +126,6 @@ def test_fetch_npm_source(
     mock_urwp.assert_called_once_with(
         request_id,
         [package],
-        "npm",
         {"CHROMEDRIVER_SKIP_DOWNLOAD": "true", "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": "true"},
     )
     mock_urwd.assert_called_once_with(request_id, deps)


### PR DESCRIPTION
This functionality is no longer needed since PR #163 removed autodetection. This means that all package managers are set on the request when it is created.