### PR TITLE
Generate test files in pytest default tmp dir

### DIFF
--- a/tests/test_workers/test_celery_logging.py
+++ b/tests/test_workers/test_celery_logging.py
@@ -9,9 +9,9 @@ from cachito.errors import CachitoError
 from cachito.workers import celery_logging
 
 
-def test_cleanup_task_logging(tmpdir):
+def test_cleanup_task_logging(tmp_path):
     # Add a file handler first to test remove handler function
-    request_log_handler = logging.FileHandler("fake-path")
+    request_log_handler = logging.FileHandler(tmp_path / "fake-path")
     logger = logging.getLogger()
     logger.addHandler(request_log_handler)
 


### PR DESCRIPTION
This will avoid generating a "fake-path" file in the project root on every test suite run