### PR TITLE
Integration tests: Add a npm test with various packages

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -107,6 +107,7 @@ class DevelopmentConfig(Config):
     cachito_nexus_proxy_password = "cachito_unprivileged"
     cachito_nexus_proxy_username = "cachito_unprivileged"
     cachito_nexus_url = "http://nexus:8081"
+    cachito_npm_file_deps_allowlist = {"cachito-npm-test": ["subpackage"]}
     cachito_request_file_logs_dir = "/var/log/cachito/requests"
     cachito_sources_dir = os.path.join(ARCHIVES_VOLUME, "sources")
 

--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -103,3 +103,8 @@ run_app:
 content_manifest:
   # Package managers for testing
   pkg_managers: ["gomod", "npm"]
+various_packages:
+  npm:
+    repo: https://github.com/akhmanova/cachito-npm-test
+    ref: 2f94fe0a21f97bd7ac0d4a70b96bea3cbab1a837
+    dependencies_count: 11


### PR DESCRIPTION
Commits: 
*  Add an npm file dependency in allowlist
* Integration tests: Add an npm test with various packages

Changes: 
* Add `various_packages` in `test_env_vars.yaml`
* New test function `test_various_packages`
* `cachito_npm_file_deps_allowlist = {"cachito-npm-test": ["subpackage"]}` in `DevelopmentConfig`
