### PR TITLE
Fix default pkg configuration param values

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -237,7 +237,7 @@ def create_request():
                 "Dependency replacements are not yet supported for the npm package manager"
             )
 
-        npm_package_configs = package_configs.get("npm", {})
+        npm_package_configs = package_configs.get("npm", [])
         chain_tasks.append(
             tasks.fetch_npm_source.si(request.id, npm_package_configs).on_error(error_callback)
         )
@@ -246,7 +246,7 @@ def create_request():
             raise ValidationError(
                 "Dependency replacements are not yet supported for the pip package manager"
             )
-        pip_package_configs = package_configs.get("pip", {})
+        pip_package_configs = package_configs.get("pip", [])
         chain_tasks.append(
             tasks.fetch_pip_source.si(request.id, pip_package_configs).on_error(error_callback)
         )

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -120,9 +120,9 @@ def test_create_and_fetch_request(
             )
         )
     if "npm" in expected_pkg_managers:
-        expected.append(fetch_npm_source.si(created_request["id"], {}).on_error(error_callback))
+        expected.append(fetch_npm_source.si(created_request["id"], []).on_error(error_callback))
     if "pip" in expected_pkg_managers:
-        expected.append(fetch_pip_source.si(created_request["id"], {}).on_error(error_callback))
+        expected.append(fetch_pip_source.si(created_request["id"], []).on_error(error_callback))
     if "git-submodule" in expected_pkg_managers:
         expected.append(
             add_git_submodules_as_package.si(


### PR DESCRIPTION
The package configurations parameters passed to the fetch_npm_source and
fetch_pip_source tasks should be lists. The API code makes them default
to dicts. This patch fixes the default values for those params.

Signed-off-by: Athos Ribeiro <athos@redhat.com>