### PR TITLE
Add a configuration to ignore missing go.mod files

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ Custom configuration for the Celery workers are listed below:
 * `cachito_js_download_batch_size` - the number of JavaScript dependencies to download at once using
   `npm pack`. If this value is too high, Nexus will return the error "Header is too large". This
   defaults to `30`.
+* `cachito_gomod_ignore_missing_gomod_file` - if `True` and the request specifies the `gomod`
+  package manager but there is no `go.mod` file present in the repository, Cachito will skip
+  the `gomod` package manager for the request. If `False`, the request will fail if the `go.mod`
+  file is missing. This defaults to `False`.
 * `cachito_log_level` - the log level to configure the workers with (e.g. `DEBUG`, `INFO`, etc.).
 * `cachito_nexus_ca_cert` - the CA certificate that signed the SSL certificate used by the Nexus
   instance. This defaults to `/etc/cachito/nexus_ca.pem`. If this file does not exist, Cachito will

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -30,6 +30,7 @@ class Config(object):
     }
     cachito_deps_patch_batch_size = 50
     cachito_download_timeout = 120
+    cachito_gomod_ignore_missing_gomod_file = False
     cachito_gomod_strict_vendor = False
     cachito_log_level = "INFO"
     cachito_js_download_batch_size = 30


### PR DESCRIPTION
This is useful if the user erroneously specifies the "gomod"
package manager in a Cachito request when the repository
is not a Go module project.

This is also useful if the default package manager is set to
"gomod" and you want to allow users to make requests without
any package managers and would like them not to need to explicitly
set `"pkg_managers": []` in their request.