### PR TITLE
Integration tests: add pip test with dependencies

### DIFF
--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -138,3 +138,39 @@ pip_packages:
       type: "pip"
       version: "1.0.0"
     purl: "pkg:pypi/cachito-pip-empty@1.0.0"
+  # pip package with dependencies in requirements.txt
+  # repo: The URL for the upstream git repository
+  # ref: A git reference at the given git repository
+  # expected_files: Expected source files <relative_path>: <file_URL>
+  # expected_deps_files: Expected dependencies files <relative_path>: <archive_URL>
+  # package: expected package from the Cachito response
+  # purl: PURL of the package
+  # dep_purls: PURLs if dependencies
+  with_deps:
+    repo: https://github.com/cachito-testing/cachito-pip-with-deps.git
+    ref: 1f00b8a6382ab4842c0299b28b7d69cfc1cbf77d
+    expected_files:
+      setup.cfg: https://raw.githubusercontent.com/cachito-testing/cachito-pip-with-deps/master/setup.cfg
+      requirements.txt: https://raw.githubusercontent.com/cachito-testing/cachito-pip-with-deps/master/requirements.txt
+    expected_deps_files:
+      pip/aiowsgi/aiowsgi-0.7.tar.gz: https://github.com/gawel/aiowsgi/archive/0.7.tar.gz
+      pip/external-appr/appr-external-sha256-ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c.zip: https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip
+    package:
+      dependencies:
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c
+      - dev: false
+        name: "aiowsgi"
+        replaces: null
+        type: "pip"
+        version: "0.7"
+      name: "cachito-pip-with-deps"
+      type: "pip"
+      version: "1.0.0"
+    purl: "pkg:pypi/cachito-pip-with-deps@1.0.0"
+    dep_purls:
+    - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+    - "pkg:pypi/aiowsgi@0.7"

--- a/tests/integration/test_pip_packages.py
+++ b/tests/integration/test_pip_packages.py
@@ -77,12 +77,13 @@ def assert_packages_from_response(response_data, expected_packages):
         assert expected_pkg in packages
 
 
-def assert_expected_files(source_path, expected_file_urls=None):
+def assert_expected_files(source_path, expected_file_urls=None, check_content=True):
     """
     Check that the source path includes expected files.
 
     :param str source_path: local path for checking
     :param dict expected_file_urls: {"relative_path/file_name": "URL", ...}
+    :param bool check_content: The flag to check content of files
     """
     if expected_file_urls is None:
         expected_file_urls = {}
@@ -99,7 +100,10 @@ def assert_expected_files(source_path, expected_file_urls=None):
             expected_file = requests.get(file_url).content
             # Assert that content of source file is equal to expected
             with open(absolute_file_path, "rb") as f:
-                assert f.read() == expected_file
+                if check_content:
+                    assert f.read() == expected_file
+                else:
+                    assert f.read()
             files.append(relative_file_path)
 
     # Assert that there are no missing or extra files

--- a/tests/integration/test_pip_packages.py
+++ b/tests/integration/test_pip_packages.py
@@ -64,6 +64,66 @@ def test_pip_package_without_deps(test_env, tmpdir):
     assert_pip_content_manifest(client, completed_response.id, image_contents)
 
 
+def test_pip_package_with_deps(test_env, tmpdir):
+    """
+    Validate data in the pip package request with dependencies.
+
+    Process:
+    Send new request to the Cachito API
+    Send request to check status of existing request
+
+    Checks:
+    * Check that the request completes successfully
+    * Check that a single pip package is identified in response
+    * Check response parameters of the package
+    * Check that the source tarball includes the application source code
+    * Check that the source tarball includes non-empty files in deps/pip directory
+    * Check: The content manifest is successfully generated and contains correct content
+    """
+    client = Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
+    repo = test_env["pip_packages"]["with_deps"]["repo"]
+    ref = test_env["pip_packages"]["with_deps"]["ref"]
+    pkg_managers = ["pip"]
+    initial_response = client.create_new_request(
+        payload={
+            "repo": repo,
+            "ref": ref,
+            "pkg_managers": pkg_managers,
+            # TODO: delete pip-dev-preview flag when
+            #  the pip package manager will be ready for production usage
+            "flags": ["pip-dev-preview"],
+        },
+    )
+    completed_response = client.wait_for_complete_request(initial_response)
+    assert completed_response.status == 200
+
+    expected_package_params = [test_env["pip_packages"]["with_deps"]["package"]]
+    assert_packages_from_response(completed_response.data, expected_package_params)
+
+    # Download and extract source tarball
+    source_name = tmpdir.join(f"download_{str(completed_response.id)}")
+    file_name_tar = tmpdir.join(f"download_{str(completed_response.id)}.tar.gz")
+    resp = client.download_bundle(completed_response.id, file_name_tar)
+    assert resp.status == 200
+    assert tarfile.is_tarfile(file_name_tar)
+    with tarfile.open(file_name_tar, "r:gz") as tar:
+        tar.extractall(source_name)
+
+    expected_file_urls = test_env["pip_packages"]["with_deps"]["expected_files"]
+    # Check that the source tarball includes the application source code under the app directory.
+    assert_expected_files(path.join(source_name, "app"), expected_file_urls)
+    expected_deps_file_urls = test_env["pip_packages"]["with_deps"]["expected_deps_files"]
+    # Check that the source tarball includes an empty deps directory.
+    assert_expected_files(
+        path.join(source_name, "deps"), expected_deps_file_urls, check_content=False
+    )
+
+    purl = test_env["pip_packages"]["with_deps"]["purl"]
+    deps_purls = [{"purl": x} for x in test_env["pip_packages"]["with_deps"]["dep_purls"]]
+    image_contents = [{"dependencies": deps_purls, "purl": purl, "sources": deps_purls}]
+    assert_pip_content_manifest(client, completed_response.id, image_contents)
+
+
 def assert_packages_from_response(response_data, expected_packages):
     """
     Check amount and params of packages in the response data.


### PR DESCRIPTION
There is a new pip integration test with dependencies based on a requerements.txt file. 

The only one problem: I was not able to add VCS project URL dependency. (https://github.com/cachito-testing/cachito-pip-with-deps.git). Because I am not sure how to get a right hash of it (hash is mandatory for requerements.txt)