### PR TITLE
Add integration test: valid test for content manifest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 celery
 gitpython
+jsonschema
 kombu # A celery dependency but it's directly imported
 requests_kerberos
 requests

--- a/tests/integration/test_content_manifest.py
+++ b/tests/integration/test_content_manifest.py
@@ -19,3 +19,28 @@ def test_invalid_content_manifest_request(test_env):
         client.fetch_content_manifest(request_id=0)
     assert e.value.response.status_code == 404
     assert e.value.response.json() == {"error": "The requested resource was not found"}
+
+
+def test_valid_content_manifest_request(test_env, default_request):
+    """
+    Send a valid content-manifest request to the Cachito API.
+
+    Checks:
+    * Check that the response code is 200
+    * Check validation of the response data with content manifest JSON schema
+    """
+    client = utils.Client(test_env["api_url"], test_env["api_auth_type"])
+
+    initial_response = default_request.initial_response
+    content_manifest_response = client.fetch_content_manifest(initial_response.id)
+    assert content_manifest_response.status == 200
+
+    response_data = content_manifest_response.data
+    assert_content_manifest_schema(response_data)
+
+
+def assert_content_manifest_schema(response_data):
+    """Validate content manifest according with JSON schema."""
+    icm_spec = response_data["metadata"]["icm_spec"]
+    schema = requests.get(icm_spec, timeout=30).json()
+    assert utils.validate_json(schema, response_data)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -127,7 +127,7 @@ class Client:
         """
         resp = requests.get(f"{self._cachito_api_url}/requests/{request_id}/content-manifest")
         resp.raise_for_status()
-        return Response(resp.json(), resp.json()["id"], resp.status_code)
+        return Response(resp.json(), request_id, resp.status_code)
 
 
 def escape_path_go(dependency):

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -3,6 +3,7 @@
 from collections import namedtuple
 import time
 
+import jsonschema
 import requests
 from requests_kerberos import HTTPKerberosAuth
 
@@ -150,3 +151,18 @@ def escape_path_go(dependency):
         return package_name
     else:
         return dependency
+
+
+def validate_json(json_schema, json_data):
+    """
+    Validate JSON data according to JSON schema.
+
+    :param str json_schema: Expected JSON schema for validation
+    :param str json_data: Data to be validated
+    :rtype: bool
+    """
+    try:
+        jsonschema.validate(instance=json_data, schema=json_schema)
+    except jsonschema.exceptions.ValidationError:
+        return False
+    return True


### PR DESCRIPTION
Changes: 
* fixed a mistake in `tests/integration/utils.py`
* a new test `test_valid_content_manifest_request`

I am not sure should I add `expected_response_data` into `test_env_vars.yaml`? 

@mprahl @lcarva PTAL :) 