### PR TITLE
Provide Content Manifest API endpoint

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -93,6 +93,21 @@ def get_request_config_files(request_id):
     return flask.jsonify(config_files_json)
 
 
+@api_v1.route("/requests/<int:request_id>/content-manifest", methods=["GET"])
+def get_request_content_manifest(request_id):
+    """
+    Retrieve the content manifest associated with the given request.
+
+    :param int request_id: the value of the request ID
+    :return: a Flask JSON response
+    :rtype: flask.Response
+    :raise NotFound: if the request is not found
+    """
+    content_manifest = Request.query.get_or_404(request_id).content_manifest
+    content_manifest_json = content_manifest.to_json()
+    return flask.jsonify(content_manifest_json)
+
+
 @api_v1.route("/requests/<int:request_id>/download", methods=["GET"])
 def download_archive(request_id):
     """

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -62,6 +62,29 @@ request_config_file_base64_table = db.Table(
 )
 
 
+class ContentManifest:
+    """A content manifest associated with the request."""
+
+    version = 1
+    json_schema_url = (
+        "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/"
+        "f4abcfdaf8247a6b074f94fa84f3846f82d781c6/atomic_reactor/schemas/content_manifest.json"
+    )
+    unknown_layer_index = -1
+
+    empty_icm = {
+        "metadata": {
+            "icm_version": version,
+            "icm_spec": json_schema_url,
+            "image_layer_index": unknown_layer_index,
+        },
+    }
+
+    def to_json(self):
+        """Generate the JSON representation of the content manifest."""
+        return self.empty_icm
+
+
 class RequestStateMapping(Enum):
     """An Enum that represents the request states."""
 
@@ -350,6 +373,10 @@ class Request(db.Model):
     config_files_base64 = db.relationship(
         "ConfigFileBase64", secondary=request_config_file_base64_table, backref="requests"
     )
+
+    # This is an empty content manifest which should be returned for all requests whose package
+    # manager does not implement content manifest creation
+    content_manifest = ContentManifest()
 
     def __repr__(self):
         return "<Request {0!r}>".format(self.id)

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -277,6 +277,69 @@ paths:
                 $ref: "#/components/schemas/RequestConfiguration"
       security:
       - "Kerberos Authentication": []
+  "/requests/{id}/content-manifest":
+    get:
+      description: Return the content manifest of a request
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: The ID of the Cachito request to retrieve the content manifest for
+        schema:
+          type: integer
+      responses:
+        "200":
+          description: The content manifest of the Cachito request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                    properties:
+                      icm_version:
+                        type: integer
+                        example: 1
+                      icm_spec:
+                        type: string
+                        example: "https://raw.githubusercontent.com/containerbuildsystem/\
+                                  atomic-reactor/f4abcfdaf8247a6b074f94fa84f3846f82d781c6/\
+                                  atomic_reactor/schemas/content_manifest.json"
+                      image_layer_index:
+                        type: integer
+                        example: -1
+                  image_contents:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        purl:
+                          $ref: "#/components/schemas/Purl"
+                        dependencies:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              purl:
+                                $ref: "#/components/schemas/Purl"
+                        sources:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              purl:
+                                $ref: "#/components/schemas/Purl"
+        "404":
+          description: The request wasn't found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: The requested resource was not found
   "/requests/{id}/download":
     get:
       description: Download a Cachito request bundle
@@ -387,6 +450,9 @@ components:
         total:
           type: integer
           example: 45
+    Purl:
+      type: string
+      example: "pkg:golang/github.com%2Frelease-engineering%2Fretrodep%2Fv2@v2.0.2"
     RequestBase:
       type: object
       properties:


### PR DESCRIPTION
Register a new “GET /requests/REQUEST_ID/content-manifest” API
endpoint. All requests should serve at least an empty, valid, content
manifest.

Assembling content manifests should be implemented in a per package
manager manner.

Signed-off-by: Athos Ribeiro <athos@redhat.com>