### PR TITLE
Add support for multiple packages for the npm package manager in a single repo

### DIFF
--- a/cachito/paths.py
+++ b/cachito/paths.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import os
 from pathlib import Path
 import shutil
 
@@ -21,24 +22,45 @@ class RequestBundleDir(type(Path())):
 
     go_mod_cache_download_part = Path("pkg", "mod", "cache", "download")
 
-    def __new__(cls, request_id, root):
-        """Create a new Path object."""
-        self = super().__new__(cls, root, "temp", str(request_id))
+    def __new__(cls, request_id, root, app_subpath=os.curdir):
+        """
+        Create a new Path object.
 
-        self.source_dir = self.joinpath("app")
-        self.go_mod_file = self.joinpath("app", "go.mod")
+        :param int request_id: the ID of the request this bundle is for.
+        :param str root: the root directory to the bundles.
+        :param str app_subpath: an optional relative path to where the application resides in the
+            source directory. This sets ``self.source_dir`` and all other related paths to
+            start from that directory. If this is not set, it is assumed the application lives in
+            the root of the source directory.
+        """
+        self = super().__new__(cls, root, "temp", str(request_id))
+        self._request_id = request_id
+        self._path_root = root
+
+        self.source_root_dir = self.joinpath("app")
+        self.source_dir = self.source_root_dir.joinpath(app_subpath)
+        self.go_mod_file = self.source_dir.joinpath("go.mod")
 
         self.deps_dir = self.joinpath("deps")
         self.gomod_download_dir = self.joinpath("deps", "gomod", cls.go_mod_cache_download_part)
 
+        self.node_modules = self.source_dir.joinpath("node_modules")
         self.npm_deps_dir = self.joinpath("deps", "npm")
-        self.npm_package_file = self.joinpath("app", "package.json")
-        self.npm_package_lock_file = self.joinpath("app", "package-lock.json")
-        self.npm_shrinkwrap_file = self.joinpath("app", "npm-shrinkwrap.json")
+        self.npm_package_file = self.source_dir.joinpath("package.json")
+        self.npm_package_lock_file = self.source_dir.joinpath("package-lock.json")
+        self.npm_shrinkwrap_file = self.source_dir.joinpath("npm-shrinkwrap.json")
 
         self.bundle_archive_file = Path(root, f"{request_id}.tar.gz")
 
         return self
+
+    def app_subpath(self, subpath):
+        """Create a new ``RequestBundleDir`` object with the sources pointed to the subpath."""
+        return RequestBundleDir(self._request_id, self._path_root, subpath)
+
+    def relpath(self, path):
+        """Get the relative path of a path from the root of the source directory."""
+        return os.path.relpath(path, start=self.source_root_dir)
 
     def rmtree(self):
         """Remove this directory tree entirely."""

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -210,6 +210,7 @@ def create_request():
         pkg_manager_to_dep_replacements.setdefault(type_, [])
         pkg_manager_to_dep_replacements[type_].append(dependency_replacement)
 
+    package_configs = payload.get("packages", {})
     if "gomod" in pkg_manager_names:
         chain_tasks.append(
             tasks.fetch_gomod_source.si(
@@ -222,7 +223,10 @@ def create_request():
                 "Dependency replacements are not yet supported for the npm package manager"
             )
 
-        chain_tasks.append(tasks.fetch_npm_source.si(request.id).on_error(error_callback))
+        npm_package_configs = package_configs.get("npm", {})
+        chain_tasks.append(
+            tasks.fetch_npm_source.si(request.id, npm_package_configs).on_error(error_callback)
+        )
 
     chain_tasks.extend(
         [

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -586,6 +586,16 @@ components:
           items:
             type: string
             example: some_flag
+        packages:
+          type: object
+          items:
+            type: array
+            items:
+              type: object
+          example:
+            npm:
+            - path: client
+            - path: legacy/client
         pkg_managers:
           type: array
           items:

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -191,9 +191,8 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
     )
 
 
-@mock.patch("cachito.web.api_v1.chain")
 def test_fetch_paginated_requests(
-    mock_chain, app, auth_env, client, db, sample_deps_replace, sample_package, worker_auth_env
+    app, auth_env, client, db, sample_deps_replace, sample_package, worker_auth_env
 ):
     sample_requests_count = 50
     repo_template = "https://github.com/release-engineering/retrodep{}.git"

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,8 @@ commands =
 show-source = True
 max-line-length = 100
 exclude = venv,.git,.tox,dist,*egg,cachito/web/migrations,.env
-# W504 line break after binary operator
-ignore = D100,D104,D105,W504
+# W503 line break before binary operator
+ignore = D100,D104,D105,W503
 per-file-ignores =
     # Ignore missing docstrings in the tests and migrations
     tests/*:D103


### PR DESCRIPTION
This is done by supplying the `packages` parameter. For example:
`{"packages": {"npm": [{"path": "client"}, {"path": "proxy"}]}}`

Resolves CLOUDBLD-1257