### PR TITLE
Change downloading of PyPI packages to use /simple

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -16,6 +16,7 @@ RUN dnf -y install \
     python3-flask-sqlalchemy \
     python3-GitPython \
     python3-mod_wsgi \
+    python3-packaging \
     python3-pip \
     python3-psycopg2 \
     python3-requests \

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -12,6 +12,7 @@ RUN dnf -y install \
     npm \
     python3-celery \
     python3-GitPython \
+    python3-packaging \
     python3-pip \
     python3-requests \
     python3-requests-kerberos \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 celery<5
 gitpython
 kombu<5 # A celery dependency but it's directly imported
+packaging
 requests_kerberos
 requests
 semver


### PR DESCRIPTION
* CLOUDBLD-2613

The `/pypi/<project>/<version>/json` endpoint is not supported by newer
versions of Nexus. Use `/simple/<project>` instead.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>