### PR TITLE
Set state complete in the `create_bundle_archive`

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -238,12 +238,7 @@ def create_request():
             tasks.fetch_npm_source.si(request.id, npm_package_configs).on_error(error_callback)
         )
 
-    chain_tasks.extend(
-        [
-            tasks.create_bundle_archive.si(request.id).on_error(error_callback),
-            tasks.set_request_state.si(request.id, "complete", "Completed successfully"),
-        ]
-    )
+    chain_tasks.extend([tasks.create_bundle_archive.si(request.id).on_error(error_callback)])
 
     try:
         chain(chain_tasks).delay()

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -141,3 +141,5 @@ def create_bundle_archive(request_id):
             bundle_archive.add(str(item), arc_name, filter=filter_git_dir)
         # Add the dependencies to the bundle
         bundle_archive.add(str(bundle_dir.deps_dir), "deps")
+
+    set_request_state(request_id, "complete", "Completed successfully")

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -20,7 +20,6 @@ from cachito.workers.tasks import (
     fetch_app_source,
     fetch_gomod_source,
     fetch_npm_source,
-    set_request_state,
     failed_request_callback,
     create_bundle_archive,
 )
@@ -109,12 +108,7 @@ def test_create_and_fetch_request(
         )
     if "npm" in expected_pkg_managers:
         expected.append(fetch_npm_source.si(created_request["id"], {}).on_error(error_callback))
-    expected.extend(
-        [
-            create_bundle_archive.si(created_request["id"]).on_error(error_callback),
-            set_request_state.si(created_request["id"], "complete", "Completed successfully"),
-        ]
-    )
+    expected.extend([create_bundle_archive.si(created_request["id"]).on_error(error_callback)])
     mock_chain.assert_called_once_with(expected)
 
     request_id = created_request["id"]
@@ -151,7 +145,6 @@ def test_create_and_fetch_request_package_configs(
         ).on_error(error_callback),
         fetch_npm_source.si(1, package_value["npm"]).on_error(error_callback),
         create_bundle_archive.si(1).on_error(error_callback),
-        set_request_state.si(1, "complete", "Completed successfully"),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -202,7 +195,6 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
             ).on_error(error_callback),
             fetch_gomod_source.si(1, []).on_error(error_callback),
             create_bundle_archive.si(1).on_error(error_callback),
-            set_request_state.si(1, "complete", "Completed successfully"),
         ]
     )
 

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -140,7 +140,7 @@ def test_create_bundle_archive(mock_gwc, mock_set_request, deps_present, tmpdir)
         expected |= set(deps_archive_contents.keys())
 
     assert bundle_contents == expected
-
-    mock_set_request.assert_called_once_with(
-        request_id, "in_progress", "Assembling the bundle archive"
-    )
+    call1 = (request_id, "in_progress", "Assembling the bundle archive")
+    call2 = (request_id, "complete", "Completed successfully")
+    assert mock_set_request.call_count == len([call1, call2])
+    mock_set_request.assert_has_calls(mock_set_request(call1), mock_set_request(call2))


### PR DESCRIPTION
Set the request state after the bundle is created rather than a separate task