### PR TITLE
Associate request dependencies with the package they came from

### DIFF
--- a/cachito/web/migrations/versions/1714d8e3002b_map_deps_to_pkg.py
+++ b/cachito/web/migrations/versions/1714d8e3002b_map_deps_to_pkg.py
@@ -1,0 +1,136 @@
+"""
+Map dependencies to their associated package.
+
+Revision ID: 1714d8e3002b
+Revises: b46cf36806d7
+Create Date: 2020-06-24 13:56:28.738839
+"""
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "1714d8e3002b"
+down_revision = "b46cf36806d7"
+branch_labels = None
+depends_on = None
+
+log = logging.getLogger("alembic")
+
+request_dependency_table = sa.Table(
+    "request_dependency",
+    sa.MetaData(),
+    sa.Column("request_id", sa.Integer()),
+    sa.Column("dependency_id", sa.Integer()),
+    sa.Column("package_id", sa.Integer()),
+)
+
+request_package_table = sa.Table(
+    "request_package",
+    sa.MetaData(),
+    sa.Column("request_id", sa.Integer()),
+    sa.Column("package_id", sa.Integer()),
+)
+
+package_table = sa.Table(
+    "package",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer(), primary_key=True),
+    sa.Column("name", sa.String()),
+    sa.Column("type", sa.String()),
+)
+
+
+def upgrade():
+    with op.batch_alter_table("request_dependency") as batch_op:
+        # Temporarily make this column nullable so it can be populated in the data migration
+        batch_op.add_column(
+            sa.Column("package_id", sa.Integer(), autoincrement=False, nullable=True)
+        )
+        batch_op.create_foreign_key(
+            "fk_request_dependency_package_id", "package", ["package_id"], ["id"]
+        )
+        batch_op.drop_constraint("request_dependency_request_id_dependency_id_key")
+
+    _upgrade_data()
+
+    with op.batch_alter_table("request_dependency") as batch_op:
+        batch_op.alter_column("package_id", existing_type=sa.INTEGER(), nullable=False)
+        batch_op.create_index(
+            batch_op.f("ix_request_dependency_package_id"), ["package_id"], unique=False
+        )
+        batch_op.create_unique_constraint(
+            "request_dependency_request_id_dependency_id_package_id_key",
+            ["request_id", "dependency_id", "package_id"],
+        )
+
+
+def _upgrade_data():
+    connection = op.get_bind()
+    last_request_id = None
+    for request_dep in connection.execute(
+        request_dependency_table.select().order_by(request_dependency_table.c.request_id)
+    ).fetchall():
+        if last_request_id != request_dep.request_id:
+            last_request_id = request_dep.request_id
+            log.info(
+                "Associating packages with the dependencies for request %d", request_dep.request_id
+            )
+
+        # Note that a package can be a top-level package or dependency
+        dependency = connection.execute(
+            package_table.select().where(package_table.c.id == request_dep.dependency_id)
+        ).fetchone()
+        package = connection.execute(
+            package_table.select()
+            .select_from(
+                package_table.join(
+                    request_package_table, package_table.c.id == request_package_table.c.package_id
+                )
+            )
+            .where(request_package_table.c.request_id == request_dep.request_id)
+            .where(package_table.c.type == dependency.type)
+        ).fetchone()
+
+        if not package:
+            raise RuntimeError(
+                f"Couldn't find a package associated with the request {request_dep.request_id} and "
+                f"type {dependency.type}",
+            )
+            continue
+
+        connection.execute(
+            request_dependency_table.update()
+            .where(request_dependency_table.c.request_id == request_dep.request_id)
+            .where(request_dependency_table.c.dependency_id == request_dep.dependency_id)
+            .values(package_id=package.id)
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    bad_request_id_results = connection.execute(
+        sa.sql.select([request_dependency_table.c.request_id])
+        .group_by(request_dependency_table.c.request_id, request_dependency_table.c.dependency_id)
+        .having(sa.sql.func.count("*") > 1)
+    ).fetchall()
+    bad_request_ids = {req_dep.request_id for req_dep in bad_request_id_results}
+    if bad_request_ids:
+        raise RuntimeError(
+            "The following requests have the same dependencies associated with different "
+            f"packages: {', '.join(str(v) for v in bad_request_ids)}. Unable to create the proper "
+            "unique constraint after the downgrade."
+        )
+
+    with op.batch_alter_table("request_dependency") as batch_op:
+        batch_op.drop_constraint(
+            "request_dependency_request_id_dependency_id_package_id_key", type_="unique"
+        )
+        batch_op.drop_constraint("fk_request_dependency_package_id", type_="foreignkey")
+        batch_op.drop_index("ix_request_dependency_package_id")
+        batch_op.drop_column("package_id")
+        batch_op.create_unique_constraint(
+            "request_dependency_request_id_dependency_id_key", ["request_id", "dependency_id"]
+        )

--- a/cachito/web/migrations/versions/c8b2a3a26191_initial_migration.py
+++ b/cachito/web/migrations/versions/c8b2a3a26191_initial_migration.py
@@ -84,7 +84,9 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["request_id"], ["request.id"], "request_dependency_dependency_id_fkey"
         ),
-        sa.UniqueConstraint("request_id", "dependency_id"),
+        sa.UniqueConstraint(
+            "request_id", "dependency_id", name="request_dependency_request_id_dependency_id_key"
+        ),
     )
 
 

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -570,10 +570,8 @@ components:
             $ref: "#/components/schemas/PackageWithReplaces"
         environment_variables:
           $ref: "#/components/schemas/EnvironmentVariable"
-        packages:
-          type: array
-          items:
-            $ref: "#/components/schemas/Package"
+        package:
+          $ref: "#/components/schemas/Package"
         state:
           type: string
           example: complete
@@ -595,7 +593,14 @@ components:
           packages:
             type: array
             items:
-              $ref: "#/components/schemas/Package"
+              allOf:
+              - $ref: "#/components/schemas/Package"
+              - type: object
+                properties:
+                  dependencies:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PackageWithReplaces"
           state_history:
             type: array
             items:

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -5,7 +5,7 @@ from cachito.errors import CachitoError
 from cachito.workers.config import get_worker_config
 from cachito.workers.pkg_managers.general import (
     update_request_with_deps,
-    update_request_with_packages,
+    update_request_with_package,
 )
 from cachito.workers.pkg_managers.gomod import resolve_gomod
 from cachito.workers.tasks.celery import app
@@ -45,5 +45,5 @@ def fetch_gomod_source(request_id, dep_replacements=None):
 
     env_vars = {"GOCACHE": "deps/gomod", "GOPATH": "deps/gomod"}
     env_vars.update(config.cachito_default_environment_variables.get("gomod", {}))
-    update_request_with_packages(request_id, [module], env_vars)
-    update_request_with_deps(request_id, deps)
+    update_request_with_package(request_id, module, env_vars)
+    update_request_with_deps(request_id, module, deps)

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -11,7 +11,7 @@ from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import (
     update_request_with_config_files,
     update_request_with_deps,
-    update_request_with_packages,
+    update_request_with_package,
 )
 from cachito.workers.pkg_managers.general_js import (
     generate_npmrc_content,
@@ -139,5 +139,6 @@ def fetch_npm_source(request_id):
 
     update_request_with_config_files(request_id, npm_config_files)
     env_vars = get_worker_config().cachito_default_environment_variables.get("npm", {})
-    update_request_with_packages(request_id, [package_and_deps_info["package"]], env_vars)
-    update_request_with_deps(request_id, package_and_deps_info["deps"])
+    package = package_and_deps_info["package"]
+    update_request_with_package(request_id, package, env_vars)
+    update_request_with_deps(request_id, package, package_and_deps_info["deps"])

--- a/tests/test_workers/test_pkg_managers/test_general.py
+++ b/tests/test_workers/test_pkg_managers/test_general.py
@@ -8,61 +8,79 @@ from cachito.errors import CachitoError
 from cachito.workers.pkg_managers.general import (
     update_request_with_config_files,
     update_request_with_deps,
-    update_request_with_packages,
+    update_request_with_package,
 )
 
 
 @mock.patch("cachito.workers.config.Config.cachito_deps_patch_batch_size", 5)
 @mock.patch("cachito.workers.requests.requests_auth_session")
-def test_update_request_with_deps(mock_requests, sample_deps_replace):
+def test_update_request_with_deps(mock_requests, sample_deps_replace, sample_package):
     mock_requests.patch.return_value.ok = True
-    update_request_with_deps(1, sample_deps_replace)
+    update_request_with_deps(1, sample_package, sample_deps_replace)
     url = "http://cachito.domain.local/api/v1/requests/1"
     calls = [
-        mock.call(url, json={"dependencies": sample_deps_replace[:5]}, timeout=60),
-        mock.call(url, json={"dependencies": sample_deps_replace[5:10]}, timeout=60),
-        mock.call(url, json={"dependencies": sample_deps_replace[10:]}, timeout=60),
+        mock.call(
+            url,
+            json={"dependencies": sample_deps_replace[:5], "package": sample_package},
+            timeout=60,
+        ),
+        mock.call(
+            url,
+            json={"dependencies": sample_deps_replace[5:10], "package": sample_package},
+            timeout=60,
+        ),
+        mock.call(
+            url,
+            json={"dependencies": sample_deps_replace[10:], "package": sample_package},
+            timeout=60,
+        ),
     ]
     assert mock_requests.patch.call_count == 3
     mock_requests.patch.assert_has_calls(calls)
 
 
 @mock.patch("cachito.workers.requests.requests_auth_session")
-def test_update_request_with_packages(mock_requests):
+def test_update_request_with_package(mock_requests):
     mock_requests.patch.return_value.ok = True
-    packages = [
-        {"name": "helloworld", "type": "gomod", "version": "v0.0.0-20200324130456-8aedc0ec8bb5"}
-    ]
+    package = {
+        "name": "helloworld",
+        "type": "gomod",
+        "version": "v0.0.0-20200324130456-8aedc0ec8bb5",
+    }
     env_vars = {"GOCACHE": "deps/gomod", "GOPATH": "deps/gomod"}
     expected_json = {
         "environment_variables": env_vars,
-        "packages": packages,
+        "package": package,
     }
-    update_request_with_packages(1, packages, env_vars)
+    update_request_with_package(1, package, env_vars)
     mock_requests.patch.assert_called_once_with(
         "http://cachito.domain.local/api/v1/requests/1", json=expected_json, timeout=60
     )
 
 
 @mock.patch("cachito.workers.requests.requests_auth_session")
-def test_update_request_with_packages_failed(mock_requests):
+def test_update_request_with_package_failed(mock_requests):
     mock_requests.patch.return_value.ok = False
-    packages = [
-        {"name": "helloworld", "type": "gomod", "version": "v0.0.0-20200324130456-8aedc0ec8bb5"}
-    ]
-    with pytest.raises(CachitoError, match="Setting the packages on request 1 failed"):
-        update_request_with_packages(1, packages)
+    package = {
+        "name": "helloworld",
+        "type": "gomod",
+        "version": "v0.0.0-20200324130456-8aedc0ec8bb5",
+    }
+    with pytest.raises(CachitoError, match="Setting a package on request 1 failed"):
+        update_request_with_package(1, package)
 
 
 @mock.patch("cachito.workers.requests.requests_auth_session")
-def test_update_request_with_packages_failed_connection(mock_requests):
+def test_update_request_with_package_failed_connection(mock_requests):
     mock_requests.patch.side_effect = requests.ConnectTimeout()
-    packages = [
-        {"name": "helloworld", "type": "gomod", "version": "v0.0.0-20200324130456-8aedc0ec8bb5"}
-    ]
-    expected_msg = "The connection failed when adding packages to the request 1"
+    package = {
+        "name": "helloworld",
+        "type": "gomod",
+        "version": "v0.0.0-20200324130456-8aedc0ec8bb5",
+    }
+    expected_msg = "The connection failed when adding a package to the request 1"
     with pytest.raises(CachitoError, match=expected_msg):
-        update_request_with_packages(1, packages)
+        update_request_with_package(1, package)
 
 
 @mock.patch("cachito.workers.requests.requests_auth_session")

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -16,7 +16,7 @@ from cachito.workers import tasks
     ),
 )
 @mock.patch("cachito.workers.tasks.gomod.RequestBundleDir")
-@mock.patch("cachito.workers.tasks.gomod.update_request_with_packages")
+@mock.patch("cachito.workers.tasks.gomod.update_request_with_package")
 @mock.patch("cachito.workers.tasks.gomod.update_request_with_deps")
 @mock.patch("cachito.workers.tasks.gomod.set_request_state")
 @mock.patch("cachito.workers.tasks.gomod.resolve_gomod")
@@ -24,7 +24,7 @@ def test_fetch_gomod_source(
     mock_resolve_gomod,
     mock_set_request_state,
     mock_update_request_with_deps,
-    mock_update_request_with_packages,
+    mock_update_request_with_package,
     mock_bundle_dir,
     dep_replacements,
     expect_state_update,
@@ -43,10 +43,10 @@ def test_fetch_gomod_source(
         mock_set_request_state.assert_called_once_with(
             1, "in_progress", "Fetching the gomod dependencies"
         )
-        mock_update_request_with_packages.assert_called_once_with(
-            1, [sample_package], sample_env_vars
+        mock_update_request_with_package.assert_called_once_with(1, sample_package, sample_env_vars)
+        mock_update_request_with_deps.assert_called_once_with(
+            1, sample_package, sample_deps_replace
         )
-        mock_update_request_with_deps.assert_called_once_with(1, sample_deps_replace)
 
     mock_resolve_gomod.assert_called_once_with(
         str(mock_bundle_dir().source_dir), mock_request, dep_replacements

--- a/tests/test_workers/test_tasks/test_npm.py
+++ b/tests/test_workers/test_tasks/test_npm.py
@@ -28,7 +28,7 @@ def test_cleanup_npm_request(mock_exec_script):
 @mock.patch("cachito.workers.tasks.npm.nexus.get_ca_cert")
 @mock.patch("cachito.workers.tasks.npm.generate_npmrc_content")
 @mock.patch("cachito.workers.tasks.npm.update_request_with_config_files")
-@mock.patch("cachito.workers.tasks.npm.update_request_with_packages")
+@mock.patch("cachito.workers.tasks.npm.update_request_with_package")
 @mock.patch("cachito.workers.tasks.npm.update_request_with_deps")
 def test_fetch_npm_source(
     mock_urwd,
@@ -125,10 +125,10 @@ def test_fetch_npm_source(
     mock_urwcf.assert_called_once_with(request_id, expected_config_files)
     mock_urwp.assert_called_once_with(
         request_id,
-        [package],
+        package,
         {"CHROMEDRIVER_SKIP_DOWNLOAD": "true", "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": "true"},
     )
-    mock_urwd.assert_called_once_with(request_id, deps)
+    mock_urwd.assert_called_once_with(request_id, package, deps)
 
 
 @mock.patch("cachito.workers.tasks.npm.RequestBundleDir")


### PR DESCRIPTION
This adds the "dependencies" key to each package in the "packages" array in the GET API endpoints.
    
This is necessary for future tasks such as generating content manifests and adding support for multiple packages of the same type in the same repository.

Relates to CLOUDBLD-1257