### PR TITLE
Update development environment Nexus version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - 3000:3000
 
   nexus:
-    image: sonatype/nexus3:3.21.2
+    image: sonatype/nexus3:3.27.0
     environment:
       # Enable the script API. This is disabled by default in 3.21.2+.
       INSTALL4J_ADD_VM_PARAMS: -Dnexus.scripts.allowCreation=true -Dstorage.diskCache.diskFreeSpaceLimit=512


### PR DESCRIPTION
The current Nexus version used in development is affected by a CVE [1].
Moreover, it was the last known version to support the PyPI JSON API
[2], which led us to revert some changes to make Cachito compatible with
newer versions of Nexus [3].

This patch updates the Nexus version used in our development
environment so it reflects what users should have in production
(versions not affected by CVEs).

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11444
[2] https://issues.sonatype.org/browse/NEXUS-23284
[3] https://github.com/release-engineering/cachito/pull/275

Signed-off-by: Athos Ribeiro <athos@redhat.com>