### PR TITLE
Set git environment variables for GitPython

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -23,6 +23,13 @@ RUN dnf -y install \
     && dnf clean all
 COPY . .
 RUN pip3 install . --no-deps
+
+# Set git user configuration for GitPython
+ENV GIT_COMMITTER_NAME=cachito \
+    GIT_COMMITTER_EMAIL=cachito@localhost \
+    GIT_AUTHOR_NAME=cachito \
+    GIT_AUTHOR_EMAIL=cachito@localhost
+
 EXPOSE 8080
 ENTRYPOINT ["/src/docker/docker-entrypoint.sh"]
 CMD ["/bin/celery-3", "-A", "cachito.workers.tasks", "worker", "--loglevel=info"]


### PR DESCRIPTION
GitPython will check the git user related environment variables when
setting reflogs on submodule updates. This patch sets such variables so
Cachito does not need to rely on the values in the passwd file.

Moreover, with
https://github.com/gitpython-developers/GitPython/pull/1072, values in
/etc/passwd will not be checked at all.

Signed-off-by: Athos Ribeiro <athos@redhat.com>