### PR TITLE
Integration tests: add pip local path test

### DIFF
--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1059,7 +1059,7 @@ class PipRequirement:
             else:
                 raise ValidationError(
                     f"Direct references with {direct_access_kind!r} scheme are not supported, "
-                    "{to_be_parsed!r}"
+                    f"{to_be_parsed!r}"
                 )
         else:
             requirement.kind = "pypi"

--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -200,3 +200,6 @@ pip_packages:
     - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
     - "pkg:generic/appr?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fquay%2Fappr.git%4058c88e4952e95935c0dd72d4a24b0c44f2249f5b"
     - "pkg:pypi/aiowsgi@0.7"
+  local_path:
+    repo: https://github.com/cachito-testing/cachito-pip-local-path.git
+    ref: d66f7e029a15e8dc96ced65865344e6088c3fdd5

--- a/tests/integration/test_pip_packages.py
+++ b/tests/integration/test_pip_packages.py
@@ -72,3 +72,33 @@ def test_all_pip_packages(env_name, test_env, tmpdir):
         deps_purls = []
     image_contents = [{"dependencies": deps_purls, "purl": purl, "sources": deps_purls}]
     utils.assert_content_manifest(client, completed_response.id, image_contents)
+
+
+def test_failing_pip_local_path(test_env):
+    """
+    Validate failing of the pip package request with local dependencies.
+
+    Process:
+    Send new request to the Cachito API
+    Send request to check status of existing request
+
+    Checks:
+    * Check that the request fails with expected error
+    """
+    env_data = test_env["pip_packages"]["local_path"]
+    client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
+    initial_response = client.create_new_request(
+        payload={
+            "repo": env_data["repo"],
+            "ref": env_data["ref"],
+            "pkg_managers": ["pip"],
+            # TODO: delete pip-dev-preview flag when
+            #  the pip package manager will be ready for production usage
+            "flags": ["pip-dev-preview"],
+        },
+    )
+    completed_response = client.wait_for_complete_request(initial_response)
+    assert completed_response.status == 200
+    assert completed_response.data["state"] == "failed"
+    error_msg = "Direct references with 'file' scheme are not supported"
+    assert error_msg in completed_response.data["state_reason"]


### PR DESCRIPTION
There is a new integration test for checking pip request with the local path in `requirements.txt`. 
It should fail with the expected message: 
`Direct references with 'file' scheme are not supported, {to_be_parsed!r}`

P.S.: I just not sure that we need `{to_be_parsed!r}`. Was it expected :D? 