### PR TITLE
Reuse testing data function for no order comparison

### DIFF
--- a/tests/integration/test_check_downloaded_output.py
+++ b/tests/integration/test_check_downloaded_output.py
@@ -57,7 +57,7 @@ def test_check_downloaded_output(test_env, default_request, tmpdir):
         expected_packages = [
             i["name"] for i in response.data["packages"] if i["type"] in pkg_managers
         ]
-        assert module_names == expected_packages
+        assert set(module_names) == set(expected_packages)
 
     list_go_files = []
     for app_path in Path(path.join(file_name, "app")).rglob("*.go"):

--- a/tests/integration/test_creating_new_request.py
+++ b/tests/integration/test_creating_new_request.py
@@ -22,7 +22,8 @@ def test_creating_new_request(test_env, default_request):
     response_specific_req = client.fetch_request(response_created_req.id)
     assert response_created_req.id == response_specific_req.id
 
-    assert test_env["package"]["pkg_managers"] == response_created_req.data["pkg_managers"]
+    response_pkg_managers = set(response_created_req.data["pkg_managers"])
+    assert set(test_env["package"]["pkg_managers"]) == response_pkg_managers
     assert test_env["package"]["ref"] == response_created_req.data["ref"]
     assert test_env["package"]["repo"] == response_created_req.data["repo"]
     assert test_env["package"]["ref"] == response_specific_req.data["ref"]

--- a/tests/integration/test_dependency_replacement.py
+++ b/tests/integration/test_dependency_replacement.py
@@ -77,4 +77,6 @@ def test_dependency_replacement(test_env, tmpdir):
                 go_mod_replace.append(
                     {"name": line.split()[-2], "type": "gomod", "version": line.split()[-1]}
                 )
-        assert go_mod_replace == dependency_replacements
+        sorted_dep_replacements = utils.make_list_of_packages_hashable(dependency_replacements)
+        sorted_go_mod_replace = utils.make_list_of_packages_hashable(go_mod_replace)
+        assert sorted_go_mod_replace == sorted_dep_replacements

--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -75,6 +75,10 @@ def test_using_cached_dependencies(test_env, tmpdir):
 
     assert first_response.data["ref"] == second_response.data["ref"]
     assert first_response.data["repo"] == second_response.data["repo"]
-    assert first_response.data["pkg_managers"] == second_response.data["pkg_managers"]
-    assert first_response.data["packages"] == second_response.data["packages"]
-    assert first_response.data["dependencies"] == second_response.data["dependencies"]
+    assert set(first_response.data["pkg_managers"]) == set(second_response.data["pkg_managers"])
+    first_pkgs = utils.make_list_of_packages_hashable(first_response.data["packages"])
+    second_pkgs = utils.make_list_of_packages_hashable(second_response.data["packages"])
+    assert first_pkgs == second_pkgs
+    first_deps = utils.make_list_of_packages_hashable(first_response.data["dependencies"])
+    second_deps = utils.make_list_of_packages_hashable(second_response.data["dependencies"])
+    assert first_deps == second_deps

--- a/tests/integration/test_valid_data_in_request.py
+++ b/tests/integration/test_valid_data_in_request.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import operator
+from utils import make_list_of_packages_hashable
 
 
 def test_valid_data_in_request(test_env, default_request):
@@ -20,22 +20,10 @@ def test_valid_data_in_request(test_env, default_request):
     assert response.status == 200
     assert response.data["state"] == "complete"
 
-    response_dependencies = list_of_dict_to_list_of_name_type_version(response.data["dependencies"])
+    response_dependencies = make_list_of_packages_hashable(response.data["dependencies"])
     expected_dependencies = test_env["get"]["dependencies"]
-    assert response_dependencies == expected_dependencies
+    assert response_dependencies == sorted(expected_dependencies)
 
-    response_packages = list_of_dict_to_list_of_name_type_version(response.data["packages"])
+    response_packages = make_list_of_packages_hashable(response.data["packages"])
     expected_packages = test_env["get"]["packages"]
-    assert response_packages == expected_packages
-
-
-def list_of_dict_to_list_of_name_type_version(data):
-    """
-    Convert the list of dictionaries to a list of lists from the keys name, type, and version.
-
-    :param data: list of dictionaries containing keys name, type and version
-    :return: list of lists with values name, type and version in this order
-    """
-    sorted_packages = sorted(data, key=operator.itemgetter("name"))
-
-    return [[i["name"], i["type"], i["version"]] for i in sorted_packages]
+    assert response_packages == sorted(expected_packages)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections import namedtuple
+import operator
 import time
 
 import jsonschema
@@ -166,3 +167,15 @@ def validate_json(json_schema, json_data):
     except jsonschema.exceptions.ValidationError:
         return False
     return True
+
+
+def make_list_of_packages_hashable(data):
+    """
+    Convert the list of dictionaries to a list of lists from the keys name, type, and version.
+
+    :param data: list of dictionaries containing keys name, type and version
+    :return: list of lists with values name, type and version in this order
+    """
+    sorted_packages = sorted(data, key=operator.itemgetter("name"))
+
+    return [[i["name"], i["type"], i["version"]] for i in sorted_packages]


### PR DESCRIPTION
The order of elements in packages/dependencies lists can be various. We need to test it in sorted order and make elements of the list hashable for that reason. 

Change:
* move (and rename) `make_list_of_packages_hashable` to utils
* reusing `make_list_of_packages_hashable` in integration tests
* no order comparison to testing data