### PR TITLE
Add an integration test: invalid content manifest request

### DIFF
--- a/tests/integration/test_content_manifest.py
+++ b/tests/integration/test_content_manifest.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+import requests
+
+import utils
+
+
+def test_invalid_content_manifest_request(test_env):
+    """
+    Send an invalid content-manifest request to the Cachito API.
+
+    Checks:
+    * Check that the response code is 404
+    """
+    client = utils.Client(test_env["api_url"], test_env["api_auth_type"])
+
+    with pytest.raises(requests.HTTPError) as e:
+        client.fetch_content_manifest(request_id=0)
+    assert e.value.response.status_code == 404
+    assert e.value.response.json() == {"error": "The requested resource was not found"}

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -116,6 +116,18 @@ class Client:
 
         return Response({"items": all_items}, None, resp.status_code)
 
+    def fetch_content_manifest(self, request_id):
+        """
+        Fetch a contest manifest by request_id from the Cachito API.
+
+        :param int request_id: The ID of the Cachito request
+        :return: An object that contains the response from the Cachito API
+        :rtype: Response
+        """
+        resp = requests.get(f"{self._cachito_api_url}/requests/{request_id}/content-manifest")
+        resp.raise_for_status()
+        return Response(resp.json(), resp.json()["id"], resp.status_code)
+
 
 def escape_path_go(dependency):
     """


### PR DESCRIPTION
The pull request was created to check that content manifest request with the wrong `request id` will return `404 Client Error`. 

Added: 
* Test: `test_invalid_content_manifest_request`
* Utils function: `fetch_content_manifest`. 

@lcarva @mprahl  PTAL. I will add positive tests later. I would prefer atomic changes and shorter communication in the PR :D 