### PR TITLE
Point PIP_INDEX_URL to the simple repository API

### DIFF
--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1967,7 +1967,9 @@ def get_index_url(nexus_pypi_hosted_repo_url, username, password):
             f"Nexus PyPI hosted repo URL: {nexus_pypi_hosted_repo_url} is not a valid URL"
         )
 
-    return index_url
+    # Append endpoint for the simple repository API
+    simple_api_url = f'{index_url.rstrip("/")}/simple'
+    return simple_api_url
 
 
 def _download_from_requirement_files(request_id, files):

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -3369,9 +3369,7 @@ def test_get_hosted_repositories_username():
 
 
 def test_get_index_url():
-    index_url = pip.get_index_url(
-        "https://repository/cachito-pip-hosted-5/simple", "admin", "admin123",
-    )
+    index_url = pip.get_index_url("https://repository/cachito-pip-hosted-5/", "admin", "admin123")
 
     expected = "https://admin:admin123@repository/cachito-pip-hosted-5/simple"
 
@@ -3379,12 +3377,10 @@ def test_get_index_url():
 
 
 def test_get_index_url_invalid_url():
-    expected = (
-        "Nexus PyPI hosted repo URL: repository/cachito-pip-hosted-5/simple is not a valid URL"
-    )
+    expected = "Nexus PyPI hosted repo URL: repository/cachito-pip-hosted-5/ is not a valid URL"
     with pytest.raises(CachitoError, match=expected):
         pip.get_index_url(
-            "repository/cachito-pip-hosted-5/simple", "admin", "admin123",
+            "repository/cachito-pip-hosted-5/", "admin", "admin123",
         )
 
 

--- a/tests/test_workers/test_tasks/test_pip.py
+++ b/tests/test_workers/test_tasks/test_pip.py
@@ -61,7 +61,10 @@ def test_fetch_pip_source(
     nexus_url = config.cachito_nexus_url
     index_base_url = nexus_url.replace("://", f"://{username}:{password}@")
     env_vars = {
-        "PIP_INDEX_URL": {"value": f"{index_base_url}/repository/{repo_name}/", "kind": "literal"}
+        "PIP_INDEX_URL": {
+            "value": f"{index_base_url}/repository/{repo_name}/simple",
+            "kind": "literal",
+        }
     }
     mock_cert.return_value = None
     cert_contents = "stub_cert"


### PR DESCRIPTION
With this, no changes to the environment variable value will be needed
in the OSBS side: using pip will work out of the box to fetch
dependencies from the PyPI hosted temporary repository.

Signed-off-by: Athos Ribeiro <athos@redhat.com>