### PR TITLE
Improve log flow for corrupted cache detection

### DIFF
--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -208,7 +208,16 @@ class Git(SCM):
                 tarfile.ExtractError,
                 OSError,  # raised by tarfile when an FS operation fails
             ) as exc:
-                log.warning("Error handling archived artifact '%s': %s", previous_archive, exc)
+                log.warning(
+                    "Error handling archived artifact '%s': %s - %s",
+                    previous_archive,
+                    repr(exc),
+                    exc,
+                )
+                log.info(
+                    "Existing archive at '%s' may be corrupted and will not be used. Recovering...",
+                    previous_archive,
+                )
 
         self.clone_and_archive(gitsubmodule=gitsubmodule)
 


### PR DESCRIPTION
The error message logged when a corrupted cache is found may lead a user
to believe something went wrong with the request. This patch adds an
additional log entry to let readers know Cachito is recovering from the
issue.

Signed-off-by: Athos Ribeiro <athos@redhat.com>