### PR TITLE
Add the request ID to the Cachito worker logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,9 @@ Custom configuration for the Celery workers are listed below:
   script. This defaults to `1`.
 * `cachito_sources_dir` - the directory for long-term storage of app source archives. This
   configuration is required, and the directory must already exist and be writeable.
+* `cachito_task_log_format` - the log format that Celery displays when a task is executing. This
+  defaults to
+  `"[%(asctime)s #%(request_id)s %(name)s %(levelname)s %(module)s.%(funcName)s] %(message)s"`.
 
 To configure the workers to use a Kerberos keytab for authentication, set the `KRB5_CLIENT_KTNAME`
 environment variable to the path of the keytab. Additional Kerberos configuration can be made in

--- a/cachito/workers/celery_logging.py
+++ b/cachito/workers/celery_logging.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import inspect
+import logging
+
+from celery.utils.log import ColorFormatter
+
+from cachito.workers.config import get_worker_config
+
+
+class AddRequestIDFilter(logging.Filter):
+    """A log filter that sets ``request_id`` on the log record."""
+
+    def __init__(self, request_id, *args, **kwargs):
+        """
+        Initialize a filter that sets ``request_id`` on the log record.
+
+        :param request_id: the request ID to set on the record
+        """
+        super().__init__(*args, **kwargs)
+        self._request_id = request_id
+
+    def filter(self, record):
+        """
+        Set ``request_id`` on the log record.
+
+        :param logging.LogRecord record: the log record
+        :return: always returns ``True`` so the log is not filtered out
+        :rtype: bool
+        """
+        record.request_id = self._request_id
+        return True
+
+
+def _get_function_arg_value(arg_name, func, args, kwargs):
+    """
+    Get the value of the given argument name.
+
+    :param str arg_name: the name of the argument to get
+    :param function func: the function the arguments are for
+    :param list args: the list of arguments passed to the function
+    :param dict kwargs: the dictionary or keyword arguments passed to the function
+    :return: the argument value or ``None``
+    """
+    original_func = func
+    while getattr(original_func, "__wrapped__", None):
+        original_func = original_func.__wrapped__
+    argspec = inspect.getfullargspec(original_func).args
+
+    arg_index = argspec.index(arg_name)
+    arg_value = kwargs.get(arg_name, None)
+    if arg_value is None and len(args) > arg_index:
+        arg_value = args[arg_index]
+
+    return arg_value
+
+
+def setup_task_logging(task_id, task, **kwargs):
+    """
+    Customize the logging for the task.
+
+    This adds a filter that sets ``request_id`` on the log record. If the request ID
+    cannot be determined, "unknown" is set instead. This also sets the log format to
+    the ``cachito_task_log_format`` config.
+
+    :param str task_id: the task ID
+    :param class task: the class of the task being executed
+    """
+    conf = get_worker_config()
+
+    request_id = _get_function_arg_value("request_id", task, kwargs["args"], kwargs["kwargs"])
+    log_filter = AddRequestIDFilter(str(request_id) or "unknown")
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if not isinstance(handler, logging.StreamHandler):
+            continue
+
+        handler.addFilter(log_filter)
+        if isinstance(handler.formatter, ColorFormatter):
+            formatter = ColorFormatter(
+                conf.cachito_task_log_format, use_color=handler.formatter.use_color
+            )
+        else:
+            formatter = logging.Formatter(conf.cachito_task_log_format)
+        handler.setFormatter(formatter)
+
+
+def cleanup_task_logging(task_id, task, **kwargs):
+    """
+    Clean up any logging customizations that were set in ``setup_task_logging``.
+
+    :param str task_id: the task ID
+    :param class task: the class of the task being executed
+    """
+    conf = get_worker_config()
+
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if not isinstance(handler, logging.StreamHandler):
+            continue
+
+        if isinstance(handler.formatter, ColorFormatter):
+            formatter = ColorFormatter(
+                conf.worker_log_format, use_color=handler.formatter.use_color
+            )
+        else:
+            formatter = logging.Formatter(conf.worker_log_format)
+        handler.setFormatter(formatter)
+
+        for log_filter in handler.filters:
+            if isinstance(log_filter, AddRequestIDFilter):
+                handler.removeFilter(log_filter)

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -47,6 +47,9 @@ class Config(object):
     cachito_nexus_username = "cachito"
     cachito_npm_file_deps_allowlist = {}
     cachito_request_lifetime = 1
+    cachito_task_log_format = (
+        "[%(asctime)s #%(request_id)s %(name)s %(levelname)s %(module)s.%(funcName)s] %(message)s"
+    )
     include = [
         "cachito.workers.tasks.general",
         "cachito.workers.tasks.gomod",

--- a/cachito/workers/tasks/celery.py
+++ b/cachito/workers/tasks/celery.py
@@ -2,8 +2,9 @@
 import sys
 
 import celery
-from celery.signals import celeryd_init
+from celery.signals import celeryd_init, task_postrun, task_prerun
 
+from cachito.workers.celery_logging import cleanup_task_logging, setup_task_logging
 from cachito.workers.config import configure_celery, validate_celery_config
 
 
@@ -18,3 +19,5 @@ if celery.version_info < (4, 3) and sys.version_info >= (3, 7):  # pragma: no co
 app = celery.Celery()
 configure_celery(app)
 celeryd_init.connect(validate_celery_config)
+task_prerun.connect(setup_task_logging)
+task_postrun.connect(cleanup_task_logging)

--- a/tests/test_workers/test_celery_logging.py
+++ b/tests/test_workers/test_celery_logging.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+from unittest import mock
+
+from celery.utils.log import ColorFormatter
+
+from cachito.workers import celery_logging
+
+
+def test_setup_task_logging(caplog):
+    # Setting the logging level via caplog.set_level is not sufficient. The Flask
+    # related settings from previous tests interfere with this.
+    workers_logger = logging.getLogger("cachito.workers")
+    workers_logger.disabled = False
+    workers_logger.setLevel(logging.INFO)
+
+    root_logger = logging.getLogger()
+    original_formatters = []
+    for handler in root_logger.handlers:
+        original_formatters.append(handler.formatter)
+
+    color_handler = logging.StreamHandler()
+    color_handler.setFormatter(ColorFormatter("%(message)s"))
+    root_logger.addHandler(color_handler)
+
+    task_id = mock.Mock()
+    task = mock.Mock()
+
+    def _dummy_task(msg, request_id):
+        return
+
+    task.__wrapped__ = _dummy_task
+
+    try:
+        celery_logging.setup_task_logging(task_id, task, args=["hello"], kwargs={"request_id": 3})
+        workers_logger.info("Test log message")
+        assert "#%(request_id)s" in color_handler.formatter._fmt
+    finally:
+        root_logger.removeHandler(color_handler)
+
+        for handler, formatter in zip(root_logger.handlers, original_formatters):
+            handler.setFormatter(formatter)
+
+    # Verify that the request filter and formatter were properly set
+    expected = (
+        "#3 cachito.workers INFO test_celery_logging.test_setup_task_logging] Test log message"
+    )
+    assert expected in caplog.text
+
+
+def test_cleanup_task_logging():
+    root_logger = logging.getLogger()
+    original_formatters = []
+    for handler in root_logger.handlers:
+        original_formatters.append(handler.formatter)
+
+    color_handler = logging.StreamHandler()
+    color_handler.setFormatter(ColorFormatter("%(message)s"))
+    log_filter = celery_logging.AddRequestIDFilter(5)
+    color_handler.addFilter(log_filter)
+    root_logger.addHandler(color_handler)
+
+    try:
+        celery_logging.cleanup_task_logging(mock.Mock(), mock.Mock())
+    finally:
+        root_logger.removeHandler(color_handler)
+
+        for handler, formatter in zip(root_logger.handlers, original_formatters):
+            handler.setFormatter(formatter)
+
+    # Verify that the AddRequestIDFilter filter was removed from the color handler
+    assert len(color_handler.filters) == 0


### PR DESCRIPTION
This will allow for easier debugging when multiple workers are running and the logs are aggregated.