### PR TITLE
Manually set Nexus asset component file names

### DIFF
--- a/cachito/workers/nexus.py
+++ b/cachito/workers/nexus.py
@@ -344,8 +344,9 @@ def upload_asset_only_component(repo_name, repo_type, component_path, to_nexus_h
         raise ValueError(f"Type {repo_type!r} is not supported or requires additional params")
 
     params = {"repository": repo_name}
+    filename = os.path.basename(component_path)
     with open(component_path, "rb") as component:
-        payload = {f"{repo_type}.asset": component.read()}
+        payload = {f"{repo_type}.asset": (filename, component.read())}
 
     log.info("Uploading the component %r to the %r Nexus repository", component_path, repo_type)
     try:

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -486,7 +486,8 @@ def test_upload_asset_only_component(mock_requests, use_hoster):
             "cachito-js-hosted", "npm", "/path/to/rxjs-6.5.5.tgz", use_hoster
         )
 
-    assert mock_requests.post.call_args[1]["files"] == {"npm.asset": b"some tgz file"}
+    expected_asset = {"npm.asset": ("rxjs-6.5.5.tgz", b"some tgz file")}
+    assert mock_requests.post.call_args[1]["files"] == expected_asset
     assert mock_requests.post.call_args[1]["params"] == {"repository": "cachito-js-hosted"}
     assert mock_requests.post.call_args[1]["auth"].username == "cachito"
     assert mock_requests.post.call_args[1]["auth"].password == "cachito"


### PR DESCRIPTION
After [1], the file binary data is passed in a dict to the proper
component upload function. As a side effect, Requests is unable to infer
a file name with [2]. This would make the file name to be set as the
dict key carrying the binary data when uploading python assets. As a
side effect, pip would be unable to fetch contents from the hosted
python repository.

This patch sets the file names for the asset only components manually,
instead of deferring it to python requests.

[1] https://github.com/release-engineering/cachito/pull/241
[2] https://github.com/psf/requests/blob/master/requests/utils.py#L220

Signed-off-by: Athos Ribeiro <athos@redhat.com>