### PR TITLE
Include package subpaths in purls and /requests JSON

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -376,8 +376,7 @@ def patch_request(request_id):
     package_object = None
     if "package" in payload:
         package_object = Package.get_or_create(payload["package"])
-        if package_object not in request.packages:
-            request.packages.append(package_object)
+        request.add_package(package_object)
 
     for dep_and_replaces in payload.get("dependencies", []):
         dep = copy.deepcopy(dep_and_replaces)

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -252,9 +252,7 @@ def create_request():
         )
     if "git-submodule" in pkg_manager_names:
         chain_tasks.append(
-            tasks.add_git_submodules_as_package.si(request.id, request.repo, request.ref).on_error(
-                error_callback
-            )
+            tasks.add_git_submodules_as_package.si(request.id).on_error(error_callback)
         )
 
     chain_tasks.append(tasks.create_bundle_archive.si(request.id).on_error(error_callback))

--- a/cachito/web/content_manifest.py
+++ b/cachito/web/content_manifest.py
@@ -132,7 +132,7 @@ class ContentManifest:
             package = request_package.package
 
             if package.type == "go-package":
-                purl = package.to_top_level_purl(self.request)
+                purl = package.to_top_level_purl(self.request, subpath=request_package.subpath)
                 self._gopkg_data.setdefault(
                     package.id,
                     {"name": package.name, "purl": purl, "dependencies": [], "sources": []},
@@ -140,11 +140,11 @@ class ContentManifest:
             elif package.type == "gomod":
                 self._gomod_data.setdefault(package.name, [])
             elif package.type in ("npm", "pip"):
-                purl = package.to_top_level_purl(self.request)
+                purl = package.to_top_level_purl(self.request, subpath=request_package.subpath)
                 data = getattr(self, f"_{package.type}_data")
                 data.setdefault(package.id, {"purl": purl, "dependencies": [], "sources": []})
             elif package.type == "git-submodule":
-                purl = package.to_top_level_purl(self.request)
+                purl = package.to_top_level_purl(self.request, subpath=request_package.subpath)
                 self._gitsubmodule_data.setdefault(
                     package.id, {"purl": purl, "dependencies": [], "sources": []}
                 )

--- a/cachito/web/content_manifest.py
+++ b/cachito/web/content_manifest.py
@@ -128,7 +128,9 @@ class ContentManifest:
         self._gitsubmodule_data = {}
 
         # Address the possibility of packages having no dependencies
-        for package in self.request.packages:
+        for request_package in self.request.request_packages:
+            package = request_package.package
+
             if package.type == "go-package":
                 purl = package.to_top_level_purl(self.request)
                 self._gopkg_data.setdefault(

--- a/cachito/web/migrations/versions/2f83b3e4c5cc_add_request_package_subpath.py
+++ b/cachito/web/migrations/versions/2f83b3e4c5cc_add_request_package_subpath.py
@@ -1,0 +1,26 @@
+"""Add the subpath column to the request_package table
+
+Revision ID: 2f83b3e4c5cc
+Revises: f133002ffdb4
+Create Date: 2020-10-13 11:43:25.052014
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2f83b3e4c5cc"
+down_revision = "f133002ffdb4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("request_package") as batch_op:
+        batch_op.add_column(sa.Column("subpath", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("request_package") as batch_op:
+        batch_op.drop_column("subpath")

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -442,6 +442,9 @@ class RequestPackage(db.Model):
     package_id = db.Column(
         db.Integer, db.ForeignKey("package.id"), autoincrement=False, index=True, primary_key=True
     )
+    # Each package in a request may have a custom subpath. If the package is located in the root
+    # of the request repo, subpath will be null.
+    subpath = db.Column(db.String, nullable=True)
 
     __table_args__ = (db.UniqueConstraint("request_id", "package_id"),)
 

--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -114,7 +114,7 @@ def update_request_with_deps(request_id, package, deps):
             raise CachitoError(f"Setting the dependencies on request {request_id} failed")
 
 
-def update_request_with_package(request_id, package, env_vars=None):
+def update_request_with_package(request_id, package, env_vars=None, package_subpath=None):
     """
     Update the request with the resolved packages and corresponding metadata.
 
@@ -122,6 +122,7 @@ def update_request_with_package(request_id, package, env_vars=None):
     :param dict env_vars: mapping of environment variables to record. The keys represent
         the environment variable name, and its value should be another map wth the "value" and
         "kind" attributes, e.g. {"NAME": {"value": "VALUE", "kind": "KIND"}}.
+    :param str package_subpath: relative path from root of repository to package directory
     :raise CachitoError: if the request to the Cachito API fails
     """
     log.info('Adding the package "%r" to the request %d', package, request_id)
@@ -130,6 +131,10 @@ def update_request_with_package(request_id, package, env_vars=None):
     if env_vars:
         log.info("Also adding environment variables to the request %d: %s", request_id, env_vars)
         payload["environment_variables"] = env_vars
+
+    if package_subpath and package_subpath != os.curdir:
+        log.info("Also setting a subpath for the package %r: %r", package["name"], package_subpath)
+        payload["package_subpath"] = package_subpath
 
     # Import this here to avoid a circular import
     from cachito.workers.requests import requests_auth_session

--- a/cachito/workers/tasks/gitsubmodule.py
+++ b/cachito/workers/tasks/gitsubmodule.py
@@ -29,4 +29,4 @@ def add_git_submodules_as_package(request_id):
             "version": f"{sm.url}#{sm.hexsha}",
         }
         log.debug("Adding submodule '%s' as a package for Cachito request", sm.name)
-        update_request_with_package(request_id, package)
+        update_request_with_package(request_id, package, package_subpath=sm.path)

--- a/cachito/workers/tasks/gitsubmodule.py
+++ b/cachito/workers/tasks/gitsubmodule.py
@@ -12,13 +12,11 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def add_git_submodules_as_package(request_id, url, ref):
+def add_git_submodules_as_package(request_id):
     """
     Add git submodules as package to the Cachtio request.
 
     :param int request_id: the Cachito request ID this is for
-    :param str url: the source control URL to pull the source from
-    :param str ref: the source control reference
     :raises CachitoError: if adding submodules as a package fail.
     """
     bundle_dir = RequestBundleDir(request_id)

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -168,7 +168,7 @@ def fetch_npm_source(request_id, package_configs=None):
         else:
             env_vars = None
         package = package_and_deps_info["package"]
-        update_request_with_package(request_id, package, env_vars)
+        update_request_with_package(request_id, package, env_vars, package_subpath=subpath)
         update_request_with_deps(request_id, package, package_and_deps_info["deps"])
 
     log.info("Finalizing the Nexus configuration for npm for the request %d", request_id)

--- a/cachito/workers/tasks/pip.py
+++ b/cachito/workers/tasks/pip.py
@@ -118,8 +118,11 @@ def fetch_pip_source(request_id, package_configs=None):
     env_vars.update(worker_config.cachito_default_environment_variables.get("pip", {}))
 
     # Finally, perform DB operations
-    for pkg_data in packages_data:
-        update_request_with_package(request_id, pkg_data["package"], env_vars)
+    for pkg_cfg, pkg_data in zip(package_configs, packages_data):
+        pkg_subpath = os.path.normpath(pkg_cfg.get("path", "."))
+        update_request_with_package(
+            request_id, pkg_data["package"], env_vars, package_subpath=pkg_subpath
+        )
         update_request_with_deps(request_id, pkg_data["package"], pkg_data["dependencies"])
 
     if pip_config_files:

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1131,6 +1131,8 @@ def test_set_package(
     get_rv = client.get("/api/v1/requests/1")
     assert get_rv.status_code == 200
     sample_package["dependencies"] = []
+    if subpath_in_db is not None:
+        sample_package["path"] = subpath_in_db
     assert get_rv.json["packages"] == [sample_package]
 
 

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -126,11 +126,7 @@ def test_create_and_fetch_request(
         expected.append(fetch_pip_source.si(created_request["id"], []).on_error(error_callback))
     if "git-submodule" in expected_pkg_managers:
         expected.append(
-            add_git_submodules_as_package.si(
-                created_request["id"],
-                "https://github.com/release-engineering/retrodep.git",
-                "c50b93a32df1c9d700e3e80996845bc2e13be848",
-            ).on_error(error_callback)
+            add_git_submodules_as_package.si(created_request["id"]).on_error(error_callback)
         )
     expected.append(create_bundle_archive.si(created_request["id"]).on_error(error_callback))
     mock_chain.assert_called_once_with(expected)

--- a/tests/test_content_manifest.py
+++ b/tests/test_content_manifest.py
@@ -6,7 +6,7 @@ import pytest
 
 from cachito.errors import ContentManifestError
 from cachito.web.content_manifest import ContentManifest
-from cachito.web.models import Package, Request
+from cachito.web.models import Package, Request, RequestPackage
 
 GIT_REPO = "https://github.com/namespace/repo"
 GIT_REF = "1798a59f297f5f3886e41bc054e538540581f8ce"
@@ -162,7 +162,8 @@ def test_to_json(app, package):
     image_contents = []
     if package:
         pkg = Package.from_json(package)
-        request.packages.append(pkg)
+        request_package = RequestPackage(package=pkg)
+        request.request_packages.append(request_package)
         content = {"purl": pkg.to_purl(), "dependencies": [], "sources": []}
         image_contents.append(content)
 
@@ -200,7 +201,8 @@ def test_to_json_with_multiple_packages(mock_generate_icm, app, packages):
     image_contents = []
     for package in packages:
         pkg = Package.from_json(package)
-        request.packages.append(pkg)
+        request_package = RequestPackage(package=pkg)
+        request.request_packages.append(request_package)
         content = {"purl": pkg.to_purl(), "dependencies": [], "sources": []}
         image_contents.append(content)
     res = cm.to_json()

--- a/tests/test_workers/test_pkg_managers/test_general.py
+++ b/tests/test_workers/test_pkg_managers/test_general.py
@@ -42,8 +42,11 @@ def test_update_request_with_deps(mock_requests, sample_deps_replace, sample_pac
     mock_requests.patch.assert_has_calls(calls)
 
 
+@pytest.mark.parametrize(
+    "package_subpath, include_subpath", [(None, False), (".", False), ("some/path", True)],
+)
 @mock.patch("cachito.workers.requests.requests_auth_session")
-def test_update_request_with_package(mock_requests):
+def test_update_request_with_package(mock_requests, package_subpath, include_subpath):
     mock_requests.patch.return_value.ok = True
     package = {
         "name": "helloworld",
@@ -58,7 +61,10 @@ def test_update_request_with_package(mock_requests):
         "environment_variables": env_vars,
         "package": package,
     }
-    update_request_with_package(1, package, env_vars)
+    if include_subpath:
+        expected_json["package_subpath"] = package_subpath
+
+    update_request_with_package(1, package, env_vars, package_subpath=package_subpath)
     mock_requests.patch.assert_called_once_with(
         "http://cachito.domain.local/api/v1/requests/1", json=expected_json, timeout=60
     )

--- a/tests/test_workers/test_tasks/test_gitsubmodule.py
+++ b/tests/test_workers/test_tasks/test_gitsubmodule.py
@@ -20,6 +20,6 @@ def test_add_git_submodules_as_package(mock_update_with_package, mock_repo):
         "name": "tour",
         "version": "https://github.com/user/tour.git#522fb816eec295ad58bc488c74b2b46748d471b2",
     }
-    gitsubmodule.add_git_submodules_as_package(3, url, ref)
+    gitsubmodule.add_git_submodules_as_package(3)
     # Verify that update_request_with_package was called correctly
     mock_update_with_package.assert_called_once_with(3, package)

--- a/tests/test_workers/test_tasks/test_gitsubmodule.py
+++ b/tests/test_workers/test_tasks/test_gitsubmodule.py
@@ -14,6 +14,7 @@ def test_add_git_submodules_as_package(mock_update_with_package, mock_repo):
     submodule.name = "tour"
     submodule.hexsha = "522fb816eec295ad58bc488c74b2b46748d471b2"
     submodule.url = "https://github.com/user/tour.git"
+    submodule.path = "tour"
     mock_repo.return_value.submodules = [submodule]
     package = {
         "type": "git-submodule",
@@ -22,4 +23,4 @@ def test_add_git_submodules_as_package(mock_update_with_package, mock_repo):
     }
     gitsubmodule.add_git_submodules_as_package(3)
     # Verify that update_request_with_package was called correctly
-    mock_update_with_package.assert_called_once_with(3, package)
+    mock_update_with_package.assert_called_once_with(3, package, package_subpath="tour")


### PR DESCRIPTION
* CLOUDBLD-2769

Git submodules,  pip packages and npm packages will now have their subpaths stored in the DB.
The subpaths will also be present in content manifests and the /requests/{id} JSON response.