### PR TITLE
Clone submodules to make them part of the archive

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -213,7 +213,9 @@ def create_request():
     # Chain tasks
     error_callback = tasks.failed_request_callback.s(request.id)
     chain_tasks = [
-        tasks.fetch_app_source.s(request.repo, request.ref, request.id).on_error(error_callback)
+        tasks.fetch_app_source.s(
+            request.repo, request.ref, request.id, "git-submodule" in pkg_manager_names
+        ).on_error(error_callback)
     ]
 
     pkg_manager_to_dep_replacements = {}

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -35,7 +35,7 @@ class DevelopmentConfig(Config):
 
     CACHITO_BUNDLES_DIR = os.path.join(tempfile.gettempdir(), "cachito-archives", "bundles")
     CACHITO_LOG_LEVEL = "DEBUG"
-    CACHITO_PACKAGE_MANAGERS = ["gomod", "npm", "pip"]
+    CACHITO_PACKAGE_MANAGERS = ["gomod", "npm", "pip", "git-submodule"]
     CACHITO_REQUEST_FILE_LOGS_DIR = "/var/log/cachito/requests"
     SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://cachito:cachito@db:5432/cachito"
     SQLALCHEMY_TRACK_MODIFICATIONS = True

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1667,7 +1667,7 @@ def _download_vcs_package(requirement, pip_deps_dir, pip_raw_repo_name, nexus_au
     if not have_raw_component:
         log.debug("Raw component not found, will fetch from git")
         repo = Git(git_info["url"], ref)
-        repo.fetch_source()
+        repo.fetch_source(gitsubmodule=False)
         # Copy downloaded archive to expected download path
         shutil.copy(repo.sources_dir.archive_path, download_path)
 

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -22,20 +22,21 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def fetch_app_source(url, ref, request_id):
+def fetch_app_source(url, ref, request_id, gitsubmodule=False):
     """
     Fetch the application source code that was requested and put it in long-term storage.
 
     :param str url: the source control URL to pull the source from
     :param str ref: the source control reference
     :param int request_id: the Cachito request ID this is for
+    :param bool gitsubmodule: a bool to determine whether git submodules need to be processed.
     """
     log.info('Fetching the source from "%s" at reference "%s"', url, ref)
     set_request_state(request_id, "in_progress", "Fetching the application source")
     try:
         # Default to Git for now
         scm = Git(url, ref)
-        scm.fetch_source()
+        scm.fetch_source(gitsubmodule=gitsubmodule)
     except requests.Timeout:
         raise CachitoError("The connection timed out while downloading the source")
     except CachitoError:

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -2,6 +2,7 @@
 import os
 import os.path
 import pathlib
+import shutil
 import tarfile
 from unittest import mock
 
@@ -13,12 +14,13 @@ from cachito.workers import tasks
 from cachito.workers.paths import RequestBundleDir, SourcesDir
 
 
+@pytest.mark.parametrize("gitsubmodule", [True, False])
 @mock.patch("cachito.workers.tasks.general.set_request_state")
-def test_fetch_app_source(mock_set_request_state, fake_repo):
+def test_fetch_app_source(mock_set_request_state, fake_repo, gitsubmodule):
     request_id = 1
 
     repo_dir, repo_name = fake_repo
-    tasks.fetch_app_source(f"file://{repo_dir}", "master", request_id)
+    tasks.fetch_app_source(f"file://{repo_dir}", "master", request_id, gitsubmodule)
 
     # Verify the archive file is created from fetched app source.
     sources_dir = SourcesDir(repo_name, "master")
@@ -29,15 +31,19 @@ def test_fetch_app_source(mock_set_request_state, fake_repo):
     assert bundle_dir.joinpath("app", "readme.rst").exists()
     assert bundle_dir.joinpath("app", "main.py").exists()
 
+    # Clean up bundle dir after unpacking archive
+    shutil.rmtree(bundle_dir)
 
+
+@pytest.mark.parametrize("gitsubmodule", [True, False])
 @mock.patch("cachito.workers.tasks.general.set_request_state")
 @mock.patch("cachito.workers.tasks.general.Git")
-def test_fetch_app_source_request_timed_out(mock_git, mock_set_request_state):
+def test_fetch_app_source_request_timed_out(mock_git, mock_set_request_state, gitsubmodule):
     url = "https://github.com/release-engineering/retrodep.git"
     ref = "c50b93a32df1c9d700e3e80996845bc2e13be848"
     mock_git.return_value.fetch_source.side_effect = Timeout("The request timed out")
     with pytest.raises(CachitoError, match="The connection timed out while downloading the source"):
-        tasks.fetch_app_source(url, ref, 1)
+        tasks.fetch_app_source(url, ref, 1, gitsubmodule)
 
 
 @mock.patch("cachito.workers.requests.requests_auth_session")


### PR DESCRIPTION
If `git-submodule` is passed in the pkg_managers list for the Cachito request, the git submodules within the requested repo will be cloned into it's respective location