### PR TITLE
Integration test: change content manifest test for all packages

### DIFF
--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -92,3 +92,7 @@ downloaded_output:
 run_app:
   # Name of the applicaiton that is downloaded via bundle
   app_name: retrodep
+# Test data for valid content manifest test
+content_manifest:
+  # Package managers for testing
+  pkg_managers: ["gomod", "npm"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,7 +26,7 @@ def test_env():
 
 
 @pytest.fixture(scope="session")
-def default_request(test_env):
+def default_requests(test_env):
     """
     Create a new request for every package manager in Cachito.
 
@@ -35,7 +35,7 @@ def default_request(test_env):
     :rtype: dict
     """
     client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
-    default_requests = {}
+    result_requests = {}
     packages = test_env["packages"]
     for package_name in packages:
         initial_response = client.create_new_request(
@@ -46,6 +46,6 @@ def default_request(test_env):
             },
         )
         completed_response = client.wait_for_complete_request(initial_response)
-        default_requests[package_name] = DefaultRequest(initial_response, completed_response)
+        result_requests[package_name] = DefaultRequest(initial_response, completed_response)
 
-    return default_requests
+    return result_requests

--- a/tests/integration/test_check_downloaded_output.py
+++ b/tests/integration/test_check_downloaded_output.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import utils
 
 
-def test_check_downloaded_output(test_env, default_request, tmpdir):
+def test_check_downloaded_output(test_env, default_requests, tmpdir):
     """
     Check that the bundle has all the necessities.
 
@@ -23,7 +23,7 @@ def test_check_downloaded_output(test_env, default_request, tmpdir):
     * Check that dir app/ contains application source code
     * Check that the same full path filename is not duplicated
     """
-    response = default_request["gomod"].complete_response
+    response = default_requests["gomod"].complete_response
     assert response.status == 200
     client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
     assert response.data["state"] == "complete"

--- a/tests/integration/test_content_manifest.py
+++ b/tests/integration/test_content_manifest.py
@@ -31,12 +31,14 @@ def test_valid_content_manifest_request(test_env, default_requests):
     """
     client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
 
-    initial_response = default_requests["gomod"].initial_response
-    content_manifest_response = client.fetch_content_manifest(initial_response.id)
-    assert content_manifest_response.status == 200
+    pkg_managers = test_env["content_manifest"]["pkg_managers"]
+    for pkg_manager in pkg_managers:
+        initial_response = default_requests[pkg_manager].initial_response
+        content_manifest_response = client.fetch_content_manifest(initial_response.id)
+        assert content_manifest_response.status == 200
 
-    response_data = content_manifest_response.data
-    assert_content_manifest_schema(response_data)
+        response_data = content_manifest_response.data
+        assert_content_manifest_schema(response_data)
 
 
 def assert_content_manifest_schema(response_data):

--- a/tests/integration/test_content_manifest.py
+++ b/tests/integration/test_content_manifest.py
@@ -21,7 +21,7 @@ def test_invalid_content_manifest_request(test_env):
     assert e.value.response.json() == {"error": "The requested resource was not found"}
 
 
-def test_valid_content_manifest_request(test_env, default_request):
+def test_valid_content_manifest_request(test_env, default_requests):
     """
     Send a valid content-manifest request to the Cachito API.
 
@@ -31,7 +31,7 @@ def test_valid_content_manifest_request(test_env, default_request):
     """
     client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
 
-    initial_response = default_request["gomod"].initial_response
+    initial_response = default_requests["gomod"].initial_response
     content_manifest_response = client.fetch_content_manifest(initial_response.id)
     assert content_manifest_response.status == 200
 

--- a/tests/integration/test_creating_new_request.py
+++ b/tests/integration/test_creating_new_request.py
@@ -3,7 +3,7 @@
 import utils
 
 
-def test_creating_new_request(test_env, default_request):
+def test_creating_new_request(test_env, default_requests):
     """
     Send a new request to the Cachito API.
 
@@ -13,7 +13,7 @@ def test_creating_new_request(test_env, default_request):
         state_reason is: The request was initiated
     """
     client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
-    response_created_req = default_request["gomod"].initial_response
+    response_created_req = default_requests["gomod"].initial_response
     assert response_created_req.status == 201
 
     assert "id" in response_created_req.data

--- a/tests/integration/test_run_app_from_bundle.py
+++ b/tests/integration/test_run_app_from_bundle.py
@@ -11,7 +11,7 @@ import utils
 
 
 @pytest.mark.skipif(not shutil.which("go"), reason="requires go to be installed")
-def test_run_app_from_bundle(test_env, default_request, tmpdir):
+def test_run_app_from_bundle(test_env, default_requests, tmpdir):
     """
     Check that downloaded bundle could be used to run the application.
 
@@ -26,7 +26,7 @@ def test_run_app_from_bundle(test_env, default_request, tmpdir):
     * Check that the bundle is properly downloaded
     * Check that the application runs successfully
     """
-    response = default_request["gomod"].complete_response
+    response = default_requests["gomod"].complete_response
     assert response.status == 200
     assert response.data["state"] == "complete"
 

--- a/tests/integration/test_valid_data_in_request.py
+++ b/tests/integration/test_valid_data_in_request.py
@@ -3,7 +3,7 @@
 from utils import make_list_of_packages_hashable
 
 
-def test_valid_data_in_request(test_env, default_request):
+def test_valid_data_in_request(test_env, default_requests):
     """
     Validate data in the request.
 
@@ -16,7 +16,7 @@ def test_valid_data_in_request(test_env, default_request):
     * Check in the response that state is complete
     * Check that "packages" and "dependencies" keys have appropriate values
     """
-    response = default_request["gomod"].complete_response
+    response = default_requests["gomod"].complete_response
     assert response.status == 200
     assert response.data["state"] == "complete"
 
@@ -29,7 +29,7 @@ def test_valid_data_in_request(test_env, default_request):
     assert response_packages == sorted(expected_packages)
 
 
-def test_npm_basic(test_env, default_request):
+def test_npm_basic(test_env, default_requests):
     """
     A basic integration test for the npm package manager.
 
@@ -47,7 +47,7 @@ def test_npm_basic(test_env, default_request):
         "CYPRESS_INSTALL_BINARY": "0", "GECKODRIVER_SKIP_DOWNLOAD": "true",
         and "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": "true" are set.
     """
-    response = default_request["npm"].complete_response
+    response = default_requests["npm"].complete_response
     assert response.status == 200
     assert response.data["state"] == "complete"
 


### PR DESCRIPTION
Changes in 2 commits: 
*  `default_request` name to `default_requests`
*  test not only `gomod` for container manifest, test all `default_requests`