### PR TITLE
Integration tests: change pip test data.

### DIFF
--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -151,7 +151,7 @@ pip_packages:
   # dep_purls: PURLs if dependencies
   with_deps:
     repo: https://github.com/cachito-testing/cachito-pip-with-deps.git
-    ref: a9221b7db5da4261b06ca34f76c20d8b53e9ee1d
+    ref: 83b387568b6287f6829403cff1e1377b0fb2f5d8
     expected_files:
       setup.cfg: https://raw.githubusercontent.com/cachito-testing/cachito-pip-with-deps/master/setup.cfg
       requirements.txt: https://raw.githubusercontent.com/cachito-testing/cachito-pip-with-deps/master/requirements.txt
@@ -169,7 +169,7 @@ pip_packages:
         name: "appr"
         replaces: null
         type: "pip"
-        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a85.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
       - dev: false
         name: "aiowsgi"
         replaces: null
@@ -186,7 +186,7 @@ pip_packages:
         name: "appr"
         replaces: null
         type: "pip"
-        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a85.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
       - dev: false
         name: "aiowsgi"
         replaces: null
@@ -197,6 +197,6 @@ pip_packages:
       version: "1.0.0"
     purl: "pkg:pypi/cachito-pip-with-deps@1.0.0"
     dep_purls:
-    - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a85.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+    - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
     - "pkg:generic/appr?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fquay%2Fappr.git%4058c88e4952e95935c0dd72d4a24b0c44f2249f5b"
     - "pkg:pypi/aiowsgi@0.7"


### PR DESCRIPTION
There is a problem with testing pip data (wrong commit). It should be:

`https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84`
instead of: 
`https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a85`

Thank you, @athos-ribeiro for finding it! 