### PR TITLE
 Implement support for downloading VCS pip deps 

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -40,6 +40,7 @@ class Config(object):
     cachito_nexus_hoster_username = None
     cachito_nexus_js_hosted_repo_name = "cachito-js-hosted"
     cachito_nexus_npm_proxy_repo_url = "http://localhost:8081/repository/cachito-js/"
+    cachito_nexus_pip_raw_repo_name = "cachito-pip-raw"
     cachito_nexus_pypi_proxy_url = "http://localhost:8081/repository/cachito-pip-proxy/"
     cachito_nexus_proxy_password = None
     cachito_nexus_proxy_username = None

--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -213,3 +213,27 @@ def verify_checksum(file_path, checksum_info, chunk_size=10240):
         )
         log.error(msg)
         raise CachitoError(msg)
+
+
+def download_binary_file(url, download_path, auth=None, chunk_size=8192):
+    """
+    Download a binary file (such as a TAR archive) from a URL.
+
+    :param str url: URL for file download
+    :param (str | Path) download_path: Path to download file to
+    :param requests.auth.AuthBase auth: Authentication for the URL
+    :param int chunk_size: Chunk size param for Response.iter_content()
+    :raise CachitoError: If download failed
+    """
+    # Import this here to avoid a circular import
+    from cachito.workers.requests import requests_session
+
+    try:
+        resp = requests_session.get(url, stream=True, auth=auth)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise CachitoError(f"Could not download {url}: {e}")
+
+    with open(download_path, "wb") as f:
+        for chunk in resp.iter_content(chunk_size=chunk_size):
+            f.write(chunk)


### PR DESCRIPTION
* CLOUDBLD-2056

pip.download_dependencies() will no longer ignore VCS dependencies

The only supported VCS is Git.

After downloading from git, will upload the archive to Nexus.