### PR TITLE
Move the jsonschema requirement to tox.ini

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 celery
 gitpython
-jsonschema
 kombu # A celery dependency but it's directly imported
 requests_kerberos
 requests

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = black,flake8,py37
 deps =
     -rrequirements.txt
     -rrequirements-web.txt
+    jsonschema
     pytest
     pyyaml
 whitelist_externals =


### PR DESCRIPTION
Since jsonschema is only a requirement for the tests, we should avoid declaring it as a runtime dependency.