### PR TITLE
Integration tests: sort Cachito response

### DIFF
--- a/tests/integration/test_pip_packages.py
+++ b/tests/integration/test_pip_packages.py
@@ -31,14 +31,18 @@ def test_all_pip_packages(env_name, test_env, tmpdir):
         payload={"repo": env_data["repo"], "ref": env_data["ref"], "pkg_managers": ["pip"]}
     )
     completed_response = client.wait_for_complete_request(initial_response)
+    response_data = completed_response.data
+    utils.sort_pkgs_and_deps_in_place(response_data["packages"], response_data["dependencies"])
+
     assert completed_response.status == 200
-    assert completed_response.data["state"] == "complete"
-    assert completed_response.data["state_reason"] == "Completed successfully"
+    assert response_data["state"] == "complete"
+    assert response_data["state_reason"] == "Completed successfully"
 
     expected_package_params = [env_data["package"]]
-    utils.assert_element_from_response(completed_response.data, expected_package_params, "packages")
     expected_deps = env_data["dependencies"]
-    utils.assert_element_from_response(completed_response.data, expected_deps, "dependencies")
+    utils.sort_pkgs_and_deps_in_place(expected_package_params, expected_deps)
+    utils.assert_element_from_response(response_data, expected_package_params, "packages")
+    utils.assert_element_from_response(response_data, expected_deps, "dependencies")
 
     # Download and extract source tarball
     source_name = tmpdir.join(f"download_{str(completed_response.id)}")

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -196,6 +196,27 @@ def make_list_of_packages_hashable(data):
     return sorted([[i["name"], i["type"], i["version"]] for i in data])
 
 
+def sort_pkgs_and_deps_in_place(packages=None, dependencies=None):
+    """
+    Sorts lists of packages and dependencies in place.
+
+    Sorting order: name -> version -> type
+
+    :param list packages: the list of packages
+    :param list dependencies: the list of dependencies
+    """
+
+    def sort_helper(elements):
+        elements.sort(key=lambda x: (x["name"], x["version"], x["type"]))
+
+    if packages:
+        sort_helper(packages)
+        for package in packages:
+            sort_helper(package["dependencies"])
+    if dependencies:
+        sort_helper(dependencies)
+
+
 def assert_content_manifest_schema(response_data):
     """Validate content manifest according with JSON schema."""
     icm_spec = response_data["metadata"]["icm_spec"]


### PR DESCRIPTION
There is a function to sort Cachito responses by dependencies, packages, and package.dependencies. 

Changes can help with testing. Because the response data doesn't guarantee dependencies order. 