### PR TITLE
WIP: Clone submodules to make them part of the tarball

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -214,7 +214,9 @@ def create_request():
     # Chain tasks
     error_callback = tasks.failed_request_callback.s(request.id)
     chain_tasks = [
-        tasks.fetch_app_source.s(request.repo, request.ref, request.id).on_error(error_callback)
+        tasks.fetch_app_source.s(
+            request.repo, request.ref, request.id, "git-submodule" in pkg_manager_names
+        ).on_error(error_callback)
     ]
 
     pkg_manager_to_dep_replacements = {}

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -35,7 +35,7 @@ class DevelopmentConfig(Config):
 
     CACHITO_BUNDLES_DIR = os.path.join(tempfile.gettempdir(), "cachito-archives", "bundles")
     CACHITO_LOG_LEVEL = "DEBUG"
-    CACHITO_PACKAGE_MANAGERS = ["gomod", "npm", "pip"]
+    CACHITO_PACKAGE_MANAGERS = ["gomod", "npm", "pip", "git-submodule"]
     CACHITO_REQUEST_FILE_LOGS_DIR = "/var/log/cachito/requests"
     SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://cachito:cachito@db:5432/cachito"
     SQLALCHEMY_TRACK_MODIFICATIONS = True

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1667,7 +1667,7 @@ def _download_vcs_package(requirement, pip_deps_dir, pip_raw_repo_name, nexus_au
     if not have_raw_component:
         log.debug("Raw component not found, will fetch from git")
         repo = Git(git_info["url"], ref)
-        repo.fetch_source()
+        repo.fetch_source(gitsubmodule=False)
         # Copy downloaded archive to expected download path
         shutil.copy(repo.sources_dir.archive_path, download_path)
 

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -22,20 +22,21 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def fetch_app_source(url, ref, request_id):
+def fetch_app_source(url, ref, request_id, gitsubmodule=False):
     """
     Fetch the application source code that was requested and put it in long-term storage.
 
     :param str url: the source control URL to pull the source from
     :param str ref: the source control reference
     :param int request_id: the Cachito request ID this is for
+    :param bool gitsubmodule: a bool to determine whether git submodules need to be processed.
     """
     log.info('Fetching the source from "%s" at reference "%s"', url, ref)
     set_request_state(request_id, "in_progress", "Fetching the application source")
     try:
         # Default to Git for now
         scm = Git(url, ref)
-        scm.fetch_source()
+        scm.fetch_source(gitsubmodule)
     except requests.Timeout:
         raise CachitoError("The connection timed out while downloading the source")
     except CachitoError:

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -109,6 +109,7 @@ def test_create_and_fetch_request(
             "https://github.com/release-engineering/retrodep.git",
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
+            False,
         ).on_error(error_callback)
     ]
     if "gomod" in expected_pkg_managers:
@@ -155,6 +156,7 @@ def test_create_and_fetch_request_npm_package_configs(
             "https://github.com/release-engineering/web-terminal.git",
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
+            False,
         ).on_error(error_callback),
         fetch_npm_source.si(1, package_value["npm"]).on_error(error_callback),
         create_bundle_archive.si(1).on_error(error_callback),
@@ -196,6 +198,7 @@ def test_create_and_fetch_request_pip_package_configs(
             "https://github.com/release-engineering/web-terminal.git",
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
+            False,
         ).on_error(error_callback),
         fetch_pip_source.si(1, package_value["pip"]).on_error(error_callback),
         create_bundle_archive.si(1).on_error(error_callback),
@@ -246,6 +249,7 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
                 "https://github.com/release-engineering/retrodep.git",
                 "c50b93a32df1c9d700e3e80996845bc2e13be848",
                 1,
+                False,
             ).on_error(error_callback),
             fetch_gomod_source.si(1, []).on_error(error_callback),
             create_bundle_archive.si(1).on_error(error_callback),
@@ -1845,6 +1849,7 @@ def test_create_and_fetch_request_with_pip_preview(
                     "https://github.com/release-engineering/retrodep.git",
                     "c50b93a32df1c9d700e3e80996845bc2e13be848",
                     1,
+                    False,
                 ).on_error(error_callback),
                 fetch_pip_source.si(1, {}).on_error(error_callback),
                 create_bundle_archive.si(1).on_error(error_callback),

--- a/tests/test_workers/test_scm.py
+++ b/tests/test_workers/test_scm.py
@@ -12,6 +12,8 @@ from cachito.errors import CachitoError
 url = "https://github.com/release-engineering/retrodep.git"
 ref = "c50b93a32df1c9d700e3e80996845bc2e13be848"
 archive_path = f"/tmp/cachito-archives/release-engineering/retrodep/{ref}.tar.gz"
+scm_git = scm.Git(url, ref)
+scm_git_submodule = scm.Git(url, f"{ref}-with-submodule")
 
 
 def test_repo_name():
@@ -22,7 +24,8 @@ def test_repo_name():
 @mock.patch("tarfile.open")
 @mock.patch("tempfile.TemporaryDirectory")
 @mock.patch("git.repo.Repo.clone_from")
-def test_clone_and_archive(mock_clone, mock_temp_dir, mock_tarfile_open):
+@mock.patch("cachito.workers.scm.Git.process_git_submodule")
+def test_clone_and_archive(mock_pgs, mock_clone, mock_temp_dir, mock_tarfile_open):
     # Mock the archive being created
     mock_tarfile = mock.Mock()
     mock_tarfile_open.return_value.__enter__.return_value = mock_tarfile
@@ -31,11 +34,14 @@ def test_clone_and_archive(mock_clone, mock_temp_dir, mock_tarfile_open):
     mock_clone.return_value.commit.return_value = mock_commit
     # Mock the tempfile.TemporaryDirectory context manager
     mock_temp_dir.return_value.__enter__.return_value = "/tmp/cachito-temp"
+    # Mock the submodules being returned from repo.submodules
+    submodules = {"fake-submodule-1", "fake-submodule-2"}
+    mock_clone.return_value.submodules = submodules
 
     git_obj = scm.Git(url, ref)
 
     with mock.patch.object(git_obj.sources_dir, "archive_path", new=archive_path):
-        git_obj.clone_and_archive()
+        git_obj.clone_and_archive(True)
 
     # Verify the tempfile.TemporaryDirectory context manager was used
     mock_temp_dir.return_value.__enter__.assert_called_once()
@@ -47,6 +53,11 @@ def test_clone_and_archive(mock_clone, mock_temp_dir, mock_tarfile_open):
     mock_clone.return_value.head.reset.assert_called_once_with(index=True, working_tree=True)
     # Verfiy the archive was created
     mock_tarfile.add.assert_called_once_with(mock_clone.return_value.working_dir, "app")
+    # Verify the process_git_submodule has correct calls
+    assert mock_pgs.call_count == 2
+    mock_pgs.assert_has_calls(
+        [mock.call("fake-submodule-1"), mock.call("fake-submodule-2")], any_order=True
+    )
 
 
 @mock.patch("tempfile.TemporaryDirectory")
@@ -59,7 +70,7 @@ def test_clone_and_archive_clone_failed(mock_git_clone, mock_temp_dir):
 
     git_obj = scm.Git(url, ref)
     with pytest.raises(CachitoError, match="Cloning the Git repository failed"):
-        git_obj.clone_and_archive()
+        git_obj.clone_and_archive(False)
 
 
 @mock.patch("tempfile.TemporaryDirectory")
@@ -77,7 +88,7 @@ def test_clone_and_archive_checkout_failed(mock_git_clone, mock_temp_dir):
     )
     with mock.patch.object(git_obj.sources_dir, "archive_path", new=archive_path):
         with pytest.raises(CachitoError, match=expected):
-            git_obj.clone_and_archive()
+            git_obj.clone_and_archive(False)
 
 
 @mock.patch("tarfile.is_tarfile", return_value=True)
@@ -87,7 +98,7 @@ def test_fetch_source_archive_exists(mock_is_tarfile):
     po = mock.patch.object
     with po(scm_git.sources_dir.archive_path, "exists", return_value=True):
         with po(scm_git.sources_dir.package_dir, "glob") as glob:
-            scm_git.fetch_source()
+            scm_git.fetch_source(False)
             glob.assert_not_called()
 
 
@@ -98,7 +109,7 @@ def test_fetch_source_clone_if_no_archive_yet(mock_clone_and_archive):
     po = mock.patch.object
     with po(scm_git.sources_dir.archive_path, "exists", return_value=False):
         with po(scm_git.sources_dir.package_dir, "glob", return_value=[]):
-            scm_git.fetch_source()
+            scm_git.fetch_source(False)
 
     mock_clone_and_archive.assert_called_once()
 
@@ -112,15 +123,29 @@ def test_fetch_source_by_pull(mock_update_and_archive, mock_getctime):
     ]
 
     scm_git = scm.Git(url, ref)
-
     po = mock.patch.object
     with po(scm_git.sources_dir.archive_path, "exists", return_value=False):
         with po(
-            scm_git.sources_dir.package_dir, "glob", return_value=["29eh2a.tar.gz", "a8c2d2.tar.gz"]
+            scm_git.sources_dir.package_dir,
+            "glob",
+            return_value=["a8c2d2.tar.gz", "a8c2d2-with-submodule.tar.gz"],
         ):
-            scm_git.fetch_source()
+            scm_git.fetch_source(False)
 
-    mock_update_and_archive.assert_called_once_with("a8c2d2.tar.gz")
+    mock_update_and_archive.assert_called_once_with("a8c2d2.tar.gz", False)
+
+
+@mock.patch("cachito.workers.scm.Git.clone_and_archive")
+@mock.patch("cachito.workers.scm.SourcesDir")
+def test_fetch_source_by_pull_gitsubmodule_true(mock_scr, mock_clone_and_archive):
+    mock_scr.return_value = scm_git_submodule.sources_dir
+    scm_git.fetch_source(True)
+
+    po = mock.patch.object
+    with po(scm_git_submodule.sources_dir.archive_path, "exists", return_value=False):
+        scm_git_submodule.fetch_source(True)
+
+    mock_clone_and_archive.assert_called_once_with(True)
 
 
 @pytest.mark.parametrize("all_corrupt", [True, False])
@@ -148,10 +173,10 @@ def test_fetch_source_by_pull_corrupt_archive(
         with po(
             scm_git.sources_dir.package_dir, "glob", return_value=["29eh2a.tar.gz", "a8c2d2.tar.gz"]
         ):
-            scm_git.fetch_source()
+            scm_git.fetch_source(False)
 
     assert mock_update_and_archive.call_count == 2
-    calls = [mock.call("a8c2d2.tar.gz"), mock.call("29eh2a.tar.gz")]
+    calls = [mock.call("a8c2d2.tar.gz", False), mock.call("29eh2a.tar.gz", False)]
     mock_update_and_archive.assert_has_calls(calls)
     if all_corrupt:
         mock_clone_and_archive.assert_called_once()
@@ -171,7 +196,7 @@ def test_update_and_archive(mock_repo, mock_temp_dir, mock_tarfile_open):
     mock_temp_dir.return_value.__enter__.return_value = "/tmp/cachito-temp"
 
     # Test does not really extract this archive file. The filename could be arbitrary.
-    scm.Git(url, ref).update_and_archive("/tmp/1234567.tar.gz")
+    scm.Git(url, ref).update_and_archive("/tmp/1234567.tar.gz", True)
 
     # Verify the tempfile.TemporaryDirectory context manager was used
     mock_temp_dir.return_value.__enter__.assert_called_once()
@@ -194,4 +219,41 @@ def test_update_and_archive_pull_error(mock_repo, mock_tarfile_open):
     repo.remote.return_value.fetch.side_effect = OSError
 
     with pytest.raises(CachitoError, match="Failed to fetch from the remote Git repository"):
-        scm.Git(url, ref).update_and_archive("/tmp/1234567.tar.gz")
+        scm.Git(url, ref).update_and_archive("/tmp/1234567.tar.gz", False)
+
+
+@mock.patch("git.repo.Repo.clone_from")
+def test_process_git_submodule(mock_clone):
+    # Mock the commit being returned from repo.commit(self.ref)
+    mock_commit = mock.Mock()
+    mock_clone.return_value.commit.return_value = mock_commit
+
+    git_obj = scm.Git(url, ref)
+
+    submodule = mock.Mock()
+    submodule.url = "fake-url"
+    submodule.abspath = "/tmp/cachito-temp/repo/submodule_path"
+    submodule.hexsha = "#abc123"
+
+    with mock.patch.object(git_obj.sources_dir, "archive_path", new=archive_path):
+        git_obj.process_git_submodule(submodule)
+
+    # Verify the repo was cloned and checked out properly
+    mock_clone.assert_called_once_with(
+        "fake-url",
+        "/tmp/cachito-temp/repo/submodule_path",
+        no_checkout=True,
+        env={"GIT_TERMINAL_PROMPT": "0"},
+    )
+    assert mock_clone.return_value.head.reference == mock_commit
+    mock_clone.return_value.head.reset.assert_called_once_with(index=True, working_tree=True)
+
+
+@mock.patch("git.repo.Repo.clone_from")
+def test_process_git_submodule_failed(mock_git_clone):
+    # Mock the git clone call
+    mock_git_clone.side_effect = git.GitCommandError("some error", 1)
+
+    git_obj = scm.Git(url, ref)
+    with pytest.raises(CachitoError, match="Cloning the Git repository failed"):
+        git_obj.process_git_submodule(True)

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -18,7 +18,7 @@ def test_fetch_app_source(mock_set_request_state, fake_repo):
     request_id = 1
 
     repo_dir, repo_name = fake_repo
-    tasks.fetch_app_source(f"file://{repo_dir}", "master", request_id)
+    tasks.fetch_app_source(f"file://{repo_dir}", "master", request_id, False)
 
     # Verify the archive file is created from fetched app source.
     sources_dir = SourcesDir(repo_name, "master")
@@ -37,7 +37,7 @@ def test_fetch_app_source_request_timed_out(mock_git, mock_set_request_state):
     ref = "c50b93a32df1c9d700e3e80996845bc2e13be848"
     mock_git.return_value.fetch_source.side_effect = Timeout("The request timed out")
     with pytest.raises(CachitoError, match="The connection timed out while downloading the source"):
-        tasks.fetch_app_source(url, ref, 1)
+        tasks.fetch_app_source(url, ref, 1, False)
 
 
 @mock.patch("cachito.workers.requests.requests_auth_session")


### PR DESCRIPTION
If `git-submodule` is passed in the pkg_managers list for the Cachito request, the git submodules within the requested repo will be cloned into it's respective location