### PR TITLE
Improve npm file dependencies PURL generation

### DIFF
--- a/cachito/web/content_manifest.py
+++ b/cachito/web/content_manifest.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import urllib.parse
+
 import flask
+
+
+PARENT_PURL_PLACEHOLDER = "PARENT_PURL"
 
 
 class ContentManifest:
@@ -82,7 +87,9 @@ class ContentManifest:
         """
         if dependency.type == "npm":
             purl = package.to_purl()
-            icm_dependency = {"purl": dependency.to_purl()}
+            safe_parent_purl = urllib.parse.quote(purl, safe="")
+            dep_purl = dependency.to_purl().replace(PARENT_PURL_PLACEHOLDER, safe_parent_purl)
+            icm_dependency = {"purl": dep_purl}
             self._npm_data[purl]["sources"].append(icm_dependency)
             if not dependency.dev:
                 self._npm_data[purl]["dependencies"].append(icm_dependency)

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -208,10 +208,14 @@ class Package(db.Model):
             protocol = match.group("protocol")
             suffix = match.group("suffix")
             has_authority = match.group("has_authority")
-            if protocol == "file":
-                qualifier = urllib.parse.quote(self.version, safe="")
-                return f"generic/{purl_name}?{qualifier}"
-            elif not has_authority:
+            if not has_authority:
+                if protocol == "file":
+                    path = self.version.split(":", 1)[1]
+                    safe_path = urllib.parse.quote(path, safe="")
+                    # this path is relative to the parent package's package.json path
+                    # let's mark this purl for later substitution
+                    marker = content_manifest.PARENT_PURL_PLACEHOLDER
+                    return f"pkg:generic/{purl_name}?download_url={marker}&file_name={safe_path}"
                 # github:namespace/name#ref or gitlab:ns1/ns2/name#ref
                 match_forge = re.match(
                     r"(?P<namespace>.+)/(?P<name>[^#/]+)#(?P<version>.+)$", suffix


### PR DESCRIPTION
The npm file dependencies "file" descriptor are relative to their parent
package root path.

Considering a PURL should be used to proper locate a package, this
information should be present in such dependencies PURLs.

This patch proposes including the parent package PURL in the
download_url qualifier and pointing to the proper package file through
the file_name qualifier.

Signed-off-by: Athos Ribeiro <athos@redhat.com>