### PR TITLE
Add purl support for git submodule

### DIFF
--- a/cachito/web/content_manifest.py
+++ b/cachito/web/content_manifest.py
@@ -29,6 +29,9 @@ class ContentManifest:
         self._npm_data = {}
         # dict to store pip package data; uses the package purl as key to identify a package
         self._pip_data = {}
+        # dict to store gitsubmodule package level data; uses the package purl as key to identify a
+        # package
+        self._gitsubmodule_data = {}
 
     def process_gomod(self, package, dependency):
         """
@@ -122,6 +125,7 @@ class ContentManifest:
         self._gomod_data = {}
         self._npm_data = {}
         self._pip_data = {}
+        self._gitsubmodule_data = {}
 
         # Address the possibility of packages having no dependencies
         for package in self.request.packages:
@@ -137,6 +141,11 @@ class ContentManifest:
                 purl = package.to_top_level_purl(self.request)
                 data = getattr(self, f"_{package.type}_data")
                 data.setdefault(package.id, {"purl": purl, "dependencies": [], "sources": []})
+            elif package.type == "git-submodule":
+                purl = package.to_top_level_purl(self.request)
+                self._gitsubmodule_data.setdefault(
+                    package.id, {"purl": purl, "dependencies": [], "sources": []}
+                )
             else:
                 flask.current_app.logger.debug(
                     "No ICM implementation for '%s' packages", package.type
@@ -159,6 +168,7 @@ class ContentManifest:
             *self._gopkg_data.values(),
             *self._npm_data.values(),
             *self._pip_data.values(),
+            *self._gitsubmodule_data.values(),
         ]
         return self.generate_icm(top_level_packages)
 

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -256,6 +256,13 @@ class Package(db.Model):
                 quoted_url = urllib.parse.quote(self.version, safe="")
                 return f"pkg:generic/{name}?download_url={quoted_url}&checksum={checksum}"
 
+        elif self.type == "git-submodule":
+            # Version is a submodule repository url followed by `#` separator and
+            # `submodule-commit-ref`, e.g.
+            # https://github.com/org-name/submodule-name.git#522fb816eec295ad58bc488c74b2b46748d471b2
+            repo_url, ref = self.version.rsplit("#", 1)
+            return self.to_vcs_purl(repo_url, ref)
+
         else:
             raise ContentManifestError(f"The PURL spec is not defined for {self.type} packages")
 
@@ -306,7 +313,7 @@ class Package(db.Model):
         :return: the PURL string of the Package object
         :rtype: str
         """
-        if self.type in ("gomod", "go-package"):
+        if self.type in ("gomod", "go-package", "git-submodule"):
             return self.to_purl()
         elif self.type in ("npm", "pip"):
             return self.to_vcs_purl(request.repo, request.ref)


### PR DESCRIPTION
Content manifest endpoint now includes the `purl` value for git submodule if it is available as package for Cachito request