### PR TITLE
Set the default per_page to 10

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -51,7 +51,11 @@ def get_requests():
         state_int = RequestStateMapping.__members__[state].value
         query = query.join(RequestState, Request.request_state_id == RequestState.id)
         query = query.filter(RequestState.state == state_int)
-    pagination_query = query.paginate(max_per_page=max_per_page)
+    try:
+        per_page = int(flask.request.args.get("per_page", 10))
+    except ValueError:
+        per_page = 10
+    pagination_query = query.paginate(per_page=per_page, max_per_page=max_per_page)
     requests = pagination_query.items
     query_params = {}
     if state:

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -26,7 +26,7 @@ paths:
           schema:
             type: integer
             example: 10
-            default: 20
+            default: 10
         - name: state
           in: query
           description: The state to filter requests by


### PR DESCRIPTION
This will reduce the load on the database and it's more likely the last 10 requests are relevant to the user than the last 20.