### PR TITLE
Implement setup.cfg handling for Pip

### DIFF
--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import ast
+import configparser
+import logging
+import re
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import pkg_resources
+
+from cachito.errors import ValidationError
+
+
+log = logging.getLogger(__name__)
+
+NOTHING = object()  # A None replacement for cases where the distinction is needed
+
+
+def any_to_version(obj):
+    """
+    Convert any python object to a version string.
+
+    https://github.com/pypa/setuptools/blob/ba209a15247b9578d565b7491f88dc1142ba29e4/setuptools/config.py#L535
+
+    :param any obj: object to convert to version
+    :rtype: str
+    """
+    version = obj
+
+    if not isinstance(version, str):
+        if hasattr(version, "__iter__"):
+            version = ".".join(map(str, version))
+        else:
+            version = str(version)
+
+    return pkg_resources.safe_version(version)
+
+
+def get_top_level_attr(block_node, attr_name, before_line=None):
+    """
+    Get attribute from module if it is defined at top level and assigned to a literal expression.
+
+    https://github.com/pypa/setuptools/blob/ba209a15247b9578d565b7491f88dc1142ba29e4/setuptools/config.py#L36
+
+    Note that this approach is not equivalent to the setuptools one - setuptools looks for the
+    attribute starting from the top, we start at the bottom. Arguably, starting at the bottom
+    makes more sense, but it should not make any real difference in practice.
+
+    :param ast.AST block_node: Any AST node that has a 'body' attribute
+    :param str attr_name: Name of attribute to search for
+    :param int before_line: Only look for attributes defined before this line
+
+    :rtype: anything that can be expressed as a literal ("primitive" types, collections)
+    :raises AttributeError: If attribute not found or not assigned to a literal expression
+    """
+    if before_line is None:
+        before_line = float("inf")
+    try:
+        return next(
+            ast.literal_eval(node.value)
+            for node in reversed(block_node.body)
+            if node.lineno < before_line and isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name) and target.id == attr_name
+        )
+    except ValueError:
+        raise AttributeError(f"Attribute {attr_name!r} is not assigned to a literal expression")
+    except StopIteration:
+        raise AttributeError(f"Attribute {attr_name!r} not found")
+
+
+class SetupFile(ABC):
+    """Abstract base class for setup.cfg and setup.py handling."""
+
+    def __init__(self, top_dir, file_name):
+        """
+        Initialize a SetupFile.
+
+        :param str top_dir: Path to root of project directory
+        :param str file_name: Name of Python setup file, expected to be in the root directory
+        """
+        self._top_dir = Path(top_dir).resolve()
+        self._path = self._top_dir / file_name
+
+    def exists(self):
+        """Check if file exists."""
+        return self._path.is_file()
+
+    @abstractmethod
+    def get_name(self):
+        """Attempt to determine the package name. Should only be called if file exists."""
+
+    @abstractmethod
+    def get_version(self):
+        """Attempt to determine the package version. Should only be called if file exists."""
+
+
+class SetupCFG(SetupFile):
+    """
+    Parse metadata.name and metadata.version from a setup.cfg file.
+
+    Aims to match setuptools behaviour as closely as possible, but does make
+    some compromises (such as never executing arbitrary Python code).
+    """
+
+    # Valid Python name - any sequence of \w characters that does not start with a number
+    _name_re = re.compile(r"[^\W\d]\w*")
+
+    def __init__(self, top_dir):
+        """
+        Initialize a SetupCFG.
+
+        :param str top_dir: Path to root of project directory
+        """
+        super().__init__(top_dir, "setup.cfg")
+        self.__parsed = NOTHING
+
+    def get_name(self):
+        """
+        Get metadata.name if present.
+
+        :rtype: str or None
+        """
+        name = self._get_option("metadata", "name")
+        if name is None:
+            log.debug("No metadata.name in setup.cfg")
+            return None
+
+        log.debug("Found metadata.name in setup.cfg: %r", name)
+        return name
+
+    def get_version(self):
+        """
+        Get metadata.version if present.
+
+        Partially supports the file: directive (setuptools supports multiple files
+        as an argument to file:, this makes no sense for version).
+
+        Partially supports the attr: directive (will only work if the attribute
+        being referenced is assigned to a literal expression).
+
+        :rtype: str or None
+        """
+        version = self._get_option("metadata", "version")
+        if version is None:
+            log.debug("No metadata.version in setup.cfg")
+            return None
+
+        log.debug("Resolving metadata.version in setup.cfg from %r", version)
+        version = self._resolve_version(version)
+        if version is None:
+            log.debug("Failed to resolve metadata.version in setup.cfg")
+            return None
+
+        version = any_to_version(version)
+        log.debug("Found metadata.version in setup.cfg: %r", version)
+        return version
+
+    @property
+    def _parsed(self):
+        """
+        Try to parse config file, return None if parsing failed.
+
+        Will not parse file (or try to) more than once.
+        """
+        if self.__parsed is NOTHING:  # Have not tried to parse file yet
+            log.debug("Parsing setup.cfg at %r", str(self._path))
+            parsed = configparser.ConfigParser()
+
+            with self._path.open() as f:
+                try:
+                    parsed.read_file(f)
+                    self.__parsed = parsed
+                except configparser.Error as e:
+                    log.debug("Failed to parse setup.cfg: %s", e)
+                    self.__parsed = None  # Tried to parse file and failed
+
+        return self.__parsed
+
+    def _get_option(self, section, option):
+        """Get option from config section, return None if option missing or file invalid."""
+        if self._parsed is None:
+            return None
+        try:
+            return self._parsed.get(section, option)
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            return None
+
+    def _resolve_version(self, version):
+        """Attempt to resolve the version attribute."""
+        if version.startswith("file:"):
+            file_arg = version[len("file:") :].strip()
+            version = self._read_version_from_file(file_arg)
+        elif version.startswith("attr:"):
+            attr_arg = version[len("attr:") :].strip()
+            version = self._read_version_from_attr(attr_arg)
+        return version
+
+    def _read_version_from_file(self, file_path):
+        """Read version from file after making sure file is a subpath of project dir."""
+        full_file_path = self._ensure_local(file_path)
+        if full_file_path.is_file():
+            version = full_file_path.read_text().strip()
+            log.debug("Read version from %r: %r", file_path, version)
+            return version
+        else:
+            log.debug("Version file %r does not exist or is not a file", file_path)
+            return None
+
+    def _ensure_local(self, path):
+        """Check that path is a subpath of project directory, return resolved path."""
+        full_path = (self._top_dir / path).resolve()
+        try:
+            full_path.relative_to(self._top_dir)
+        except ValueError:
+            raise ValidationError(f"{str(path)!r} is not a subpath of {str(self._top_dir)!r}")
+        return full_path
+
+    def _read_version_from_attr(self, attr_spec):
+        """
+        Read version from module attribute.
+
+        Like setuptools, will try to find the attribute by looking for Python
+        literals in the AST of the module. Unlike setuptools, will not execute
+        the module if this fails.
+
+        https://github.com/pypa/setuptools/blob/ba209a15247b9578d565b7491f88dc1142ba29e4/setuptools/config.py#L354
+
+        :param str attr_spec: "import path" of attribute, e.g. package.version.__version__
+        :rtype: str or None
+        """
+        module_name, _, attr_name = attr_spec.rpartition(".")
+        if not module_name:
+            # Assume current directory is a package, look for attribute in __init__.py
+            module_name = "__init__"
+
+        log.debug("Attempting to find attribute %r in %r", attr_name, module_name)
+
+        module_file = self._find_module(module_name, self._get_package_dirs())
+        if module_file is not None:
+            log.debug("Found module %r at %r", module_name, str(module_file))
+        else:
+            log.debug("Module %r not found", module_name)
+            return None
+
+        try:
+            module_ast = ast.parse(module_file.read_text(), module_file.name)
+        except SyntaxError as e:
+            log.debug("Syntax error when parsing module: %s", e)
+            return None
+
+        try:
+            version = get_top_level_attr(module_ast, attr_name)
+            log.debug("Found attribute %r in %r: %r", attr_name, module_name, version)
+            return version
+        except AttributeError as e:
+            log.debug("Could not find attribute in %r: %s", module_name, e)
+            return None
+
+    def _find_module(self, module_name, package_dir=None):
+        """
+        Try to find a module in the project directory and return path to source file.
+
+        :param str module_name: "import path" of module
+        :param dict[str, str] package_dir: same semantics as options.package_dir in setup.cfg
+
+        :rtype: Path or None
+        """
+        module_path = self._convert_to_path(module_name)
+        root_module = module_path.parts[0]
+
+        package_dir = package_dir or {}
+
+        if root_module in package_dir:
+            custom_path = Path(package_dir[root_module])
+            log.debug(f"Custom path set for root module %r: %r", root_module, str(custom_path))
+            # Custom path replaces the root module
+            module_path = custom_path.joinpath(*module_path.parts[1:])
+        elif "" in package_dir:
+            custom_path = Path(package_dir[""])
+            log.debug(f"Custom path set for all root modules: %r", str(custom_path))
+            # Custom path does not replace the root module
+            module_path = custom_path / module_path
+
+        full_module_path = self._ensure_local(module_path)
+
+        package_init = full_module_path / "__init__.py"
+        if package_init.is_file():
+            return package_init
+
+        module_py = Path(f"{full_module_path}.py")
+        if module_py.is_file():
+            return module_py
+
+        return None
+
+    def _convert_to_path(self, module_name):
+        """Check that module name is valid and covert to file path."""
+        parts = module_name.split(".")
+        if not parts[0]:
+            # Relative import (supported only to the extent that one leading '.' is ignored)
+            parts.pop(0)
+        if not all(self._name_re.fullmatch(part) for part in parts):
+            raise ValidationError(f"{module_name!r} is not an accepted module name")
+        return Path(*parts)
+
+    def _get_package_dirs(self):
+        """
+        Get options.package_dir and convert to dict if present.
+
+        https://github.com/pypa/setuptools/blob/ba209a15247b9578d565b7491f88dc1142ba29e4/setuptools/config.py#L264
+
+        :rtype: dict[str, str] or None
+        """
+        package_dir_value = self._get_option("options", "package_dir")
+        if package_dir_value is None:
+            return None
+
+        if "\n" in package_dir_value:
+            package_items = package_dir_value.splitlines()
+        else:
+            package_items = package_dir_value.split(",")
+
+        # Strip whitespace and discard empty values
+        package_items = filter(bool, (p.strip() for p in package_items))
+
+        package_dirs = {}
+        for item in package_items:
+            package, sep, p_dir = item.partition("=")
+            if sep:
+                # Otherwise value was malformed ('=' was missing)
+                package_dirs[package.strip()] = p_dir.strip()
+
+        return package_dirs

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -21,6 +21,7 @@ RUN dnf -y install \
     python3-requests \
     python3-requests-kerberos \
     python3-semver \
+    python3-setuptools \
     && dnf clean all
 COPY . .
 COPY ./docker/cachito-httpd.conf /etc/httpd/conf/httpd.conf

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -16,6 +16,7 @@ RUN dnf -y install \
     python3-requests \
     python3-requests-kerberos \
     python3-semver \
+    python3-setuptools \
     && dnf clean all
 COPY . .
 RUN pip3 install . --no-deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ kombu<5 # A celery dependency but it's directly imported
 requests_kerberos
 requests
 semver
+setuptools

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -1,0 +1,656 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from cachito.workers.pkg_managers import pip
+from cachito.errors import ValidationError
+
+
+def setup_module():
+    """Re-enable logging that was disabled at some point in previous tests."""
+    pip.log.disabled = False
+    pip.log.setLevel(logging.DEBUG)
+
+
+def write_file_tree(tree_def, rooted_at):
+    """
+    Write a file tree to disk.
+
+    :param dict tree_def: Definition of file tree, see usage for intuitive examples
+    :param (str | Path) rooted_at: Root of file tree, must be an existing directory
+    """
+    root = Path(rooted_at)
+    for entry, value in tree_def.items():
+        entry_path = root / entry
+        if isinstance(value, str):
+            entry_path.write_text(value)
+        else:
+            entry_path.mkdir()
+            write_file_tree(value, entry_path)
+
+
+class TestSetupCFG:
+    """SetupCFG tests."""
+
+    @pytest.mark.parametrize("exists", [True, False])
+    def test_exists(self, exists, tmpdir):
+        """Test file existence check."""
+        if exists:
+            tmpdir.join("setup.cfg").write("")
+
+        setup_cfg = pip.SetupCFG(tmpdir.strpath)
+        assert setup_cfg.exists() == exists
+
+    @pytest.mark.parametrize(
+        "cfg_content, expect_name, expect_logs",
+        [
+            (
+                "",
+                None,
+                ["Parsing setup.cfg at '{tmpdir}/setup.cfg'", "No metadata.name in setup.cfg"],
+            ),
+            ("[metadata]", None, ["No metadata.name in setup.cfg"]),
+            (
+                dedent(
+                    """\
+                    [metadata]
+                    name = foo
+                    """
+                ),
+                "foo",
+                [
+                    "Parsing setup.cfg at '{tmpdir}/setup.cfg'",
+                    "Found metadata.name in setup.cfg: 'foo'",
+                ],
+            ),
+            (
+                "[malformed",
+                None,
+                [
+                    "Parsing setup.cfg at '{tmpdir}/setup.cfg'",
+                    "Failed to parse setup.cfg: File contains no section headers",
+                    "No metadata.name in setup.cfg",
+                ],
+            ),
+        ],
+    )
+    def test_get_name(self, cfg_content, expect_name, expect_logs, tmpdir, caplog):
+        """Test get_name() method."""
+        setup_cfg = tmpdir.join("setup.cfg")
+        setup_cfg.write(cfg_content)
+
+        assert pip.SetupCFG(tmpdir.strpath).get_name() == expect_name
+        self._assert_has_logs(expect_logs, tmpdir, caplog)
+
+    @pytest.mark.parametrize(
+        "cfg_content, expect_version, expect_logs",
+        [
+            (
+                "",
+                None,
+                ["Parsing setup.cfg at '{tmpdir}/setup.cfg'", "No metadata.version in setup.cfg"],
+            ),
+            ("[metadata]", None, ["No metadata.version in setup.cfg"]),
+            (
+                dedent(
+                    """\
+                    [metadata]
+                    version = 1.0.0
+                    """
+                ),
+                "1.0.0",
+                [
+                    "Parsing setup.cfg at '{tmpdir}/setup.cfg'",
+                    "Resolving metadata.version in setup.cfg from '1.0.0'",
+                    "Found metadata.version in setup.cfg: '1.0.0'",
+                ],
+            ),
+            (
+                "[malformed",
+                None,
+                [
+                    "Parsing setup.cfg at '{tmpdir}/setup.cfg'",
+                    "Failed to parse setup.cfg: File contains no section headers",
+                    "No metadata.version in setup.cfg",
+                ],
+            ),
+        ],
+    )
+    def test_get_version_basic(self, cfg_content, expect_version, expect_logs, tmpdir, caplog):
+        """Test get_version() method with basic cases."""
+        setup_cfg = tmpdir.join("setup.cfg")
+        setup_cfg.write(cfg_content)
+
+        assert pip.SetupCFG(tmpdir.strpath).get_version() == expect_version
+        self._assert_has_logs(expect_logs, tmpdir, caplog)
+
+    def _assert_has_logs(self, expect_logs, tmpdir, caplog):
+        for log in expect_logs:
+            assert log.format(tmpdir=tmpdir.strpath) in caplog.text
+
+    def _test_version_with_file_tree(
+        self, project_tree, expect_version, expect_logs, expect_error, tmpdir, caplog
+    ):
+        """Test resolving version from file: or attr: directive."""
+        write_file_tree(project_tree, tmpdir.strpath)
+        setup_cfg = pip.SetupCFG(tmpdir.strpath)
+
+        if expect_error is None:
+            assert setup_cfg.get_version() == expect_version
+        else:
+            with pytest.raises(ValidationError) as exc_info:
+                setup_cfg.get_version()
+            assert str(exc_info.value) == expect_error.format(tmpdir=tmpdir.strpath)
+
+        logs = expect_logs.copy()
+        # Does not actually have to be at index 0, this is just to be more obvious
+        logs.insert(0, f"Parsing setup.cfg at '{tmpdir.join('setup.cfg')}'")
+        if expect_version is not None:
+            logs.append(f"Found metadata.version in setup.cfg: '{expect_version}'")
+        elif expect_error is None:
+            logs.append("Failed to resolve metadata.version in setup.cfg")
+
+        self._assert_has_logs(logs, tmpdir, caplog)
+
+    @pytest.mark.parametrize(
+        "project_tree, expect_version, expect_logs, expect_error",
+        [
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = file: missing.txt
+                        """
+                    ),
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'file: missing.txt'",
+                    "Version file 'missing.txt' does not exist or is not a file",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = file: version.txt
+                        """
+                    ),
+                    "version.txt": "1.0.0",
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'file: version.txt'",
+                    "Read version from 'version.txt': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = file: version.txt
+                        """
+                    ),
+                    "version.txt": "\n1.0.0\n",
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'file: version.txt'",
+                    "Read version from 'version.txt': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = file: data/version.txt
+                        """
+                    ),
+                    "data": {"version.txt": "1.0.0"},
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'file: data/version.txt'",
+                    "Read version from 'data/version.txt': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = file: ../version.txt
+                        """
+                    ),
+                },
+                None,
+                ["Resolving metadata.version in setup.cfg from 'file: ../version.txt'"],
+                "'../version.txt' is not a subpath of '{tmpdir}'",
+            ),
+        ],
+    )
+    def test_get_version_file(
+        self, project_tree, expect_version, expect_logs, expect_error, tmpdir, caplog
+    ):
+        """Test get_version() method with file: directive."""
+        self._test_version_with_file_tree(
+            project_tree, expect_version, expect_logs, expect_error, tmpdir, caplog
+        )
+
+    @pytest.mark.parametrize(
+        "project_tree, expect_version, expect_logs, expect_error",
+        [
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: missing_file.__ver__
+                        """
+                    ),
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: missing_file.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'missing_file'",
+                    "Module 'missing_file' not found",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: syntax_error.__ver__
+                        """
+                    ),
+                    "syntax_error.py": "syntax error",
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: syntax_error.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'syntax_error'",
+                    "Found module 'syntax_error' at '{tmpdir}/syntax_error.py'",
+                    "Syntax error when parsing module: invalid syntax (syntax_error.py, line 1)",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: missing_attr.__ver__
+                        """
+                    ),
+                    "missing_attr.py": "",
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: missing_attr.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'missing_attr'",
+                    "Found module 'missing_attr' at '{tmpdir}/missing_attr.py'",
+                    "Could not find attribute in 'missing_attr': Attribute '__ver__' not found",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: not_a_literal.__ver__
+                        """
+                    ),
+                    "not_a_literal.py": "__ver__ = get_version()",
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: not_a_literal.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'not_a_literal'",
+                    "Found module 'not_a_literal' at '{tmpdir}/not_a_literal.py'",
+                    (
+                        "Could not find attribute in 'not_a_literal': "
+                        "Attribute '__ver__' is not assigned to a literal expression"
+                    ),
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: module.__ver__
+                        """
+                    ),
+                    "module.py": "__ver__ = '1.0.0'",
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: module.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'module'",
+                    "Found module 'module' at '{tmpdir}/module.py'",
+                    "Found attribute '__ver__' in 'module': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: package.__ver__
+                        """
+                    ),
+                    "package": {"__init__.py": "__ver__ = '1.0.0'"},
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: package.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'package'",
+                    "Found module 'package' at '{tmpdir}/package/__init__.py'",
+                    "Found attribute '__ver__' in 'package': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: package.module.__ver__
+                        """
+                    ),
+                    "package": {"module.py": "__ver__ = '1.0.0'"},
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: package.module.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'package.module'",
+                    "Found module 'package.module' at '{tmpdir}/package/module.py'",
+                    "Found attribute '__ver__' in 'package.module': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: package_before_module.__ver__
+                        """
+                    ),
+                    "package_before_module": {"__init__.py": "__ver__ = '1.0.0'"},
+                    "package_before_module.py": "__ver__ = '2.0.0'",
+                },
+                "1.0.0",
+                [
+                    (
+                        "Resolving metadata.version in setup.cfg from "
+                        "'attr: package_before_module.__ver__'"
+                    ),
+                    "Attempting to find attribute '__ver__' in 'package_before_module'",
+                    (
+                        "Found module 'package_before_module' at "
+                        "'{tmpdir}/package_before_module/__init__.py'"
+                    ),
+                    "Found attribute '__ver__' in 'package_before_module': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: __ver__
+                        """
+                    ),
+                    "__init__.py": "__ver__ = '1.0.0'",
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: __ver__'",
+                    "Attempting to find attribute '__ver__' in '__init__'",
+                    "Found module '__init__' at '{tmpdir}/__init__.py'",
+                    "Found attribute '__ver__' in '__init__': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: .__ver__
+                        """
+                    ),
+                    "__init__.py": "__ver__ = '1.0.0'",
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: .__ver__'",
+                    "Attempting to find attribute '__ver__' in '__init__'",
+                    "Found module '__init__' at '{tmpdir}/__init__.py'",
+                    "Found attribute '__ver__' in '__init__': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: is_tuple.__ver__
+                        """
+                    ),
+                    "is_tuple.py": "__ver__ = (1, 0, 'alpha', 1)",
+                },
+                "1.0a1",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: is_tuple.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'is_tuple'",
+                    "Found module 'is_tuple' at '{tmpdir}/is_tuple.py'",
+                    "Found attribute '__ver__' in 'is_tuple': (1, 0, 'alpha', 1)",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: is_integer.__ver__
+                        """
+                    ),
+                    "is_integer.py": "__ver__ = 1",
+                },
+                "1",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: is_integer.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'is_integer'",
+                    "Found module 'is_integer' at '{tmpdir}/is_integer.py'",
+                    "Found attribute '__ver__' in 'is_integer': 1",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: ..module.__ver__
+                        """
+                    ),
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: ..module.__ver__'",
+                    "Attempting to find attribute '__ver__' in '..module'",
+                ],
+                "'..module' is not an accepted module name",
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: /root.module.__ver__
+                        """
+                    ),
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: /root.module.__ver__'",
+                    "Attempting to find attribute '__ver__' in '/root.module'",
+                ],
+                "'/root.module' is not an accepted module name",
+            ),
+        ],
+    )
+    def test_get_version_attr(
+        self, project_tree, expect_version, expect_logs, expect_error, tmpdir, caplog
+    ):
+        """Test get_version() method with attr: directive."""
+        self._test_version_with_file_tree(
+            project_tree, expect_version, expect_logs, expect_error, tmpdir, caplog
+        )
+
+    @pytest.mark.parametrize(
+        "project_tree, expect_version, expect_logs, expect_error",
+        [
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: module.__ver__
+
+                        [options]
+                        package_dir =
+                            =src
+                        """
+                    ),
+                    "src": {"module.py": "__ver__ = '1.0.0'"},
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: module.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'module'",
+                    "Custom path set for all root modules: 'src'",
+                    "Found module 'module' at '{tmpdir}/src/module.py'",
+                    "Found attribute '__ver__' in 'module': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: module.__ver__
+
+                        [options]
+                        package_dir =
+                            module = src/module
+                        """
+                    ),
+                    "src": {"module.py": "__ver__ = '1.0.0'"},
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: module.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'module'",
+                    "Custom path set for root module 'module': 'src/module'",
+                    "Found module 'module' at '{tmpdir}/src/module.py'",
+                    "Found attribute '__ver__' in 'module': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: module.__ver__
+
+                        [options]
+                        package_dir = module=src/module, =src
+                        """
+                    ),
+                    "src": {"module.py": "__ver__ = '1.0.0'"},
+                },
+                "1.0.0",
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: module.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'module'",
+                    "Custom path set for root module 'module': 'src/module'",
+                    "Found module 'module' at '{tmpdir}/src/module.py'",
+                    "Found attribute '__ver__' in 'module': '1.0.0'",
+                ],
+                None,
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: module.__ver__
+
+                        [options]
+                        package_dir =
+                            = ..
+                        """
+                    ),
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: module.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'module'",
+                    "Custom path set for all root modules: '..'",
+                ],
+                "'../module' is not a subpath of '{tmpdir}'",
+            ),
+            (
+                {
+                    "setup.cfg": dedent(
+                        """\
+                        [metadata]
+                        version = attr: module.__ver__
+
+                        [options]
+                        package_dir =
+                            module = ../module
+                        """
+                    ),
+                },
+                None,
+                [
+                    "Resolving metadata.version in setup.cfg from 'attr: module.__ver__'",
+                    "Attempting to find attribute '__ver__' in 'module'",
+                    "Custom path set for root module 'module': '../module'",
+                ],
+                "'../module' is not a subpath of '{tmpdir}'",
+            ),
+        ],
+    )
+    def test_get_version_attr_with_package_dir(
+        self, project_tree, expect_version, expect_logs, expect_error, tmpdir, caplog
+    ):
+        """Test get_version() method with attr: directive and options.package_dir."""
+        self._test_version_with_file_tree(
+            project_tree, expect_version, expect_logs, expect_error, tmpdir, caplog
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,8 @@ show-source = True
 max-line-length = 100
 exclude = venv,.git,.tox,dist,*egg,cachito/web/migrations,.env
 # W503 line break before binary operator
-ignore = D100,D104,D105,W503
+# E203 whitespace before ':' ("black" will catch the valid cases)
+ignore = D100,D104,D105,W503,E203
 per-file-ignores =
     # Ignore missing docstrings in the tests and migrations
     tests/*:D103


### PR DESCRIPTION
* CLOUDBLD-2053

Aims for near parity with the setuptools way of handling setup.cfg files
with the notable exception of never executing unknown Python modules.

There may be other minor differences, but should cover 99% of the
typical use cases.