### PR TITLE
Do not generate ICM for incomplete requests

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -103,8 +103,14 @@ def get_request_content_manifest(request_id):
     :return: a Flask JSON response
     :rtype: flask.Response
     :raise NotFound: if the request is not found
+    :raise ValidationError: if the request is not in the "complete" or "stale" state
     """
-    content_manifest = Request.query.get_or_404(request_id).content_manifest
+    request = Request.query.get_or_404(request_id)
+    if request.state.state_name not in ("complete", "stale"):
+        raise ValidationError(
+            'Content manifests are only available for requests in the "complete" or "stale" states'
+        )
+    content_manifest = request.content_manifest
     content_manifest_json = content_manifest.to_json()
     return flask.jsonify(content_manifest_json)
 

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -340,6 +340,16 @@ paths:
                   error:
                     type: string
                     example: The requested resource was not found
+        "400":
+          description: The input is invalid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Content manifests are only available for requests in the \"complete\" or \"stale\" states"
   "/requests/{id}/environment-variables":
     get:
       description: Return information about the environment variables of a request


### PR DESCRIPTION
Requests in incomplete states, i.e., failed or in_progress, should not
have a content manifest returned in the content-manifest endpoint. Doing
so would make the endpoint mutable for in_progress requests and for
requests that failed due to network issues, etc.

Signed-off-by: Athos Ribeiro <athos@redhat.com>