### PR TITLE
Support arbitrary user ids within container image

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -6,10 +6,12 @@ RUN dnf -y install \
     --setopt=deltarpm=0 \
     --setopt=install_weak_deps=false \
     --setopt=tsflags=nodocs \
-    golang \
+    gettext \
     git-core \
+    golang \
     mercurial \
     npm \
+    nss_wrapper \
     python3-celery \
     python3-GitPython \
     python3-packaging \
@@ -22,4 +24,5 @@ RUN dnf -y install \
 COPY . .
 RUN pip3 install . --no-deps
 EXPOSE 8080
+ENTRYPOINT ["/src/docker/docker-entrypoint.sh"]
 CMD ["/bin/celery-3", "-A", "cachito.workers.tasks", "worker", "--loglevel=info"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# The first 6 commands are added here for using NSS_WRAPPER. See "Support Arbitrary User IDs" in
+# https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/creating_images/creating-images-guidelines
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < /src/docker/passwd.template > /tmp/passwd
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=/tmp/passwd
+export NSS_WRAPPER_GROUP=/etc/group
+exec "$@"

--- a/docker/passwd.template
+++ b/docker/passwd.template
@@ -1,0 +1,14 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+cachito:x:${USER_ID}:${GROUP_ID}:Cachito Server:${HOME}:/bin/bash


### PR DESCRIPTION
This is to avoid hitting an error with `get_user_id()` while using git-python library. We can remove this when an upstream patch is submitted to fix the issue.