### PR TITLE
Pin celery and kombu versions to 4.x.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-celery
+celery<5
 gitpython
-kombu # A celery dependency but it's directly imported
+kombu<5 # A celery dependency but it's directly imported
 requests_kerberos
 requests
 semver


### PR DESCRIPTION
Kombu 5.0.0 has been released while the corresponding Celery version is
still in alpha, this means we end up installing an unsupported version
of Kombu for tests.

Pin both to 4.x.x for now, upgrade to 5.x.x when they land in Fedora.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>