### PR TITLE
Change retry parameters for requests session to handle short network issues/outages

### DIFF
--- a/cachito/workers/requests.py
+++ b/cachito/workers/requests.py
@@ -29,7 +29,7 @@ def get_requests_session(auth=False):
             session.cert = config.cachito_auth_cert
 
     retry = Retry(
-        total=3, read=3, connect=3, backoff_factor=1, status_forcelist=(500, 502, 503, 504)
+        total=5, read=5, connect=5, backoff_factor=1.3, status_forcelist=(500, 502, 503, 504)
     )
     adapter = requests.adapters.HTTPAdapter(max_retries=retry)
     session.mount("http://", adapter)


### PR DESCRIPTION
Changed: 
* backoff_factor
* connect & retry & total numbers of retries

According to backoff formula: 
```{backoff factor} * (2 ** ({number of total retries} - 1))```

How it was: 
`0, 1, 2, 4` seconds between retries, 3 retries maximum. 
Now:
`0, 1.3, 2.6, 5.2, 10.4, 20.8` seconds between retries. 4 retries maximum. 

I did not change `read` param because it is not related to the problem. 