### PR TITLE
Fix conflicting expectations in API test suite

### DIFF
--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1858,7 +1858,7 @@ def test_create_and_fetch_request_with_pip_preview(
                     1,
                     False,  # default value for gitsubmodule
                 ).on_error(error_callback),
-                fetch_pip_source.si(1, {}).on_error(error_callback),
+                fetch_pip_source.si(1, []).on_error(error_callback),
                 create_bundle_archive.si(1).on_error(error_callback),
             ]
         )


### PR DESCRIPTION
533c1be and e5e01db added conflicting changes for Cachito test suite.
This patch fixes the API unit tests expectations to resolve the
conflicting changes.

Signed-off-by: Athos Ribeiro <athos@redhat.com>