### PR TITLE
Integration tests: add check for pip without deps

### DIFF
--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -124,6 +124,7 @@ pip_packages:
   # repo: The URL for the upstream git repository
   # ref: A git reference at the given git repository
   # expected_files: Expected source files <relative_path>: <file_URL>
+  # expected_deps_files: Expected dependencies files (empty)
   # dependencies: expected dependencies from the Cachito response
   # package: expected package from the Cachito response
   # purl: PURL of the package
@@ -133,6 +134,7 @@ pip_packages:
     expected_files:
       setup.cfg: https://raw.githubusercontent.com/cachito-testing/cachito-pip-without-deps/master/setup.cfg
       setup.py: https://raw.githubusercontent.com/cachito-testing/cachito-pip-without-deps/master/setup.py
+    expected_deps_files: null
     dependencies: []
     package:
       dependencies: []

--- a/tests/integration/test_pip_packages.py
+++ b/tests/integration/test_pip_packages.py
@@ -59,12 +59,12 @@ def test_all_pip_packages(env_name, test_env, tmpdir):
     expected_file_urls = env_data["expected_files"]
     # Check that the source tarball includes the application source code under the app directory.
     utils.assert_expected_files(path.join(source_name, "app"), expected_file_urls)
-    if "expected_deps_files" in env_data:
-        expected_deps_file_urls = env_data["expected_deps_files"]
-        # Check that the source tarball includes an empty deps directory.
-        utils.assert_expected_files(
-            path.join(source_name, "deps"), expected_deps_file_urls, check_content=False
-        )
+
+    expected_deps_file_urls = env_data["expected_deps_files"]
+    # Check that the source tarball includes an expected files in the deps directory.
+    utils.assert_expected_files(
+        path.join(source_name, "deps"), expected_deps_file_urls, check_content=False
+    )
     purl = env_data["purl"]
     if "dep_purls" in env_data:
         deps_purls = [{"purl": x} for x in env_data["dep_purls"]]


### PR DESCRIPTION
There should be a validation of empty dependencies
directory for pip test without deps.

