### PR TITLE
Revert "Change how Nexus PyPI proxy is configured."

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -40,8 +40,8 @@ class Config(object):
     cachito_nexus_hoster_username = None
     cachito_nexus_js_hosted_repo_name = "cachito-js-hosted"
     cachito_nexus_npm_proxy_repo_url = "http://localhost:8081/repository/cachito-js/"
-    cachito_nexus_pip_proxy_repo_name = "cachito-pip-proxy"
     cachito_nexus_pip_raw_repo_name = "cachito-pip-raw"
+    cachito_nexus_pypi_proxy_url = "http://localhost:8081/repository/cachito-pip-proxy/"
     cachito_nexus_proxy_password = None
     cachito_nexus_proxy_username = None
     cachito_nexus_request_repo_prefix = "cachito-"
@@ -276,7 +276,7 @@ def validate_pip_config():
     """
     validate_nexus_config()
     conf = get_worker_config()
-    for pip_config in ("cachito_nexus_pip_proxy_repo_name", "cachito_nexus_pip_raw_repo_name"):
+    for pip_config in ("cachito_nexus_pypi_proxy_url", "cachito_nexus_pip_raw_repo_name"):
         if not conf.get(pip_config):
             raise ConfigError(
                 f'The configuration "{pip_config}" must be set for this package manager'

--- a/cachito/workers/nexus.py
+++ b/cachito/workers/nexus.py
@@ -36,7 +36,7 @@ def get_nexus_hoster_credentials():
     return username, password
 
 
-def get_nexus_hoster_url():
+def _get_nexus_hoster_url():
     """
     Get the Nexus instance with the hosted repositories.
 
@@ -302,7 +302,7 @@ def search_components(in_nexus_hoster=True, **query_params):
     config = get_worker_config()
     if in_nexus_hoster:
         username, password = get_nexus_hoster_credentials()
-        nexus_url = get_nexus_hoster_url()
+        nexus_url = _get_nexus_hoster_url()
     else:
         username = config.cachito_nexus_username
         password = config.cachito_nexus_password
@@ -427,7 +427,7 @@ def upload_component(params, payload, to_nexus_hoster, additional_data=None):
     config = get_worker_config()
     if to_nexus_hoster:
         username, password = get_nexus_hoster_credentials()
-        nexus_url = get_nexus_hoster_url()
+        nexus_url = _get_nexus_hoster_url()
     else:
         username = config.cachito_nexus_username
         password = config.cachito_nexus_password

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1276,13 +1276,11 @@ def download_dependencies(request_id, requirements_file):
     bundle_dir.pip_deps_dir.mkdir(parents=True, exist_ok=True)
 
     config = get_worker_config()
-    pip_proxy_repo_name = config.cachito_nexus_pip_proxy_repo_name
+    pypi_proxy_url = config.cachito_nexus_pypi_proxy_url
     pip_raw_repo_name = config.cachito_nexus_pip_raw_repo_name
 
     nexus_username, nexus_password = nexus.get_nexus_hoster_credentials()
     nexus_auth = requests.auth.HTTPBasicAuth(nexus_username, nexus_password)
-
-    pypi_proxy_url = f"{nexus.get_nexus_hoster_url()}/repository/{pip_proxy_repo_name}"
     pypi_proxy_auth = nexus_auth
 
     downloads = []

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -192,16 +192,16 @@ def test_validate_npm_config(mock_vnc, mock_gwc):
 @pytest.mark.parametrize(
     "missing_configs",
     (
-        ["cachito_nexus_pip_proxy_repo_name"],
+        ["cachito_nexus_pypi_proxy_url"],
         ["cachito_nexus_pip_raw_repo_name"],
-        ["cachito_nexus_pip_proxy_repo_name", "cachito_nexus_pip_raw_repo_name"],
+        ["cachito_nexus_pypi_proxy_url", "cachito_nexus_pip_raw_repo_name"],
         [],
     ),
 )
 @patch("cachito.workers.config.get_worker_config")
 @patch("cachito.workers.config.validate_nexus_config")
 def test_validate_pip_config(mock_vnc, mock_gwc, missing_configs):
-    configs = {"cachito_nexus_pip_proxy_repo_name": "foo", "cachito_nexus_pip_raw_repo_name": "bar"}
+    configs = {"cachito_nexus_pypi_proxy_url": "foo", "cachito_nexus_pip_raw_repo_name": "bar"}
     for conf in missing_configs:
         configs.pop(conf)
 

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -142,7 +142,7 @@ def test_get_nexus_hoster_url(mock_gwc, cachito_nexus_hoster_url, cachito_nexus_
     mock_gwc.return_value.cachito_nexus_hoster_url = cachito_nexus_hoster_url
     mock_gwc.return_value.cachito_nexus_url = cachito_nexus_url
 
-    assert nexus.get_nexus_hoster_url() == expected
+    assert nexus._get_nexus_hoster_url() == expected
 
 
 @mock.patch("cachito.workers.requests.requests_session")

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -2945,7 +2945,6 @@ class TestDownload:
     @mock.patch("cachito.workers.pkg_managers.pip.RequestBundleDir")
     @mock.patch("cachito.workers.pkg_managers.pip.get_worker_config")
     @mock.patch("cachito.workers.pkg_managers.pip.nexus.get_nexus_hoster_credentials")
-    @mock.patch("cachito.workers.pkg_managers.pip.nexus.get_nexus_hoster_url")
     @mock.patch("cachito.workers.pkg_managers.pip._download_pypi_package")
     @mock.patch("cachito.workers.pkg_managers.pip._download_vcs_package")
     @mock.patch("cachito.workers.pkg_managers.pip._download_url_package")
@@ -2958,7 +2957,6 @@ class TestDownload:
         mock_url_download,
         mock_vcs_download,
         mock_pypi_download,
-        mock_get_nexus_url,
         mock_get_nexus_creds,
         mock_get_config,
         mock_request_bundle_dir,
@@ -3005,10 +3003,10 @@ class TestDownload:
             requirements=[pypi_req, vcs_req, url_req], options=options,
         )
 
+        proxy_url = "https://pypi-proxy.example.org"
         nexus_auth = requests.auth.HTTPBasicAuth("username", "password")
         proxy_auth = nexus_auth
 
-        proxy_repo = "cachito-pip-proxy"
         raw_repo = "cachito-pip-raw"
 
         mock_bundle_dir = MockBundleDir(tmp_path)
@@ -3040,10 +3038,9 @@ class TestDownload:
 
         mock_request_bundle_dir.return_value = mock_bundle_dir
         mock_get_config.return_value = mock.Mock(
-            cachito_nexus_pip_proxy_repo_name=proxy_repo, cachito_nexus_pip_raw_repo_name=raw_repo
+            cachito_nexus_pypi_proxy_url=proxy_url, cachito_nexus_pip_raw_repo_name=raw_repo
         )
         mock_get_nexus_creds.return_value = ("username", "password")
-        mock_get_nexus_url.return_value = "http://nexus:8081"
         mock_pypi_download.return_value = pypi_info
         mock_vcs_download.return_value = vcs_info
         mock_url_download.return_value = url_info
@@ -3062,9 +3059,7 @@ class TestDownload:
         # <check calls that must always be made>
         mock_request_bundle_dir.assert_called_once_with(1)
         mock_get_config.assert_called_once()
-        mock_pypi_download.assert_called_once_with(
-            pypi_req, pip_deps, f"http://nexus:8081/repository/{proxy_repo}", proxy_auth
-        )
+        mock_pypi_download.assert_called_once_with(pypi_req, pip_deps, proxy_url, proxy_auth)
         mock_vcs_download.assert_called_once_with(vcs_req, pip_deps, raw_repo, nexus_auth)
         mock_url_download.assert_called_once_with(
             url_req, pip_deps, raw_repo, nexus_auth, set(trusted_hosts)


### PR DESCRIPTION
This reverts commit b381abce93025094dad59dbc84b5830a97b8e73a.

There *is* a reason to use the full URL after all, which is that the
PyPI proxy may be hosted at a different URL than the other repositories
in the Nexus hoster instance.