### PR TITLE
Skip test_various_packages in prod

### DIFF
--- a/tests/integration/test_valid_data_in_request.py
+++ b/tests/integration/test_valid_data_in_request.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import os
+
+import pytest
+
 import utils
 
 
@@ -69,6 +73,10 @@ def test_npm_basic(test_env, default_requests):
     assert env_variables["SKIP_SASS_BINARY_DOWNLOAD_FOR_CI"] == "true"
 
 
+@pytest.mark.skipif(
+    "cachito-prod" in str(os.environ.get("JOB_NAME")),
+    reason="Test is skipped in production environment",
+)
 def test_various_packages(test_env):
     client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
     for pkg_manager, package in test_env["various_packages"].items():

--- a/tox.ini
+++ b/tox.ini
@@ -58,4 +58,4 @@ commands =
     pytest -rA -vvv \
         --confcutdir=tests/integration \
         {posargs:tests/integration}
-passenv = KRB5CCNAME REQUESTS_CA_BUNDLE KRB5_CLIENT_KTNAME CACHITO_TEST_CERT CACHITO_TEST_KEY
+passenv = KRB5CCNAME REQUESTS_CA_BUNDLE KRB5_CLIENT_KTNAME CACHITO_TEST_CERT CACHITO_TEST_KEY JOB_NAME


### PR DESCRIPTION
Test test_various_packages is using package whose subpackage is hosted in an unsupported location. Therefore this test is skipped in production environment.