### PR TITLE
Add pip Nexus cleanup task

### DIFF
--- a/cachito/workers/tasks/pip.py
+++ b/cachito/workers/tasks/pip.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from cachito.workers import nexus
+from cachito.workers.pkg_managers.pip import (
+    get_pypi_hosted_repo_name,
+    get_raw_hosted_repo_name,
+    get_hosted_repositories_username,
+)
+from cachito.workers.tasks.celery import app
+
+
+@app.task
+def cleanup_pip_request(request_id):
+    """Clean up the Nexus Python content for the Cachito request."""
+    payload = {
+        "pip_repository_name": get_pypi_hosted_repo_name(request_id),
+        "raw_repository_name": get_raw_hosted_repo_name(request_id),
+        "username": get_hosted_repositories_username(request_id),
+    }
+    nexus.execute_script("pip_cleanup", payload)

--- a/tests/test_workers/test_tasks/test_pip.py
+++ b/tests/test_workers/test_tasks/test_pip.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from unittest import mock
+
+from cachito.workers.tasks import pip
+
+
+@mock.patch("cachito.workers.tasks.pip.nexus.execute_script")
+def test_cleanup_pip_request(mock_exec_script):
+    pip.cleanup_pip_request(42)
+
+    expected_payload = {
+        "pip_repository_name": "cachito-pip-hosted-42",
+        "raw_repository_name": "cachito-pip-raw-42",
+        "username": "cachito-pip-42",
+    }
+    mock_exec_script.assert_called_once_with("pip_cleanup", expected_payload)


### PR DESCRIPTION
Remove temporary Nexus data for stale or failed requests that used "pip"
as a package manager.

Signed-off-by: Athos Ribeiro <athos@redhat.com>