### PR TITLE
Configure Python repositories for final usage

### DIFF
--- a/cachito/workers/nexus_scripts/pip_after_content_staged.groovy
+++ b/cachito/workers/nexus_scripts/pip_after_content_staged.groovy
@@ -1,0 +1,93 @@
+/*
+This script configures Nexus so that a temporary user for the request is created and is given
+permission to access the PyPI hosted repository and the raw hosted repository. It'd be preferable
+to give access to the Nexus anonymous user instead, but there is no way to add a role to a user.
+You can only set the entire set of roles at once. This is an issue since if more than one Cachito
+request is in progress and modifies the set of roles at the same time, one of the additions will be
+lost.
+
+Differently from its JS counterpart, this script does not block outbound connections for the
+temporary request repositories. This is not needed because both Python repositories used here
+are hosted repositories, and not PyPI proxies. In other words, they would not automatically pull
+unavailable contents from PyPI, as the npm repository would.
+ */
+import com.google.common.collect.Sets
+import groovy.json.JsonSlurper
+import groovy.transform.Field
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.sonatype.nexus.security.role.NoSuchRoleException
+import org.sonatype.nexus.security.user.UserStatus
+import org.sonatype.nexus.security.authz.AuthorizationManager
+import org.sonatype.nexus.security.role.Role
+import static org.sonatype.nexus.security.user.UserManager.DEFAULT_SOURCE
+import org.sonatype.nexus.security.user.UserNotFoundException
+
+
+// Scope logger to the script using @Field
+@Field final Logger logger = LoggerFactory.getLogger('cachito');
+
+
+void createUser(String username, String password, List<String> roles) {
+    try {
+        // security is an object that is injected by Nexus when the script is executed
+        def user = security.securitySystem.getUser(username)
+        logger.info("Modifying the existing user ${username}")
+        user.setFirstName(username)
+        user.setLastName(username)
+        user.setEmailAddress('noreply@domain.local')
+        user.setStatus(UserStatus.active)
+        security.securitySystem.updateUser(user)
+        security.setUserRoles(username, roles)
+        security.securitySystem.changePassword(username, password)
+    } catch (UserNotFoundException e) {
+        logger.info("Creating the user ${username}")
+        String firstName = username
+        String lastName = username
+        String email = 'noreply@domain.local'
+        Boolean active = true
+        // security is an object that is injected by Nexus when the script is executed
+        security.addUser(username, firstName, lastName, email, active, password, roles)
+    }
+}
+
+
+void createRole(String name, String description, List<String> privileges) {
+    // security is an object that is injected by Nexus when the script is executed
+    AuthorizationManager authorizationManager = security.securitySystem.getAuthorizationManager(DEFAULT_SOURCE)
+
+    String roleID = name
+    try {
+        Role role = authorizationManager.getRole(roleID)
+        logger.info("Modifying the role ${name}")
+        role.privileges = Sets.newHashSet(privileges)
+        authorizationManager.updateRole(role)
+    } catch (NoSuchRoleException e) {
+        logger.info("Creating the role ${name}")
+        List<String> roles = []
+        security.addRole(roleID, name, description, privileges, roles)
+    }
+}
+
+
+// Main execution starts here
+request = new JsonSlurper().parseText(args)
+['pip_repository_name', 'raw_repository_name', 'password', 'username'].each { param ->
+    assert request.get(param): "The ${param} parameter is required"
+}
+
+// Just name the role the same as the username for convenience
+String roleName = request.username
+// toString is needed to convert the GString to the Java String
+String pypiHostedPrivilege = "nx-repository-view-pypi-${request.pip_repository_name}-read".toString()
+String rawHostedPrivilege = "nx-repository-view-raw-${request.raw_repository_name}-read".toString()
+List<String> privileges = [pypiHostedPrivilege, rawHostedPrivilege]
+// Create a role that has read access on the new repositories.
+// This will allow a user with this role to utilize the the Python repos for this Cachito request.
+String desc = "Read access for ${request.pip_repository_name} and ${request.raw_repository_name}".toString()
+createRole(roleName, desc, privileges)
+List<String> roles = [roleName]
+// Create a user with the role above
+createUser(request.username, request.password, roles)
+
+return 'The repositories, user, and role were configured successfully'

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -2,7 +2,9 @@
 import ast
 import configparser
 import logging
+import random
 import re
+import secrets
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -1013,3 +1015,31 @@ def prepare_nexus_for_pip_request(pip_repo_name, raw_repo_name):
     except NexusScriptError:
         log.exception("Failed to execute the script %s", script_name)
         raise CachitoError("Failed to prepare Nexus for Cachito to stage Python content")
+
+
+def finalize_nexus_for_pip_request(pip_repo_name, raw_repo_name, username):
+    """
+    Configure Nexus so that the request's Pyhton repositories are ready for consumption.
+
+    :param str pip_repo_name: the name of the pip repository for the Cachito pip request
+    :param str raw_repo_name: the name of the raw repository for the Cachito pip request
+    :param str username: the username of the user to be created for the Cachito pip request
+    :return: the password of the Nexus user that has access to the request's Python repositories
+    :rtype: str
+    :raise CachitoError: if the script execution fails
+    """
+    # Generate a 24-32 character (each byte is two hex characters) password
+    password = secrets.token_hex(random.randint(12, 16))
+    payload = {
+        "password": password,
+        "pip_repository_name": pip_repo_name,
+        "raw_repository_name": raw_repo_name,
+        "username": username,
+    }
+    script_name = "pip_after_content_staged"
+    try:
+        nexus.execute_script(script_name, payload)
+    except NexusScriptError:
+        log.exception("Failed to execute the script %s", script_name)
+        raise CachitoError("Failed to configure Nexus Python repositories for final consumption")
+    return password

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -263,6 +263,7 @@ def test_create_or_update_scripts(mock_cous):
         "js_after_content_staged",
         "js_before_content_staged",
         "js_cleanup",
+        "pip_after_content_staged",
         "pip_before_content_staged",
     }
     for call_args in mock_cous.call_args_list:

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -1630,3 +1630,32 @@ class TestNexus:
         expected = "Failed to prepare Nexus for Cachito to stage Python content"
         with pytest.raises(CachitoError, match=expected):
             pip.prepare_nexus_for_pip_request(1, 1)
+
+    @mock.patch("secrets.token_hex")
+    @mock.patch("cachito.workers.pkg_managers.pip.nexus.execute_script")
+    def test_finalize_nexus_for_pip_request(self, mock_exec_script, mock_secret):
+        """Check whether groovy srcript is called with proper args."""
+        mock_secret.return_value = "password"
+        password = pip.finalize_nexus_for_pip_request(
+            "cachito-pip-hosted-1", "cachito-pip-raw-1", "user-1"
+        )
+
+        mock_exec_script.assert_called_once_with(
+            "pip_after_content_staged",
+            {
+                "pip_repository_name": "cachito-pip-hosted-1",
+                "raw_repository_name": "cachito-pip-raw-1",
+                "username": "user-1",
+                "password": "password",
+            },
+        )
+
+        assert password == "password"
+
+    @mock.patch("cachito.workers.pkg_managers.pip.nexus.execute_script")
+    def test_finalize_nexus_for_pip_request_failed(self, mock_exec_script):
+        """Check whether proper error is raised on groovy srcript failures."""
+        mock_exec_script.side_effect = NexusScriptError()
+        expected = "Failed to configure Nexus Python repositories for final consumption"
+        with pytest.raises(CachitoError, match=expected):
+            pip.finalize_nexus_for_pip_request(1, 1, 1)


### PR DESCRIPTION
A part of supporting Python packages in Cachito, we need to configure
the temporary Nexus repositories, which will be available for a Cachito
request while assembling the bundle.

Here, we allow creating a user for a given request, who will have the
proper permissions to read from both the PyPI hosted and the raw hosted
Nexus request repositories.

Signed-off-by: Athos Ribeiro <athos@redhat.com>