### PR TITLE
Handle PURL for npm dependencies from file

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -198,7 +198,10 @@ class Package(db.Model):
             protocol = match.group("protocol")
             suffix = match.group("suffix")
             has_authority = match.group("has_authority")
-            if not has_authority:
+            if protocol == "file":
+                qualifier = urllib.parse.quote(self.version, safe="")
+                return f"generic/{purl_name}?{qualifier}"
+            elif not has_authority:
                 # github:namespace/name#ref or gitlab:ns1/ns2/name#ref
                 match_forge = re.match(
                     r"(?P<namespace>.+)/(?P<name>[^#/]+)#(?P<version>.+)$", suffix

--- a/tests/test_content_manifest.py
+++ b/tests/test_content_manifest.py
@@ -229,6 +229,12 @@ def test_set_go_package_sources(mock_warning, app, pkg_name, gomod_data, warn):
             True,
         ],
         [
+            {"name": "fromfile", "type": "npm", "version": "file:client-default"},
+            "generic/fromfile?file%3Aclient-default",
+            True,
+            True,
+        ],
+        [
             {
                 "name": "fromunknown",
                 "type": "npm",


### PR DESCRIPTION
Due to cachito_npm_file_deps_allowlist, Cachito allows NPM dependencies
to be embedded in the application repository. For this reason, purl
conversion for these dependencies must also be supported. Othewise, the
content manifests cannot be generated for the whole request.

* CLOUDBLD-2223

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>