### PR TITLE
Pip integration tests with deps

### DIFF
--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -138,3 +138,46 @@ pip_packages:
       type: "pip"
       version: "1.0.0"
     purl: "pkg:pypi/cachito-pip-empty@1.0.0"
+  # pip package with dependencies in requirements.txt
+  # repo: The URL for the upstream git repository
+  # ref: A git reference at the given git repository
+  # expected_files: Expected source files <relative_path>: <file_URL>
+  # expected_deps_files: Expected dependencies files <relative_path>: <archive_URL>
+  # package: expected package from the Cachito response
+  # purl: PURL of the package
+  # dep_purls: PURLs if dependencies
+  with_deps:
+    repo: https://github.com/cachito-testing/cachito-pip-with-deps.git
+    ref: a9221b7db5da4261b06ca34f76c20d8b53e9ee1d
+    expected_files:
+      setup.cfg: https://raw.githubusercontent.com/cachito-testing/cachito-pip-with-deps/master/setup.cfg
+      requirements.txt: https://raw.githubusercontent.com/cachito-testing/cachito-pip-with-deps/master/requirements.txt
+    expected_deps_files:
+      pip/aiowsgi/aiowsgi-0.7.tar.gz: "https://github.com/gawel/aiowsgi/archive/0.7.tar.gz"
+      pip/external-appr/appr-external-sha256-ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c.zip: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip"
+      pip/github.com/quay/appr/appr-external-gitcommit-58c88e4952e95935c0dd72d4a24b0c44f2249f5b.tar.gz: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+    package:
+      dependencies:
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a85.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+      - dev: false
+        name: "aiowsgi"
+        replaces: null
+        type: "pip"
+        version: "0.7"
+      name: "cachito-pip-with-deps"
+      type: "pip"
+      version: "1.0.0"
+    purl: "pkg:pypi/cachito-pip-with-deps@1.0.0"
+    dep_purls:
+    - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a85.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+    - "pkg:generic/appr?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fquay%2Fappr.git%4058c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+    - "pkg:pypi/aiowsgi@0.7"

--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -124,6 +124,7 @@ pip_packages:
   # repo: The URL for the upstream git repository
   # ref: A git reference at the given git repository
   # expected_files: Expected source files <relative_path>: <file_URL>
+  # dependencies: expected dependencies from the Cachito response
   # package: expected package from the Cachito response
   # purl: PURL of the package
   without_deps:
@@ -132,6 +133,7 @@ pip_packages:
     expected_files:
       setup.cfg: https://raw.githubusercontent.com/cachito-testing/cachito-pip-without-deps/master/setup.cfg
       setup.py: https://raw.githubusercontent.com/cachito-testing/cachito-pip-without-deps/master/setup.py
+    dependencies: []
     package:
       dependencies: []
       name: "cachito-pip-empty"
@@ -143,6 +145,7 @@ pip_packages:
   # ref: A git reference at the given git repository
   # expected_files: Expected source files <relative_path>: <file_URL>
   # expected_deps_files: Expected dependencies files <relative_path>: <archive_URL>
+  # dependencies: expected dependencies from the Cachito response
   # package: expected package from the Cachito response
   # purl: PURL of the package
   # dep_purls: PURLs if dependencies
@@ -156,6 +159,22 @@ pip_packages:
       pip/aiowsgi/aiowsgi-0.7.tar.gz: "https://github.com/gawel/aiowsgi/archive/0.7.tar.gz"
       pip/external-appr/appr-external-sha256-ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c.zip: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip"
       pip/github.com/quay/appr/appr-external-gitcommit-58c88e4952e95935c0dd72d4a24b0c44f2249f5b.tar.gz: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+    dependencies:
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a85.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+      - dev: false
+        name: "aiowsgi"
+        replaces: null
+        type: "pip"
+        version: "0.7"
     package:
       dependencies:
       - dev: false

--- a/tests/integration/test_pip_packages.py
+++ b/tests/integration/test_pip_packages.py
@@ -19,6 +19,7 @@ def test_all_pip_packages(env_name, test_env, tmpdir):
     Checks:
     * Check that the request completes successfully
     * Check that expected pip packages are identified in response
+    * Check that expected pip dependencies are identified in response
     * Check response parameters of the package
     * Check that the source tarball includes the application source code
     * Check that the source tarball includes expected deps/pip directory
@@ -42,7 +43,9 @@ def test_all_pip_packages(env_name, test_env, tmpdir):
     assert completed_response.data["state_reason"] == "Completed successfully"
 
     expected_package_params = [env_data["package"]]
-    utils.assert_packages_from_response(completed_response.data, expected_package_params)
+    utils.assert_element_from_response(completed_response.data, expected_package_params, "packages")
+    expected_deps = env_data["dependencies"]
+    utils.assert_element_from_response(completed_response.data, expected_deps, "dependencies")
 
     # Download and extract source tarball
     source_name = tmpdir.join(f"download_{str(completed_response.id)}")

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -216,12 +216,13 @@ def assert_packages_from_response(response_data, expected_packages):
         assert expected_pkg in packages
 
 
-def assert_expected_files(source_path, expected_file_urls=None):
+def assert_expected_files(source_path, expected_file_urls=None, check_content=True):
     """
     Check that the source path includes expected files.
 
     :param str source_path: local path for checking
     :param dict expected_file_urls: {"relative_path/file_name": "URL", ...}
+    :param bool check_content: The flag to check content of files
     """
     if expected_file_urls is None:
         expected_file_urls = {}
@@ -233,12 +234,15 @@ def assert_expected_files(source_path, expected_file_urls=None):
             # Get path to file in the project
             absolute_file_path = os.path.join(root, file_name)
             relative_file_path = os.path.relpath(absolute_file_path, start=source_path)
-            file_url = expected_file_urls[relative_file_path]
-            # Download expected file
-            expected_file = requests.get(file_url).content
             # Assert that content of source file is equal to expected
             with open(absolute_file_path, "rb") as f:
-                assert f.read() == expected_file
+                if check_content:
+                    # Download expected file
+                    file_url = expected_file_urls[relative_file_path]
+                    expected_file = requests.get(file_url).content
+                    assert f.read() == expected_file
+                else:
+                    assert f.read()
             files.append(relative_file_path)
 
     # Assert that there are no missing or extra files

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -203,17 +203,24 @@ def assert_content_manifest_schema(response_data):
     assert validate_json(schema, response_data)
 
 
-def assert_packages_from_response(response_data, expected_packages):
+def assert_element_from_response(response_data, expected_element, element_name):
     """
-    Check amount and params of packages in the response data.
+    Check element from the response data.
+
+    In case the expected element is a list, every element in the list will be checked
+    (otherwise only equality between expected_element and element from response).
 
     :param dict response_data: response data from the Cachito request
-    :param list expected_packages: expected params of packages
+    :param expected_element: expected content of particular element in response
+    :param str element_name: name of the element (ex. "dependencies", "packages")
     """
-    packages = response_data["packages"]
-    assert len(packages) == len(expected_packages)
-    for expected_pkg in expected_packages:
-        assert expected_pkg in packages
+    response_element = response_data[element_name]
+    if isinstance(response_element, list):
+        assert len(response_element) == len(expected_element)
+        for e in expected_element:
+            assert e in response_element
+    else:
+        assert response_element == expected_element
 
 
 def assert_expected_files(source_path, expected_file_urls=None, check_content=True):


### PR DESCRIPTION
Sorry guys, I closed the previous pull request. https://github.com/release-engineering/cachito/pull/282
 @ejegrova and me, we needed to move all assertions to utils.py to reuse them one more time. 

Changes: 
* Both pip tests (without deps, with deps) are located in the same test function right now with pytest parameters.
* All changes in `assert_expected_files` have additional info in the commit message. 
* Added git dep and changed dependencies in https://github.com/cachito-testing/cachito-pip-with-deps.git