### PR TITLE
Support multiple gomod packages in a single repository

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -245,9 +245,10 @@ def create_request():
 
     package_configs = payload.get("packages", {})
     if "gomod" in pkg_manager_names:
+        go_package_configs = package_configs.get("gomod", [])
         chain_tasks.append(
             tasks.fetch_gomod_source.si(
-                request.id, pkg_manager_to_dep_replacements.get("gomod", [])
+                request.id, pkg_manager_to_dep_replacements.get("gomod", []), go_package_configs
             ).on_error(error_callback)
         )
     if "npm" in pkg_manager_names:

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -530,7 +530,7 @@ def _validate_request_package_configs(request_kwargs, pkg_managers_names):
             + ", ".join(invalid_package_managers)
         )
 
-    supported_packages_configs = {"npm", "pip"}
+    supported_packages_configs = {"npm", "pip", "gomod"}
     unsupported_packages_managers = packages_configs.keys() - supported_packages_configs
     if unsupported_packages_managers:
         raise ValidationError(
@@ -543,6 +543,7 @@ def _validate_request_package_configs(request_kwargs, pkg_managers_names):
     valid_package_config_keys = {
         "npm": {"path"},
         "pip": {"path", "requirements_build_files", "requirements_files"},
+        "gomod": {"path"},
     }
     for pkg_manager, packages_config in packages_configs.items():
         invalid_format_error = (

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
+import os
 
 from cachito.errors import CachitoError
 from cachito.workers.config import get_worker_config
@@ -16,45 +17,105 @@ __all__ = ["fetch_gomod_source"]
 log = logging.getLogger(__name__)
 
 
+def _find_missing_gomod_files(bundle_dir, subpaths):
+    """
+    Find all go modules with missing gomod files.
+
+    These files will need to be present in order for the package manager to proceed with
+    fetching the package sources.
+
+    :param RequestBundleDir bundle_dir: the ``RequestBundleDir`` object for the request
+    :param list subpaths: a list of subpaths in the source repository of gomod packages
+    :return: a list containing all non-existing go.mod files across subpaths
+    :rtype: list
+    """
+    invalid_gomod_files = []
+    for subpath in subpaths:
+        bundle_dir_subpath = bundle_dir.app_subpath(subpath)
+        package_gomod_rel_path = bundle_dir_subpath.relpath(bundle_dir_subpath.go_mod_file)
+        log.debug("Testing for go mod file in {}".format(package_gomod_rel_path))
+        if not bundle_dir_subpath.go_mod_file.exists():
+            invalid_gomod_files.append(package_gomod_rel_path)
+
+    return invalid_gomod_files
+
+
 @app.task
-def fetch_gomod_source(request_id, dep_replacements=None):
+def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
     """
     Resolve and fetch gomod dependencies for a given request.
 
     :param int request_id: the Cachito request ID this is for
-    :param list dep_replacements: dependency replacements with the keys "name" and "version"
+    :param list dep_replacements: dependency replacements with the keys "name" and "version"; only
+        supported with a single path
+    :param list package_configs: the list of optional package configurations submitted by the user
     :raises CachitoError: if the dependencies could not be retrieved
     """
     config = get_worker_config()
-    bundle_dir = RequestBundleDir(request_id)
+    if package_configs is None:
+        package_configs = []
 
-    if not bundle_dir.go_mod_file.exists():
-        if config.cachito_gomod_ignore_missing_gomod_file:
-            log.warning("The go.mod file is missing for request %d", request_id)
+    bundle_dir = RequestBundleDir(request_id)
+    subpaths = [os.path.normpath(c["path"]) for c in package_configs if c.get("path")]
+
+    if not subpaths:
+        # Default to the root of the application source
+        subpaths = [os.curdir]
+
+    invalid_gomod_files = _find_missing_gomod_files(bundle_dir, subpaths)
+    if invalid_gomod_files:
+        invalid_files_print = "; ".join(invalid_gomod_files)
+        file_suffix = "s" if len(invalid_gomod_files) > 1 else ""
+
+        # missing gomod files is supported if there is only one path referenced
+        if config.cachito_gomod_ignore_missing_gomod_file and len(subpaths) == 1:
+            log.warning("go.mod file missing for request at %s", invalid_files_print)
             return
 
-        raise CachitoError("The go.mod file is missing")
+        raise CachitoError(
+            "The {} file{} must be present for the gomod package manager".format(
+                invalid_files_print.strip(), file_suffix
+            )
+        )
 
-    log.info("Fetching gomod dependencies for request %d", request_id)
-    request = set_request_state(request_id, "in_progress", "Fetching the gomod dependencies")
-    try:
-        gomod = resolve_gomod(str(bundle_dir.source_dir), request, dep_replacements)
-    except CachitoError:
-        log.exception("Failed to fetch gomod dependencies for request %d", request_id)
-        raise
+    if len(subpaths) > 1 and dep_replacements:
+        raise CachitoError(
+            "Dependency replacements are only supported for a single go module path."
+        )
 
-    env_vars = {
-        "GOCACHE": {"value": "deps/gomod", "kind": "path"},
-        "GOPATH": {"value": "deps/gomod", "kind": "path"},
-    }
-    env_vars.update(config.cachito_default_environment_variables.get("gomod", {}))
-    update_request_with_package(request_id, gomod["module"], env_vars)
-    update_request_with_deps(request_id, gomod["module"], gomod["module_deps"])
+    for i, subpath in enumerate(subpaths):
+        log.info(
+            "Fetching the gomod dependencies for request %d in subpath %s", request_id, subpath
+        )
+        request = set_request_state(
+            request_id,
+            "in_progress",
+            f'Fetching the gomod dependencies at the "{subpath}" directory',
+        )
+        gomod_source_path = str(bundle_dir.app_subpath(subpath).source_dir)
+        try:
+            gomod = resolve_gomod(
+                gomod_source_path, request, dep_replacements, bundle_dir.source_dir
+            )
+        except CachitoError:
+            log.exception("Failed to fetch gomod dependencies for request %d", request_id)
+            raise
 
-    # add package deps
-    for package in gomod["packages"]:
-        if package.get("pkg_deps"):
-            # This also adds the package to the request
-            update_request_with_deps(request_id, package["pkg"], package["pkg_deps"])
+        if i == 0:
+            env_vars = {
+                "GOCACHE": {"value": "deps/gomod", "kind": "path"},
+                "GOPATH": {"value": "deps/gomod", "kind": "path"},
+            }
+            env_vars.update(config.cachito_default_environment_variables.get("gomod", {}))
         else:
-            update_request_with_package(request_id, package["pkg"])
+            env_vars = None
+        update_request_with_package(request_id, gomod["module"], env_vars)
+        update_request_with_deps(request_id, gomod["module"], gomod["module_deps"])
+
+        # add package deps
+        for package in gomod["packages"]:
+            if package.get("pkg_deps"):
+                # This also adds the package to the request
+                update_request_with_deps(request_id, package["pkg"], package["pkg_deps"])
+            else:
+                update_request_with_package(request_id, package["pkg"])

--- a/tests/helper_utils/__init__.py
+++ b/tests/helper_utils/__init__.py
@@ -1,0 +1,47 @@
+import filecmp
+import os
+from pathlib import Path
+
+
+def assert_directories_equal(dir_a, dir_b):
+    """
+    Check recursively directories have equal content.
+
+    :param dir_a: first directory to check
+    :param dir_b: second directory to check
+    """
+    dirs_cmp = filecmp.dircmp(dir_a, dir_b)
+    assert (
+        len(dirs_cmp.left_only) == 0
+    ), f"Found files: {dirs_cmp.left_only} in {dir_a}, but not {dir_b}."
+    assert (
+        len(dirs_cmp.right_only) == 0
+    ), f"Found files: {dirs_cmp.right_only} in {dir_b}, but not {dir_a}."
+    assert (
+        len(dirs_cmp.funny_files) == 0
+    ), f"Found files: {dirs_cmp.funny_files} in {dir_a}, {dir_b} which could not be compared."
+    (_, mismatch, errors) = filecmp.cmpfiles(dir_a, dir_b, dirs_cmp.common_files, shallow=False)
+    assert len(mismatch) == 0, f"Found mismatches: {mismatch} between {dir_a} {dir_b}."
+    assert len(errors) == 0, f"Found errors: {errors} between {dir_a} {dir_b}."
+
+    for common_dir in dirs_cmp.common_dirs:
+        inner_a = os.path.join(dir_a, common_dir)
+        inner_b = os.path.join(dir_b, common_dir)
+        assert_directories_equal(inner_a, inner_b)
+
+
+def write_file_tree(tree_def, rooted_at):
+    """
+    Write a file tree to disk.
+
+    :param dict tree_def: Definition of file tree, see usage for intuitive examples
+    :param (str | Path) rooted_at: Root of file tree, must be an existing directory
+    """
+    root = Path(rooted_at)
+    for entry, value in tree_def.items():
+        entry_path = root / entry
+        if isinstance(value, str):
+            entry_path.write_text(value)
+        else:
+            entry_path.mkdir()
+            write_file_tree(value, entry_path)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from collections import namedtuple
-import filecmp
 import json
 import os
 import shutil
@@ -10,6 +9,8 @@ import jsonschema
 import requests
 from requests_kerberos import HTTPKerberosAuth
 import yaml
+
+from tests.helper_utils import assert_directories_equal
 
 Response = namedtuple("Response", "data id status")
 
@@ -279,33 +280,6 @@ def assert_elements_from_response(response_data, expected_response_data):
             f"{json.dumps(response_data[element_name], indent=4, sort_keys=True)}, \n"
             f"Test expectations: {json.dumps(expected_data, indent=4, sort_keys=True)}"
         )
-
-
-def assert_directories_equal(dir_a, dir_b):
-    """
-    Check recursively directories have equal content.
-
-    :param dir_a: first directory to check
-    :param dir_b: second directory to check
-    """
-    dirs_cmp = filecmp.dircmp(dir_a, dir_b)
-    assert (
-        len(dirs_cmp.left_only) == 0
-    ), f"Found files: {dirs_cmp.left_only} in {dir_a}, but not {dir_b}."
-    assert (
-        len(dirs_cmp.right_only) == 0
-    ), f"Found files: {dirs_cmp.right_only} in {dir_b}, but not {dir_a}."
-    assert (
-        len(dirs_cmp.funny_files) == 0
-    ), f"Found files: {dirs_cmp.funny_files} in {dir_a}, {dir_b} which could not be compared."
-    (_, mismatch, errors) = filecmp.cmpfiles(dir_a, dir_b, dirs_cmp.common_files, shallow=False)
-    assert len(mismatch) == 0, f"Found mismatches: {mismatch} between {dir_a} {dir_b}."
-    assert len(errors) == 0, f"Found errors: {errors} between {dir_a} {dir_b}."
-
-    for common_dir in dirs_cmp.common_dirs:
-        inner_a = os.path.join(dir_a, common_dir)
-        inner_b = os.path.join(dir_b, common_dir)
-        assert_directories_equal(inner_a, inner_b)
 
 
 def assert_expected_files(source_path, expected_files, tmpdir):

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -14,6 +14,7 @@ from cachito.errors import CachitoError, ValidationError
 from cachito.workers.errors import NexusScriptError
 from cachito.workers.pkg_managers import pip, general
 from cachito.workers.requests import requests_session
+from tests.helper_utils import write_file_tree
 
 
 GIT_REF = "9a557920b2a6d4110f838506120904a6fda421a2"
@@ -23,23 +24,6 @@ def setup_module():
     """Re-enable logging that was disabled at some point in previous tests."""
     pip.log.disabled = False
     pip.log.setLevel(logging.DEBUG)
-
-
-def write_file_tree(tree_def, rooted_at):
-    """
-    Write a file tree to disk.
-
-    :param dict tree_def: Definition of file tree, see usage for intuitive examples
-    :param (str | Path) rooted_at: Root of file tree, must be an existing directory
-    """
-    root = Path(rooted_at)
-    for entry, value in tree_def.items():
-        entry_path = root / entry
-        if isinstance(value, str):
-            entry_path.write_text(value)
-        else:
-            entry_path.mkdir()
-            write_file_tree(value, entry_path)
 
 
 @pytest.mark.parametrize("py_exists", [True, False])

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -8,11 +8,56 @@ from cachito.workers import tasks
 
 
 @pytest.mark.parametrize(
-    "dep_replacements, expect_state_update",
+    "dep_replacements, expect_state_update, pkg_config, pkg_results",
     (
-        (None, True),
-        (None, False),
-        (False, [{"name": "github.com/pkg/errors", "type": "gomod", "version": "v0.8.1"}]),
+        (
+            None,
+            True,
+            None,
+            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": "./"}},
+        ),
+        (
+            None,
+            False,
+            None,
+            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": "./"}},
+        ),
+        (
+            [{"name": "github.com/pkg/errors", "type": "gomod", "version": "v0.8.1"}],
+            True,
+            None,
+            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": "./"}},
+        ),
+        (
+            None,
+            True,
+            [{"path": "bar"}, {"path": "foo"}],
+            {
+                "present": {"bar": True, "foo": True},
+                "relpath": {"bar": "./bar/go.mod", "foo": "./foo/go.mod"},
+                "sourcedir": {"bar": "./bar/", "foo": "./foo/"},
+            },
+        ),
+        (
+            None,
+            True,
+            [{"path": "."}, {"path": "foo"}],
+            {
+                "present": {".": True, "foo": True},
+                "relpath": {".": "./go.mod", "foo": "./foo/go.mod"},
+                "sourcedir": {".": "./", "foo": "./foo/"},
+            },
+        ),
+        (
+            [{"name": "github.com/pkg/errors", "type": "gomod", "version": "v0.8.1"}],
+            False,
+            [{"path": "."}, {"path": "foo"}],
+            {
+                "present": {".": True, "foo": True},
+                "relpath": {".": "./go.mod", "foo": "./foo/go.mod"},
+                "sourcedir": {".": "./", "foo": "./foo/"},
+            },
+        ),
     ),
 )
 @pytest.mark.parametrize("has_pkg_lvl_deps", (True, False))
@@ -29,6 +74,8 @@ def test_fetch_gomod_source(
     mock_bundle_dir,
     dep_replacements,
     expect_state_update,
+    pkg_config,
+    pkg_results,
     has_pkg_lvl_deps,
     sample_deps_replace,
     sample_package,
@@ -36,6 +83,16 @@ def test_fetch_gomod_source(
     sample_pkg_lvl_pkg,
     sample_env_vars,
 ):
+    def directory_present(*args, **kwargs):
+        mock_subpath = mock.Mock()
+        (subpath,) = args
+        mock_subpath.go_mod_file.exists.return_value = pkg_results["present"][subpath]
+        mock_subpath.relpath.return_value = pkg_results["relpath"][subpath]
+        mock_subpath.source_dir = pkg_results["sourcedir"][subpath]
+        return mock_subpath
+
+    mock_bundle_dir.return_value.app_subpath.side_effect = directory_present
+
     # Add the default environment variables from the configuration
     env_vars = {
         "GO111MODULE": {"value": "on", "kind": "literal"},
@@ -52,47 +109,153 @@ def test_fetch_gomod_source(
         "module_deps": sample_deps_replace,
         "packages": [{"pkg": sample_pkg_lvl_pkg, "pkg_deps": pkg_lvl_deps}],
     }
-    tasks.fetch_gomod_source(1, dep_replacements)
+
+    paths = ["."]
+    if pkg_config is not None:
+        paths = [paths["path"] for paths in pkg_config]
+
+    if dep_replacements is not None and len(paths) > 1:
+        # This is unsupported and no other tests are necessary
+        with pytest.raises(
+            CachitoError,
+            match="Dependency replacements are only supported for a single go module path.",
+        ):
+            tasks.fetch_gomod_source(1, dep_replacements, pkg_config)
+        return
+
+    tasks.fetch_gomod_source(1, dep_replacements, pkg_config)
+
     if expect_state_update:
-        mock_set_request_state.assert_called_once_with(
-            1, "in_progress", "Fetching the gomod dependencies"
-        )
-        pkg_calls = [
-            mock.call(1, sample_package, sample_env_vars),
-        ]
-        dep_calls = [
-            mock.call(1, sample_package, sample_deps_replace),
-        ]
-        if has_pkg_lvl_deps:
-            dep_calls.append(mock.call(1, sample_pkg_lvl_pkg, sample_pkg_deps))
-        else:
-            pkg_calls.append(mock.call(1, sample_pkg_lvl_pkg))
+        state_calls = []
+        pkg_calls = []
+        dep_calls = []
+        for i, path in enumerate(paths):
+            state_calls.append(
+                mock.call(
+                    1,
+                    "in_progress",
+                    'Fetching the gomod dependencies at the "{}" directory'.format(path),
+                )
+            )
+            if i != 0:
+                sample_env_vars = None
+            pkg_calls.append(mock.call(1, sample_package, sample_env_vars))
+
+            dep_calls.append(mock.call(1, sample_package, sample_deps_replace))
+            if has_pkg_lvl_deps:
+                dep_calls.append(mock.call(1, sample_pkg_lvl_pkg, sample_pkg_deps))
+            else:
+                pkg_calls.append(mock.call(1, sample_pkg_lvl_pkg))
+
+        mock_set_request_state.assert_has_calls(state_calls)
         mock_update_request_with_package.assert_has_calls(pkg_calls)
         assert mock_update_request_with_package.call_count == len(pkg_calls)
         mock_update_request_with_deps.assert_has_calls(dep_calls)
         assert mock_update_request_with_deps.call_count == len(dep_calls)
 
-    mock_resolve_gomod.assert_called_once_with(
-        str(mock_bundle_dir().source_dir), mock_request, dep_replacements
-    )
+    gomod_calls = [
+        mock.call(
+            str(mock_bundle_dir().app_subpath(path).source_dir),
+            mock_request,
+            dep_replacements,
+            mock_bundle_dir().source_dir,
+        )
+        for path in paths
+    ]
+    mock_resolve_gomod.assert_has_calls(gomod_calls)
 
 
 @pytest.mark.parametrize(
-    "ignore_missing_gomod_file, exc_expected", ((True, False), (False, True)),
+    "ignore_missing_gomod_file, exception_expected, pkg_config, pkg_results",
+    (
+        (
+            True,
+            False,
+            None,
+            {
+                "present": {".": False},
+                "relpath": {".": "./go.mod"},
+                "missing_files": "./go.mod",
+                "file_plurality": "",
+            },
+        ),
+        (
+            False,
+            True,
+            None,
+            {
+                "present": {".": False},
+                "relpath": {".": "./go.mod"},
+                "missing_files": "./go.mod",
+                "file_plurality": "",
+            },
+        ),
+        (
+            False,
+            True,
+            [{"path": "bar"}, {"path": "foo"}],
+            {
+                "present": {"bar": True, "foo": False},
+                "relpath": {"bar": "./bar/go.mod", "foo": "./foo/go.mod"},
+                "missing_files": "./foo/go.mod",
+                "file_plurality": "",
+            },
+        ),
+        (
+            False,
+            True,
+            [{"path": "bar"}, {"path": "foo"}],
+            {
+                "present": {"bar": False, "foo": False},
+                "relpath": {"bar": "./bar/go.mod", "foo": "./foo/go.mod"},
+                "missing_files": "./bar/go.mod; ./foo/go.mod",
+                "file_plurality": "s",
+            },
+        ),
+        (
+            True,
+            True,
+            [{"path": "bar"}, {"path": "foo"}],
+            {
+                "present": {"bar": False, "foo": False},
+                "relpath": {"bar": "./bar/go.mod", "foo": "./foo/go.mod"},
+                "missing_files": "./bar/go.mod; ./foo/go.mod",
+                "file_plurality": "s",
+            },
+        ),
+    ),
 )
 @mock.patch("cachito.workers.tasks.gomod.get_worker_config")
 @mock.patch("cachito.workers.tasks.gomod.RequestBundleDir")
 @mock.patch("cachito.workers.tasks.gomod.resolve_gomod")
 def test_fetch_gomod_source_no_go_mod_file(
-    mock_resolve_gomod, mock_bundle_dir, mock_gwc, ignore_missing_gomod_file, exc_expected,
+    mock_resolve_gomod,
+    mock_bundle_dir,
+    mock_gwc,
+    ignore_missing_gomod_file,
+    exception_expected,
+    pkg_config,
+    pkg_results,
 ):
+    def directory_present(*args, **kwargs):
+        mock_subpath = mock.Mock()
+        (subpath,) = args
+        mock_subpath.go_mod_file.exists.return_value = pkg_results["present"][subpath]
+        mock_subpath.relpath.return_value = pkg_results["relpath"][subpath]
+        return mock_subpath
+
     mock_config = mock.Mock()
     mock_config.cachito_gomod_ignore_missing_gomod_file = ignore_missing_gomod_file
     mock_gwc.return_value = mock_config
-    mock_bundle_dir.return_value.go_mod_file.exists.return_value = False
-    if exc_expected:
-        with pytest.raises(CachitoError, match="The go.mod file is missing"):
-            tasks.fetch_gomod_source(1)
+    mock_bundle_dir.return_value.app_subpath.side_effect = directory_present
+    if exception_expected:
+        with pytest.raises(
+            CachitoError,
+            match="The {} file{} must be present for the gomod package manager".format(
+                pkg_results["missing_files"], pkg_results["file_plurality"]
+            ),
+        ):
+            tasks.fetch_gomod_source(1, package_configs=pkg_config)
     else:
         tasks.fetch_gomod_source(1)
 


### PR DESCRIPTION
- CLOUDBLD-1611

Handle multiple gomod packages in a single repo in Cachito

While investigating the code to see if a custom `go.mod` path could be provided to Cachito, I went ahead and performed an initial implementation of supporting multiple gomod packages.

Signed-off-by: arewm <arewm@users.noreply.github.com>