### PR TITLE
Only warn when there is a missing package in the map_deps_to_pkg migration

### DIFF
--- a/cachito/web/migrations/versions/1714d8e3002b_map_deps_to_pkg.py
+++ b/cachito/web/migrations/versions/1714d8e3002b_map_deps_to_pkg.py
@@ -95,9 +95,10 @@ def _upgrade_data():
         ).fetchone()
 
         if not package:
-            raise RuntimeError(
-                f"Couldn't find a package associated with the request {request_dep.request_id} and "
-                f"type {dependency.type}",
+            log.warning(
+                "Couldn't find a package associated with the request %d and type %s",
+                request_dep.request_id,
+                dependency.type,
             )
             continue
 


### PR DESCRIPTION
This will prevent Cachito deployments with old data from failing when migrating the database.