### PR TITLE
Add go-package without dependencies to request

### DIFF
--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -53,4 +53,8 @@ def fetch_gomod_source(request_id, dep_replacements=None):
 
     # add package deps
     for package in gomod["packages"]:
-        update_request_with_deps(request_id, package["pkg"], package["pkg_deps"])
+        if package.get("pkg_deps"):
+            # This also adds the package to the request
+            update_request_with_deps(request_id, package["pkg"], package["pkg_deps"])
+        else:
+            update_request_with_package(request_id, package["pkg"])

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -15,6 +15,7 @@ from cachito.workers import tasks
         (False, [{"name": "github.com/pkg/errors", "type": "gomod", "version": "v0.8.1"}]),
     ),
 )
+@pytest.mark.parametrize("has_pkg_lvl_deps", (True, False))
 @mock.patch("cachito.workers.tasks.gomod.RequestBundleDir")
 @mock.patch("cachito.workers.tasks.gomod.update_request_with_package")
 @mock.patch("cachito.workers.tasks.gomod.update_request_with_deps")
@@ -28,6 +29,7 @@ def test_fetch_gomod_source(
     mock_bundle_dir,
     dep_replacements,
     expect_state_update,
+    has_pkg_lvl_deps,
     sample_deps_replace,
     sample_package,
     sample_pkg_deps,
@@ -38,25 +40,33 @@ def test_fetch_gomod_source(
     sample_env_vars["GO111MODULE"] = {"value": "on", "kind": "literal"}
     mock_request = mock.Mock()
     mock_set_request_state.return_value = mock_request
+    pkg_lvl_deps = []
+    if has_pkg_lvl_deps:
+        pkg_lvl_deps = sample_pkg_deps
     mock_resolve_gomod.return_value = {
         "module": sample_package,
         "module_deps": sample_deps_replace,
-        "packages": [{"pkg": sample_pkg_lvl_pkg, "pkg_deps": sample_pkg_deps}],
+        "packages": [{"pkg": sample_pkg_lvl_pkg, "pkg_deps": pkg_lvl_deps}],
     }
     tasks.fetch_gomod_source(1, dep_replacements)
-
     if expect_state_update:
         mock_set_request_state.assert_called_once_with(
             1, "in_progress", "Fetching the gomod dependencies"
         )
-        mock_update_request_with_package.assert_called_once_with(1, sample_package, sample_env_vars)
-
+        pkg_calls = [
+            mock.call(1, sample_package, sample_env_vars),
+        ]
         dep_calls = [
             mock.call(1, sample_package, sample_deps_replace),
-            mock.call(1, sample_pkg_lvl_pkg, sample_pkg_deps),
         ]
+        if has_pkg_lvl_deps:
+            dep_calls.append(mock.call(1, sample_pkg_lvl_pkg, sample_pkg_deps))
+        else:
+            pkg_calls.append(mock.call(1, sample_pkg_lvl_pkg))
+        mock_update_request_with_package.assert_has_calls(pkg_calls)
+        assert mock_update_request_with_package.call_count == len(pkg_calls)
         mock_update_request_with_deps.assert_has_calls(dep_calls)
-        assert mock_update_request_with_deps.call_count == 2
+        assert mock_update_request_with_deps.call_count == len(dep_calls)
 
     mock_resolve_gomod.assert_called_once_with(
         str(mock_bundle_dir().source_dir), mock_request, dep_replacements


### PR DESCRIPTION
This patch fixes the case where a go package without dependencies would
be processed. Before, the go package would not be added to the request.
This patch ensures the package is added to the request by explicitly
calling the method to add packages to a request instead of relying on
the logic of adding dependencies to a package.

Signed-off-by: Athos Ribeiro <athos@redhat.com>