### PR TITLE
Fix function for sorting ICMs

### DIFF
--- a/cachito/web/utils.py
+++ b/cachito/web/utils.py
@@ -10,18 +10,23 @@ def deep_sort_icm(orig_item):
 
     The function for sorting image content manifests
 
+    All dicts in the content manifest will be turned into OrderedDicts with alphabetically
+    sorted keys. All lists of dicts with a "purl" key will be sorted alphabetically by the
+    "purl" value. Any other objects will be left as is.
+
     :param orig_item: Original content manifest to be sorted
     :return: Recursively sorted dict or list according to orig_item
     :rtype: Any
     """
     if isinstance(orig_item, list):
         sorted_item = [deep_sort_icm(item) for item in orig_item]
-        if len(sorted_item) and isinstance(sorted_item[0], OrderedDict):
-            sorted_item = sorted(sorted_item, key=lambda ordered_dict: list(ordered_dict.items()))
+        # If item is a list of dicts with the "purl" key, sort by the "purl" value
+        if sorted_item and isinstance(sorted_item[0], OrderedDict) and "purl" in sorted_item[0]:
+            sorted_item = sorted(sorted_item, key=lambda item: item["purl"])
     elif isinstance(orig_item, dict):
-        sorted_item = OrderedDict(
-            sorted({k: deep_sort_icm(v) for k, v in orig_item.items()}.items())
-        )
+        items = ((k, deep_sort_icm(v)) for k, v in orig_item.items())
+        # Sort items by key
+        sorted_item = OrderedDict(sorted(items, key=lambda keyval: keyval[0]))
     else:
         sorted_item = orig_item
     return sorted_item

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,20 +15,20 @@ from cachito.web.utils import deep_sort_icm
                 "image_contents": [
                     {
                         "dependencies": [
-                            {"purl": "sample-URL"},
-                            {"apurl": "sample-URL"},
-                            {"bpurl": "asample-URL"},
-                            {"bpurl": "0sample-URL"},
-                            {"apurl": "sample-URL"},
-                            {"purl": "asample-URL"},
+                            {"purl": "5sample-URL"},
+                            {"purl": "4sample-URL"},
+                            {"purl": "3sample-URL"},
+                            {"purl": "2sample-URL"},
+                            {"purl": "1sample-URL"},
+                            {"purl": "0sample-URL"},
                         ],
-                        "purl": "sample-URL",
+                        "purl": "1sample-URL",
                         "sources": [],
                     },
                     {
-                        "purl": "sample-URL",
-                        "sources": [{"purl": "sample-URL"}, {"apurl": "sample-URL"}],
-                        "adependencies": [],
+                        "dependencies": [],
+                        "purl": "0sample-URL",
+                        "sources": [{"purl": "1sample-URL"}, {"purl": "0sample-URL"}],
                     },
                 ],
             }
@@ -42,25 +42,25 @@ def test_deep_sort_icm(orig_items):
                 "image_contents": [
                     OrderedDict(
                         {
-                            "adependencies": [],
-                            "purl": "sample-URL",
+                            "dependencies": [],
+                            "purl": "0sample-URL",
                             "sources": [
-                                OrderedDict({"apurl": "sample-URL"}),
-                                OrderedDict({"purl": "sample-URL"}),
+                                OrderedDict({"purl": "0sample-URL"}),
+                                OrderedDict({"purl": "1sample-URL"}),
                             ],
                         }
                     ),
                     OrderedDict(
                         {
                             "dependencies": [
-                                OrderedDict({"apurl": "sample-URL"}),
-                                OrderedDict({"apurl": "sample-URL"}),
-                                OrderedDict({"bpurl": "0sample-URL"}),
-                                OrderedDict({"bpurl": "asample-URL"}),
-                                OrderedDict({"purl": "asample-URL"}),
-                                OrderedDict({"purl": "sample-URL"}),
+                                OrderedDict({"purl": "0sample-URL"}),
+                                OrderedDict({"purl": "1sample-URL"}),
+                                OrderedDict({"purl": "2sample-URL"}),
+                                OrderedDict({"purl": "3sample-URL"}),
+                                OrderedDict({"purl": "4sample-URL"}),
+                                OrderedDict({"purl": "5sample-URL"}),
                             ],
-                            "purl": "sample-URL",
+                            "purl": "1sample-URL",
                             "sources": [],
                         }
                     ),


### PR DESCRIPTION
In some cases, the function could fail when sorting lists of dicts.
List of dicts are sorted by the `items()` of those dicts, which may
result in comparisons such as this one:

```python
("dependencies", list_of_dicts) < ("dependencies", list_of_dicts)

TypeError: '<' not supported between instances of
'collections.OrderedDict' and 'collections.OrderedDict'
```

Instead of sorting lists of dicts by `items()`, sort by `"purl"`.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>