### PR TITLE
Reuse functions in integration tests

### DIFF
--- a/tests/integration/test_check_downloaded_output.py
+++ b/tests/integration/test_check_downloaded_output.py
@@ -24,19 +24,11 @@ def test_check_downloaded_output(test_env, default_requests, tmpdir):
     * Check that the same full path filename is not duplicated
     """
     response = default_requests["gomod"].complete_response
-    assert response.status == 200
+    utils.assert_properly_completed_response(response)
     client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
-    assert response.data["state"] == "complete"
 
     file_name = tmpdir.join(f"download_{str(response.id)}")
-    file_name_tar = tmpdir.join(f"download_{str(response.id)}.tar.gz")
-
-    resp = client.download_bundle(response.id, file_name_tar)
-    assert resp.status == 200
-    assert tarfile.is_tarfile(file_name_tar)
-
-    with tarfile.open(file_name_tar, "r:gz") as tar:
-        tar.extractall(file_name)
+    client.download_and_extract_archive(response.id, tmpdir)
 
     pkg_managers = test_env["downloaded_output"]["pkg_managers"]
     dependencies_path = path.join("deps", "gomod", "pkg", "mod", "cache", "download")
@@ -64,6 +56,7 @@ def test_check_downloaded_output(test_env, default_requests, tmpdir):
         list_go_files.append(app_path)
     assert len(list_go_files) > 0
 
+    file_name_tar = tmpdir.join(f"download_{str(response.id)}.tar.gz")
     with tarfile.open(file_name_tar, mode="r:gz") as tar:
         members = tar.getmembers()
         path_names = set()

--- a/tests/integration/test_run_app_from_bundle.py
+++ b/tests/integration/test_run_app_from_bundle.py
@@ -3,7 +3,6 @@
 from os import path
 import shutil
 import subprocess
-import tarfile
 
 import pytest
 
@@ -27,19 +26,11 @@ def test_run_app_from_bundle(test_env, default_requests, tmpdir):
     * Check that the application runs successfully
     """
     response = default_requests["gomod"].complete_response
-    assert response.status == 200
-    assert response.data["state"] == "complete"
+    utils.assert_properly_completed_response(response)
 
-    file_name_tar = tmpdir.join(f"download_{str(response.id)}.tar.gz")
-    bundle_dir = tmpdir.mkdir(f"download_{str(response.id)}")
     client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
-    resp = client.download_bundle(response.id, file_name_tar)
-    assert resp.status == 200
-    assert tarfile.is_tarfile(file_name_tar)
-
-    with tarfile.open(file_name_tar, "r:gz") as tar:
-        tar.extractall(bundle_dir)
-
+    client.download_and_extract_archive(response.id, tmpdir)
+    bundle_dir = tmpdir.join(f"download_{str(response.id)}")
     app_name = test_env["run_app"]["app_name"]
     app_binary_file = str(tmpdir.join(app_name))
     subprocess.run(

--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -108,7 +108,7 @@ class TestCachedDependencies:
                 },
             )
             first_response = client.wait_for_complete_request(response)
-            assert first_response.data["state"] == "complete"
+            utils.assert_properly_completed_response(first_response)
             assert repo.git.branch("-a", "--contains", commit)
         finally:
             repo.git.push("--delete", remote.name, branch_name)
@@ -125,7 +125,7 @@ class TestCachedDependencies:
             },
         )
         second_response = client.wait_for_complete_request(response)
-        assert second_response.data["state"] == "complete"
+        utils.assert_properly_completed_response(second_response)
         assert first_response.data["ref"] == second_response.data["ref"]
         assert first_response.data["repo"] == second_response.data["repo"]
         assert set(first_response.data["pkg_managers"]) == set(second_response.data["pkg_managers"])

--- a/tests/integration/test_valid_data_in_request.py
+++ b/tests/integration/test_valid_data_in_request.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from utils import make_list_of_packages_hashable, Client
+import utils
 
 
 def test_valid_data_in_request(test_env, default_requests):
@@ -20,11 +20,11 @@ def test_valid_data_in_request(test_env, default_requests):
     assert response.status == 200
     assert response.data["state"] == "complete"
 
-    response_dependencies = make_list_of_packages_hashable(response.data["dependencies"])
+    response_dependencies = utils.make_list_of_packages_hashable(response.data["dependencies"])
     expected_dependencies = test_env["get"]["gomod"]["dependencies"]
     assert response_dependencies == sorted(expected_dependencies)
 
-    response_packages = make_list_of_packages_hashable(response.data["packages"])
+    response_packages = utils.make_list_of_packages_hashable(response.data["packages"])
     expected_packages = test_env["get"]["gomod"]["packages"]
     assert response_packages == sorted(expected_packages)
 
@@ -48,10 +48,9 @@ def test_npm_basic(test_env, default_requests):
         and "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": "true" are set.
     """
     response = default_requests["npm"].complete_response
-    assert response.status == 200
-    assert response.data["state"] == "complete"
+    utils.assert_properly_completed_response(response)
 
-    response_packages = make_list_of_packages_hashable(response.data["packages"])
+    response_packages = utils.make_list_of_packages_hashable(response.data["packages"])
     expected_packages = test_env["get"]["npm"]["packages"]
     assert response_packages == expected_packages
 
@@ -71,7 +70,7 @@ def test_npm_basic(test_env, default_requests):
 
 
 def test_various_packages(test_env):
-    client = Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
+    client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
     for pkg_manager, package in test_env["various_packages"].items():
         initial_response = client.create_new_request(
             payload={
@@ -81,6 +80,6 @@ def test_various_packages(test_env):
             },
         )
         completed_response = client.wait_for_complete_request(initial_response)
-        assert completed_response.status == 200
+        utils.assert_properly_completed_response(completed_response)
 
         assert len(completed_response.data["dependencies"]) == package["dependencies_count"]


### PR DESCRIPTION
Recently added functions assert_properly_completed_response and download_and_extract_archive are reused in most integration tests.