### PR TITLE
Remove print statements

### DIFF
--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -136,7 +136,6 @@ class Git(SCM):
             self._reset_git_head(repo)
 
             if gitsubmodule:
-                print("called")
                 self.update_git_submodules(repo)
 
             self._create_archive(repo.working_dir)
@@ -233,7 +232,6 @@ class Git(SCM):
         :raises CachitoError: if updating the git submodules fail.
         """
         try:
-            print("called?????")
             log.debug(f"Git submodules for the requested repo are: {repo.submodules}")
             repo.submodule_update(recursive=False)
         except Exception as e:


### PR DESCRIPTION
f0a32e5fac0207a47954018a52c2d399ab05d346 introduced print statements to
the code base. This patch removes the unintentionally added snippets.

Signed-off-by: Athos Ribeiro <athos@redhat.com>