### PR TITLE
Add resources to set Nexus repositories for python

### DIFF
--- a/cachito/workers/nexus_scripts/pip_before_content_staged.groovy
+++ b/cachito/workers/nexus_scripts/pip_before_content_staged.groovy
@@ -1,0 +1,60 @@
+/*
+This script configures Nexus so that Cachito can stage Python content for the Cachito request.
+
+This script creates a PyPI hosted repository and a raw repository to be used by a Cachito request
+to fetch Python content
+
+No permissions are configured since it is expected that Cachito's Nexus service account has access
+to use all Python related repositories managed by the Nexus instance.
+ */
+import groovy.json.JsonSlurper
+import groovy.transform.Field
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.sonatype.nexus.repository.config.Configuration
+import org.sonatype.nexus.repository.storage.WritePolicy
+
+
+// Scope logger to the script using @Field
+@Field final Logger logger = LoggerFactory.getLogger('cachito');
+
+
+def createHostedRepo(String name, String repoType) {
+    WritePolicy writePolicy = WritePolicy.ALLOW_ONCE
+    Boolean strictContentValidation = true
+    String blobStoreName = "cachito-pip"
+    // repository is an object that is injected by Nexus when the script is executed
+    if(repository.repositoryManager.exists(name)) {
+        logger.info("Modifying the hosted repository ${name}")
+        Configuration hostedRepoConfig = repository.repositoryManager.get(name).configuration
+        def storage = hostedRepoConfig.attributes('storage')
+        storage.set('strictContentTypeValidation', strictContentValidation)
+        storage.set('writePolicy', writePolicy)
+        repository.repositoryManager.update(hostedRepoConfig)
+    }
+    else {
+        logger.info("Creating the hosted ${repoType} repository ${name}")
+        switch(repoType) {
+            case "raw":
+                repository.createRawHosted(name, blobStoreName, strictContentValidation, writePolicy)
+                break;
+            case "pypi":
+                repository.createPyPiHosted(name, blobStoreName, strictContentValidation, writePolicy)
+                break;
+            default:
+                logger.warn("Type ${repoType} not supported. repository ${name} not created.")
+                break;
+        }
+    }
+}
+
+
+request = new JsonSlurper().parseText(args)
+['pip_repository_name', 'raw_repository_name'].each { param ->
+    assert request.get(param): "The ${param} parameter is required"
+}
+
+createHostedRepo(request.pip_repository_name, "pypi")
+createHostedRepo(request.raw_repository_name, "raw")
+
+return 'The repositories were created successfully'

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -259,7 +259,12 @@ def test_create_or_update_update_fails(mock_requests):
 @mock.patch("cachito.workers.nexus.create_or_update_script")
 def test_create_or_update_scripts(mock_cous):
     nexus.create_or_update_scripts()
-    expected_scripts = {"js_after_content_staged", "js_before_content_staged", "js_cleanup"}
+    expected_scripts = {
+        "js_after_content_staged",
+        "js_before_content_staged",
+        "js_cleanup",
+        "pip_before_content_staged",
+    }
     for call_args in mock_cous.call_args_list:
         script_name = call_args[0][0]
         expected_scripts.remove(script_name)


### PR DESCRIPTION
A part of supporting Python packages in Cachito, we need to Create the
temporary Nexus repositories that will be available for a Cachito
request while assembling the bundle.

- Add Nexus preparation scripts for Python
- Add Nexus preparation function for Python

Signed-off-by: Athos Ribeiro <athos@redhat.com>