### PR TITLE
Ensure no npm scripts are executed on the Cachito worker

### DIFF
--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -79,6 +79,9 @@ def download_dependencies(request_id, deps, proxy_repo_url, skip_deps=None):
             # in /etc/passwd.
             "HOME": os.environ.get("HOME", ""),
             "NPM_CONFIG_CACHE": os.path.join(temp_dir, "cache"),
+            # This should not be necessary since all the dependencies come from Nexus, but it's an
+            # extra precaution
+            "NPM_CONFIG_IGNORE_SCRIPTS": "true",
             "NPM_CONFIG_USERCONFIG": npm_rc_file,
             "PATH": os.environ.get("PATH", ""),
         }
@@ -328,15 +331,20 @@ def prepare_nexus_for_js_request(repo_name):
         raise CachitoError("Failed to prepare Nexus for Cachito to stage JavaScript content")
 
 
-def upload_non_registry_dependency(dep_identifier, version_suffix):
+def upload_non_registry_dependency(dep_identifier, version_suffix, verify_scripts=False):
     """
     Upload the non-registry npm dependency to the Nexus hosted repository with a custom version.
 
     :param str dep_identifier: the identifier of the dependency to download
     :param str version_suffix: the suffix to append to the dependency's version in its package.json
         file
+    :param bool verify_scripts: if ``True``, raise an exception if dangerous scripts are present in
+        the ``package.json`` file and would have been executed by ``npm pack`` if ``ignore-scripts``
+        was set to ``false``
     :raise CachitoError: if the dependency cannot be download, uploaded, or is invalid
     """
+    # These are the scripts that should not be present if verify_scripts is True
+    dangerous_scripts = {"prepare", "prepack"}
     with tempfile.TemporaryDirectory(prefix="cachito-") as temp_dir:
         env = {
             # This is set since the home directory must be determined by the HOME environment
@@ -345,6 +353,8 @@ def upload_non_registry_dependency(dep_identifier, version_suffix):
             # in /etc/passwd.
             "HOME": os.environ.get("HOME", ""),
             "NPM_CONFIG_CACHE": os.path.join(temp_dir, "cache"),
+            # This is important to avoid executing any dangerous scripts if it's a Git dependency
+            "NPM_CONFIG_IGNORE_SCRIPTS": "true",
             "PATH": os.environ.get("PATH", ""),
             # Have `npm pack` fail without a prompt if the SSH key from a protected source such
             # as a private GitHub repo is not trusted
@@ -389,6 +399,21 @@ def upload_non_registry_dependency(dep_identifier, version_suffix):
                         )
                         log.exception(msg)
                         raise CachitoError(msg)
+
+                    if verify_scripts:
+                        log.info(
+                            "Checking for dangerous scripts in the package.json of %s",
+                            dep_identifier,
+                        )
+                        scripts = package_json.get("scripts", {})
+                        if dangerous_scripts & scripts.keys():
+                            msg = (
+                                f"The dependency {dep_identifier} is not supported because Cachito "
+                                "cannot execute the following required scripts of Git "
+                                f"dependencies: {', '.join(sorted(dangerous_scripts))}"
+                            )
+                            log.error(msg)
+                            raise CachitoError(msg)
 
                     new_version = f"{package_json['version']}{version_suffix}"
                     log.debug(

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -81,9 +81,6 @@ def download_dependencies(request_id, deps, proxy_repo_url, skip_deps=None):
             "NPM_CONFIG_CACHE": os.path.join(temp_dir, "cache"),
             "NPM_CONFIG_USERCONFIG": npm_rc_file,
             "PATH": os.environ.get("PATH", ""),
-            # Have `npm pack` fail without a prompt if the SSH key from a protected source such
-            # as a private GitHub repo is not trusted
-            "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=yes",
         }
         bundle_dir = RequestBundleDir(request_id)
         bundle_dir.npm_deps_dir.mkdir(exist_ok=True)
@@ -349,6 +346,9 @@ def upload_non_registry_dependency(dep_identifier, version_suffix):
             "HOME": os.environ.get("HOME", ""),
             "NPM_CONFIG_CACHE": os.path.join(temp_dir, "cache"),
             "PATH": os.environ.get("PATH", ""),
+            # Have `npm pack` fail without a prompt if the SSH key from a protected source such
+            # as a private GitHub repo is not trusted
+            "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=yes",
         }
         run_params = {"env": env, "cwd": temp_dir}
         npm_pack_args = ["npm", "pack", dep_identifier]

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -405,6 +405,38 @@ def test_upload_non_registry_dependency(mock_ua, mock_fpj, mock_run_cmd, mock_td
 @mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
 @mock.patch("cachito.workers.pkg_managers.general_js.run_cmd")
 @mock.patch("cachito.workers.pkg_managers.general_js.find_package_json")
+def test_upload_non_registry_dependency_invalid_prepare_script(
+    mock_fpj, mock_run_cmd, mock_td, tmpdir
+):
+    tarfile_path = os.path.join(tmpdir, "star-wars-5.0.0.tgz")
+    with tarfile.open(tarfile_path, "x:gz") as archive:
+        tar_info = tarfile.TarInfo("package/fair-warning.html")
+        content = "<h1>Je vais te détruire monsieur Solo!</h1>".encode("utf-8")
+        tar_info.size = len(content)
+        archive.addfile(tar_info, io.BytesIO(content))
+
+        tar_info = tarfile.TarInfo("package/package.json")
+        content = b'{"version": "5.0.0", "scripts": {"prepare": "rm -rf /"}}'
+        tar_info.size = len(content)
+        archive.addfile(tar_info, io.BytesIO(content))
+
+    mock_td.return_value.__enter__.return_value = str(tmpdir)
+    mock_run_cmd.return_value = "star-wars-5.0.0.tgz\n"
+    mock_fpj.return_value = "package/package.json"
+
+    expected = (
+        "The dependency star-wars@5.0.0 is not supported because Cachito cannot execute the "
+        "following required scripts of Git dependencies: prepack, prepare"
+    )
+    with pytest.raises(CachitoError, match=expected):
+        general_js.upload_non_registry_dependency(
+            "star-wars@5.0.0", "-the-empire-strikes-back", verify_scripts=True
+        )
+
+
+@mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
+@mock.patch("cachito.workers.pkg_managers.general_js.run_cmd")
+@mock.patch("cachito.workers.pkg_managers.general_js.find_package_json")
 def test_upload_non_registry_dependency_no_package_json(mock_fpj, mock_run_cmd, mock_td, tmpdir):
     mock_td.return_value.__enter__.return_value = str(tmpdir)
     mock_run_cmd.return_value = "star-wars-5.0.0.tgz\n"


### PR DESCRIPTION
This ensures that Git dependencies don't have their dev dependencies installed and their "prepare" and/or "prepack" scripts executed on the Cachito worker. If Git dependencies have these scripts defined, Cachito will fail the request.