### PR TITLE
Remove the JSON parameters in the POST API endpoint docstring

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -137,10 +137,6 @@ def create_request():
     """
     Submit a request to resolve and cache the given source code and its dependencies.
 
-    :param str repo: the URL to the SCM repository
-    :param str ref: the SCM reference to fetch
-    :param list<str> pkg_managers: list of package managers to be used for resolving dependencies
-    :param list<str> flags: list of flag names
     :rtype: flask.Response
     :raise ValidationError: if required parameters are not supplied
     """


### PR DESCRIPTION
This is out of date and all documentation for the API lives in the OpenAPI document.