### PR TITLE
Sort content manifest

### DIFF
--- a/cachito/web/content_manifest.py
+++ b/cachito/web/content_manifest.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import flask
 
+from cachito.web.utils import deep_sort_icm
+
 
 class ContentManifest:
     """A content manifest associated with a Cacihto request."""
@@ -92,7 +94,7 @@ class ContentManifest:
         Generate the JSON representation of the content manifest.
 
         :return: the JSON form of the ContentManifest object
-        :rtype: dict
+        :rtype: OrderedDict
         """
         self._gopkg_data = {}
         self._gomod_data = {}
@@ -135,7 +137,7 @@ class ContentManifest:
 
         :param list image_contents: List with components for the ICM's ``image_contents`` field
         :return: a valid Image Content Manifest
-        :rtype: dict
+        :rtype: OrderedDict
         """
         icm = {
             "metadata": {
@@ -146,4 +148,4 @@ class ContentManifest:
         }
         icm["image_contents"] = image_contents or []
 
-        return icm
+        return deep_sort_icm(icm)

--- a/cachito/web/utils.py
+++ b/cachito/web/utils.py
@@ -1,5 +1,30 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+from collections import OrderedDict
+
 from flask import request, url_for
+
+
+def deep_sort_icm(orig_item):
+    """
+    Return a new element recursively sorted in ascending order.
+
+    The function for sorting image content manifests
+
+    :param orig_item: Original content manifest to be sorted
+    :return: Recursively sorted dict or list according to orig_item
+    :rtype: Any
+    """
+    if isinstance(orig_item, list):
+        sorted_item = [deep_sort_icm(item) for item in orig_item]
+        if len(sorted_item) and isinstance(sorted_item[0], OrderedDict):
+            sorted_item = sorted(sorted_item, key=lambda ordered_dict: list(ordered_dict.items()))
+    elif isinstance(orig_item, dict):
+        sorted_item = OrderedDict(
+            sorted({k: deep_sort_icm(v) for k, v in orig_item.items()}.items())
+        )
+    else:
+        sorted_item = orig_item
+    return sorted_item
 
 
 def pagination_metadata(pagination_query, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,18 +147,6 @@ def sample_pkg_lvl_pkg():
 def sample_pkg_deps():
     return [
         {
-            "name": "github.com/release-engineering/retrodep/v2/retrodep/glide",
-            "type": "go-package",
-            "replaces": None,
-            "version": "v2.1.1",
-        },
-        {
-            "name": "github.com/release-engineering/retrodep/v2/retrodep",
-            "type": "go-package",
-            "replaces": None,
-            "version": "v2.1.1",
-        },
-        {
             "name": "github.com/Masterminds/semver",
             "type": "go-package",
             "replaces": None,
@@ -176,13 +164,25 @@ def sample_pkg_deps():
             "replaces": None,
             "version": "v1.0.0",
         },
-        {"name": "gopkg.in/yaml.v2", "type": "go-package", "replaces": None, "version": "v2.2.2"},
+        {
+            "name": "github.com/release-engineering/retrodep/v2/retrodep/glide",
+            "type": "go-package",
+            "replaces": None,
+            "version": "v2.1.1",
+        },
+        {
+            "name": "github.com/release-engineering/retrodep/v2/retrodep",
+            "type": "go-package",
+            "replaces": None,
+            "version": "v2.1.1",
+        },
         {
             "name": "golang.org/x/tools/go/vcs",
             "type": "go-package",
             "replaces": None,
             "version": "v0.0.0-20190325161752-5a8dccf5b48a",
         },
+        {"name": "gopkg.in/yaml.v2", "type": "go-package", "replaces": None, "version": "v2.2.2"},
     ]
 
 

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1459,8 +1459,8 @@ def test_fetch_request_content_manifest_go(
         image_content["dependencies"].append({"purl": p})
 
     expected = {
-        "metadata": {"icm_version": 1, "icm_spec": json_schema_url, "image_layer_index": -1},
         "image_contents": [image_content],
+        "metadata": {"icm_version": 1, "icm_spec": json_schema_url, "image_layer_index": -1},
     }
 
     # emulate worker
@@ -1532,20 +1532,20 @@ def test_fetch_request_content_manifest_npm(app, client, db, auth_env, worker_au
 
     image_contents = [
         {
-            "purl": "pkg:npm/client@1.0.0",
             "dependencies": [],
+            "purl": "pkg:npm/client@1.0.0",
             "sources": [{"purl": "pkg:npm/rxjs@6.5.5"}, {"purl": "pkg:npm/safe-regex@1.1.0"}],
         },
         {
-            "purl": "pkg:npm/proxy@1.0.0",
             "dependencies": [{"purl": "pkg:npm/react@16.13.1"}],
-            "sources": [{"purl": "pkg:npm/rxjs@6.5.5"}, {"purl": "pkg:npm/react@16.13.1"}],
+            "purl": "pkg:npm/proxy@1.0.0",
+            "sources": [{"purl": "pkg:npm/react@16.13.1"}, {"purl": "pkg:npm/rxjs@6.5.5"}],
         },
     ]
 
     expected = {
-        "metadata": {"icm_version": 1, "icm_spec": json_schema_url, "image_layer_index": -1},
         "image_contents": image_contents,
+        "metadata": {"icm_version": 1, "icm_spec": json_schema_url, "image_layer_index": -1},
     }
 
     rv = client.get("/api/v1/requests/1")

--- a/tests/test_content_manifest.py
+++ b/tests/test_content_manifest.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+from collections import OrderedDict
 from unittest import mock
 
 import pytest
@@ -114,17 +115,21 @@ def test_to_json(app, package):
     assert cm.to_json() == expected
 
 
-@pytest.mark.parametrize("contents", [None, [], "foobar", 42, {"egg": "bacon"}])
+@pytest.mark.parametrize("contents", [None, [], "foobar", 42, OrderedDict({"egg": "bacon"})])
 def test_generate_icm(contents):
     cm = ContentManifest()
-    expected = {
-        "metadata": {
-            "icm_version": 1,
-            "icm_spec": ContentManifest.json_schema_url,
-            "image_layer_index": -1,
-        },
-        "image_contents": contents or [],
-    }
+    expected = OrderedDict(
+        {
+            "image_contents": contents or [],
+            "metadata": OrderedDict(
+                {
+                    "icm_spec": ContentManifest.json_schema_url,
+                    "icm_version": 1,
+                    "image_layer_index": -1,
+                }
+            ),
+        }
+    )
     assert cm.generate_icm(contents) == expected
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from collections import OrderedDict
+
+import pytest
+
+from cachito.web.utils import deep_sort_icm
+
+
+@pytest.mark.parametrize(
+    "orig_items",
+    [
+        [
+            {
+                "metadata": {"image_layer_index": -1, "icm_spec": "sample-URL", "icm_version": 1},
+                "image_contents": [
+                    {
+                        "dependencies": [
+                            {"purl": "sample-URL"},
+                            {"apurl": "sample-URL"},
+                            {"bpurl": "asample-URL"},
+                            {"bpurl": "0sample-URL"},
+                            {"apurl": "sample-URL"},
+                            {"purl": "asample-URL"},
+                        ],
+                        "purl": "sample-URL",
+                        "sources": [],
+                    },
+                    {
+                        "purl": "sample-URL",
+                        "sources": [{"purl": "sample-URL"}, {"apurl": "sample-URL"}],
+                        "adependencies": [],
+                    },
+                ],
+            }
+        ],
+    ],
+)
+def test_deep_sort_icm(orig_items):
+    expected = [
+        OrderedDict(
+            {
+                "image_contents": [
+                    OrderedDict(
+                        {
+                            "adependencies": [],
+                            "purl": "sample-URL",
+                            "sources": [
+                                OrderedDict({"apurl": "sample-URL"}),
+                                OrderedDict({"purl": "sample-URL"}),
+                            ],
+                        }
+                    ),
+                    OrderedDict(
+                        {
+                            "dependencies": [
+                                OrderedDict({"apurl": "sample-URL"}),
+                                OrderedDict({"apurl": "sample-URL"}),
+                                OrderedDict({"bpurl": "0sample-URL"}),
+                                OrderedDict({"bpurl": "asample-URL"}),
+                                OrderedDict({"purl": "asample-URL"}),
+                                OrderedDict({"purl": "sample-URL"}),
+                            ],
+                            "purl": "sample-URL",
+                            "sources": [],
+                        }
+                    ),
+                ],
+                "metadata": OrderedDict(
+                    {"icm_spec": "sample-URL", "icm_version": 1, "image_layer_index": -1}
+                ),
+            }
+        ),
+    ]
+    assert deep_sort_icm(orig_items) == expected


### PR DESCRIPTION
The list of dependencies in an Image Content Manifest file should always be sorted to make reproducibility and testing easier. For instance, one may want to check an ICM digest.

Changes:
* a new `deep_sort()` function in `cachito/web/utils.py`
* change return values for content manifest
* change related tests expected data