### PR TITLE
Change how Nexus PyPI proxy is configured.

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -40,8 +40,8 @@ class Config(object):
     cachito_nexus_hoster_username = None
     cachito_nexus_js_hosted_repo_name = "cachito-js-hosted"
     cachito_nexus_npm_proxy_repo_url = "http://localhost:8081/repository/cachito-js/"
+    cachito_nexus_pip_proxy_repo_name = "cachito-pip-proxy"
     cachito_nexus_pip_raw_repo_name = "cachito-pip-raw"
-    cachito_nexus_pypi_proxy_url = "http://localhost:8081/repository/cachito-pip-proxy/"
     cachito_nexus_proxy_password = None
     cachito_nexus_proxy_username = None
     cachito_nexus_request_repo_prefix = "cachito-"
@@ -276,7 +276,7 @@ def validate_pip_config():
     """
     validate_nexus_config()
     conf = get_worker_config()
-    for pip_config in ("cachito_nexus_pypi_proxy_url", "cachito_nexus_pip_raw_repo_name"):
+    for pip_config in ("cachito_nexus_pip_proxy_repo_name", "cachito_nexus_pip_raw_repo_name"):
         if not conf.get(pip_config):
             raise ConfigError(
                 f'The configuration "{pip_config}" must be set for this package manager'

--- a/cachito/workers/nexus.py
+++ b/cachito/workers/nexus.py
@@ -36,7 +36,7 @@ def get_nexus_hoster_credentials():
     return username, password
 
 
-def _get_nexus_hoster_url():
+def get_nexus_hoster_url():
     """
     Get the Nexus instance with the hosted repositories.
 
@@ -286,7 +286,7 @@ def search_components(**query_params):
 
     username, password = get_nexus_hoster_credentials()
     auth = requests.auth.HTTPBasicAuth(username, password)
-    url = f"{_get_nexus_hoster_url()}/service/rest/v1/search"
+    url = f"{get_nexus_hoster_url()}/service/rest/v1/search"
     # Create a copy so that the original query parameters are unaltered later on
     params = copy.deepcopy(query_params)
     config = get_worker_config()
@@ -405,7 +405,7 @@ def upload_component(params, payload, to_nexus_hoster, additional_data=None):
     config = get_worker_config()
     if to_nexus_hoster:
         username, password = get_nexus_hoster_credentials()
-        nexus_url = _get_nexus_hoster_url()
+        nexus_url = get_nexus_hoster_url()
     else:
         username = config.cachito_nexus_username
         password = config.cachito_nexus_password

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1276,11 +1276,13 @@ def download_dependencies(request_id, requirements_file):
     bundle_dir.pip_deps_dir.mkdir(parents=True, exist_ok=True)
 
     config = get_worker_config()
-    pypi_proxy_url = config.cachito_nexus_pypi_proxy_url
+    pip_proxy_repo_name = config.cachito_nexus_pip_proxy_repo_name
     pip_raw_repo_name = config.cachito_nexus_pip_raw_repo_name
 
     nexus_username, nexus_password = nexus.get_nexus_hoster_credentials()
     nexus_auth = requests.auth.HTTPBasicAuth(nexus_username, nexus_password)
+
+    pypi_proxy_url = f"{nexus.get_nexus_hoster_url()}/repository/{pip_proxy_repo_name}"
     pypi_proxy_auth = nexus_auth
 
     downloads = []

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -192,16 +192,16 @@ def test_validate_npm_config(mock_vnc, mock_gwc):
 @pytest.mark.parametrize(
     "missing_configs",
     (
-        ["cachito_nexus_pypi_proxy_url"],
+        ["cachito_nexus_pip_proxy_repo_name"],
         ["cachito_nexus_pip_raw_repo_name"],
-        ["cachito_nexus_pypi_proxy_url", "cachito_nexus_pip_raw_repo_name"],
+        ["cachito_nexus_pip_proxy_repo_name", "cachito_nexus_pip_raw_repo_name"],
         [],
     ),
 )
 @patch("cachito.workers.config.get_worker_config")
 @patch("cachito.workers.config.validate_nexus_config")
 def test_validate_pip_config(mock_vnc, mock_gwc, missing_configs):
-    configs = {"cachito_nexus_pypi_proxy_url": "foo", "cachito_nexus_pip_raw_repo_name": "bar"}
+    configs = {"cachito_nexus_pip_proxy_repo_name": "foo", "cachito_nexus_pip_raw_repo_name": "bar"}
     for conf in missing_configs:
         configs.pop(conf)
 

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -137,7 +137,7 @@ def test_get_nexus_hoster_url(mock_gwc, cachito_nexus_hoster_url, cachito_nexus_
     mock_gwc.return_value.cachito_nexus_hoster_url = cachito_nexus_hoster_url
     mock_gwc.return_value.cachito_nexus_url = cachito_nexus_url
 
-    assert nexus._get_nexus_hoster_url() == expected
+    assert nexus.get_nexus_hoster_url() == expected
 
 
 @mock.patch("cachito.workers.requests.requests_session")


### PR DESCRIPTION
There is no reason to require a full url, the repo name is more than
enough.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>