### PR TITLE
Revert "Only compute the hash for external npm dependencies when not present"

### DIFF
--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -180,7 +180,6 @@ def convert_to_nexus_hosted(dep_name, dep_info):
     #   github:ReactiveX/rxjs#78032157f5c1655436829017bbda787565b48c30
     #   https://github.com/jsplumb/jsplumb/archive/2.10.2.tar.gz
     dep_identifier = dep_info["version"]
-    integrity = None
     verify_scripts = False
     if any(dep_identifier.startswith(prefix) for prefix in git_prefixes):
         try:
@@ -204,8 +203,7 @@ def convert_to_nexus_hosted(dep_name, dep_info):
             log.error(msg)
             raise CachitoError(msg)
 
-        integrity = dep_info["integrity"]
-        algorithm, checksum = convert_integrity_to_hex_checksum(integrity)
+        algorithm, checksum = convert_integrity_to_hex_checksum(dep_info["integrity"])
         # When the dependency is uploaded to the Nexus hosted repository, it will be in the format
         # of `<version>-external-<checksum algorithm>-<hex checksum>`
         version_suffix = f"-external-{algorithm}-{checksum}"
@@ -226,13 +224,11 @@ def convert_to_nexus_hosted(dep_name, dep_info):
     converted_dep_info = copy.deepcopy(dep_info)
     # The "from" value is the original value from package.json for some locations
     converted_dep_info.pop("from", None)
-    # If this was an HTTP dependency, reuse the supplied integrity as it should be the same
-    integrity = integrity or convert_hex_sha512_to_npm(
-        component_info["assets"][0]["checksum"]["sha512"]
-    )
     converted_dep_info.update(
         {
-            "integrity": integrity,
+            "integrity": convert_hex_sha512_to_npm(
+                component_info["assets"][0]["checksum"]["sha512"]
+            ),
             "resolved": component_info["assets"][0]["downloadUrl"],
             "version": component_info["version"],
         }

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -443,9 +443,8 @@ def test_convert_to_nexus_hosted_github(mock_unrd, mock_gncifn, exists):
 
 @pytest.mark.parametrize("exists", (False, True))
 @mock.patch("cachito.workers.pkg_managers.npm.get_npm_component_info_from_nexus")
-@mock.patch("cachito.workers.pkg_managers.npm.convert_hex_sha512_to_npm")
 @mock.patch("cachito.workers.pkg_managers.npm.upload_non_registry_dependency")
-def test_convert_to_nexus_hosted_http(mock_unrd, mock_chstn, mock_gncifn, exists):
+def test_convert_to_nexus_hosted_http(mock_unrd, mock_gncifn, exists):
     checksum = (
         "325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342b5507481408832bfaac8e48f344"
         "dc650c8df0f8182c0271ed9fa233aa32c329839"
@@ -503,8 +502,6 @@ def test_convert_to_nexus_hosted_http(mock_unrd, mock_chstn, mock_gncifn, exists
         "-external-sha512-325f07861e0ab888d90606b1074fde956fd3954dcc4c6e418dbff9d8aa8342b5"
         "507481408832bfaac8e48f344dc650c8df0f8182c0271ed9fa233aa32c329839"
     )
-    # The hash should not have been recomputed for an HTTP dependency
-    mock_chstn.assert_not_called()
 
     suffix_search = f"*{suffix}"
     if exists:


### PR DESCRIPTION
This reverts commit 69868798800cbf7a79faef34610ea8073a573273 because
the integrity always needs to be recomputed since the package.json
is altered by Cachito, and thus the original integrity will not match.