### PR TITLE
Fix downloading VCS Pip dependencies

### DIFF
--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1554,7 +1554,7 @@ def _extract_git_info(vcs_url):
 
     Given a URL such as git+https://user:pass@host:port/namespace/repo.git@123456?foo=bar#egg=spam
     this function will extract:
-    - the "clean" URL: https://user:pass@host:port/namespace/repo.git?foo=bar#egg=spam
+    - the "clean" URL: https://user:pass@host:port/namespace/repo.git
     - the git ref: 123456
     - the host, namespace and repo: host:port, namespace, repo
 
@@ -1564,25 +1564,18 @@ def _extract_git_info(vcs_url):
     :param str vcs_url: The URL of a VCS requirement, must be valid (have git ref in path)
     :return: Dict with url, ref, host, namespace and repo keys
     """
-    url = urllib.parse.urlparse(vcs_url)
-
     # If scheme is git+protocol://, keep only protocol://
-    if url.scheme.startswith("git+"):
-        clean_scheme = url.scheme[len("git+") :]
-    else:
-        clean_scheme = url.scheme
+    # Do this before parsing URL, otherwise urllib may not extract URL params
+    if vcs_url.startswith("git+"):
+        vcs_url = vcs_url[len("git+") :]
+
+    url = urllib.parse.urlparse(vcs_url)
 
     ref = url.path[-40:]  # Take the last 40 characters (the git ref)
     clean_path = url.path[:-41]  # Drop the last 41 characters ('@' + git ref)
 
-    clean_url = urllib.parse.ParseResult(
-        scheme=clean_scheme,
-        netloc=url.netloc,
-        path=clean_path,
-        params=url.params,
-        query=url.query,
-        fragment=url.fragment,
-    )
+    # Note: despite starting with an underscore, the namedtuple._replace() method is public
+    clean_url = url._replace(path=clean_path, params="", query="", fragment="")
 
     # Assume everything up to the last '@' is user:pass. This should be kept in the
     # clean URL used for fetching, but should not be considered part of the host.

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -2521,25 +2521,38 @@ class TestDownload:
     @pytest.mark.parametrize(
         "url, nonstandard_info",  # See body of function for what is standard info
         [
-            (f"git+https://github.com/monty/python@{GIT_REF}", None),
             (
+                # Standard case
+                f"git+https://github.com/monty/python@{GIT_REF}",
+                None,
+            ),
+            (
+                # Ref should be converted to lowercase
                 f"git+https://github.com/monty/python@{GIT_REF.upper()}",
                 {"ref": GIT_REF},  # Standard but be explicit about it
             ),
             (
+                # Repo ends with .git (that is okay)
                 f"git+https://github.com/monty/python.git@{GIT_REF}",
                 {"url": "https://github.com/monty/python.git"},
             ),
-            (f"git://github.com/monty/python@{GIT_REF}", {"url": "git://github.com/monty/python"}),
             (
+                # git://
+                f"git://github.com/monty/python@{GIT_REF}",
+                {"url": "git://github.com/monty/python"},
+            ),
+            (
+                # git+git://
                 f"git+git://github.com/monty/python@{GIT_REF}",
                 {"url": "git://github.com/monty/python"},
             ),
             (
+                # No namespace
                 f"git+https://github.com/python@{GIT_REF}",
                 {"url": "https://github.com/python", "namespace": ""},
             ),
             (
+                # Namespace with more parts
                 f"git+https://github.com/monty/python/and/the/holy/grail@{GIT_REF}",
                 {
                     "url": "https://github.com/monty/python/and/the/holy/grail",
@@ -2548,14 +2561,24 @@ class TestDownload:
                 },
             ),
             (
+                # Port should be part of host
                 f"git+https://github.com:443/monty/python@{GIT_REF}",
                 {"url": "https://github.com:443/monty/python", "host": "github.com:443"},
             ),
             (
+                # Authentication should not be part of host
                 f"git+https://user:password@github.com/monty/python@{GIT_REF}",
                 {
                     "url": "https://user:password@github.com/monty/python",
                     "host": "github.com",  # Standard but be explicit about it
+                },
+            ),
+            (
+                # Params, query and fragment should be stripped
+                f"git+https://github.com/monty/python@{GIT_REF};foo=bar?bar=baz#egg=spam",
+                {
+                    # Standard but be explicit about it
+                    "url": "https://github.com/monty/python",
                 },
             ),
         ],
@@ -2564,7 +2587,7 @@ class TestDownload:
         """Test extraction of git info from VCS URL."""
         info = {
             "url": "https://github.com/monty/python",
-            "ref": f"{GIT_REF}",
+            "ref": GIT_REF,
             "namespace": "monty",
             "repo": "python",
             "host": "github.com",


### PR DESCRIPTION
The URL passed to 'git clone' must not contain any params, query or
fragment.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>