### PR TITLE
Integration tests: add gomod vendored tests

### DIFF
--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -5,6 +5,8 @@ api_url: http://localhost:8080/api/v1
 api_auth_type: null
 # Time in minutes at which the request must be completed
 timeout: 15
+# The flag cachito_gomod_strict_vendor is enabled on the environment
+strict_mode_enabled: false
 # Package that will be used for testing
 packages:
   # repo: The URL for the upstream git repository

--- a/tests/integration/test_data/gomod_packages.yaml
+++ b/tests/integration/test_data/gomod_packages.yaml
@@ -1,6 +1,7 @@
 # gomod package without dependencies
 # repo: The URL for the upstream git repository
 # ref: A git reference at the given git repository
+# flags: A list of strings with Cachito flags
 # expected_files: Expected source files <relative_path>: <file_URL>
 # expected_deps_files: Expected dependencies files (empty)
 # response_expectations: Parts of the Cachito response to check
@@ -108,3 +109,90 @@ with_deps:
     - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/rsc.io%2Fquote@v1.5.2"
     - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+# The test data for gomod package with vendor directory
+# and with `gomod-vendor` flag.
+vendored_with_flag:
+  repo: https://github.com/cachito-testing/gomod-vendored.git
+  ref:  3604a4d7990f5c9279f26dda783b7b9bce617ed4
+  flags: ["gomod-vendor"]
+  pkg_managers: ["gomod"]
+  response_expectations:
+    packages:
+    - dependencies:
+      - name: "rsc.io/sampler"
+        replaces: null
+        type: "gomod"
+        version: "v1.3.0"
+      - name: "rsc.io/quote"
+        replaces: null
+        type: "gomod"
+        version: "v1.5.2"
+      - name: "golang.org/x/text"
+        replaces: null
+        type: "gomod"
+        version: "v0.0.0-20170915032832-14c0d48ead0c"
+      name: "github.com/cachito-testing/gomod-vendored"
+      type: "gomod"
+      version: "v0.0.0-20201021173631-3604a4d7990f"
+    - dependencies:
+      - name: "rsc.io/quote"
+        replaces: null
+        type: "go-package"
+        version: "v1.5.2"
+      - name: "rsc.io/sampler"
+        replaces: null
+        type: "go-package"
+        version: "v1.3.0"
+      - name: "golang.org/x/text/language"
+        replaces: null
+        type: "go-package"
+        version: "v0.0.0-20170915032832-14c0d48ead0c"
+      - name: "golang.org/x/text/internal/tag"
+        replaces: null
+        type: "go-package"
+        version: "v0.0.0-20170915032832-14c0d48ead0c"
+      name: "github.com/cachito-testing/gomod-vendored"
+      type: "go-package"
+      version: "v0.0.0-20201021173631-3604a4d7990f"
+    dependencies:
+    - name: "rsc.io/quote"
+      replaces: null
+      type: "go-package"
+      version: "v1.5.2"
+    - name: "rsc.io/sampler"
+      replaces: null
+      type: "go-package"
+      version: "v1.3.0"
+    - name: "golang.org/x/text/language"
+      replaces: null
+      type: "go-package"
+      version: "v0.0.0-20170915032832-14c0d48ead0c"
+    - name: "golang.org/x/text/internal/tag"
+      replaces: null
+      type: "go-package"
+      version: "v0.0.0-20170915032832-14c0d48ead0c"
+    - name: "rsc.io/sampler"
+      replaces: null
+      type: "gomod"
+      version: "v1.3.0"
+    - name: "rsc.io/quote"
+      replaces: null
+      type: "gomod"
+      version: "v1.5.2"
+    - name: "golang.org/x/text"
+      replaces: null
+      type: "gomod"
+      version: "v0.0.0-20170915032832-14c0d48ead0c"
+  expected_files:
+    app: https://github.com/cachito-testing/gomod-vendored/tarball/3604a4d7990f5c9279f26dda783b7b9bce617ed4
+    deps/gomod/pkg/mod/cache/download: null
+  purl: "pkg:golang/github.com%2Fcachito-testing%2Fgomod-vendored@v0.0.0-20201021173631-3604a4d7990f"
+  dep_purls:
+  - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
+  - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
+  - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+  - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+  source_purls:
+  - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
+  - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+  - "pkg:golang/rsc.io%2Fsampler@v1.3.0"

--- a/tests/integration/test_data/gomod_packages.yaml
+++ b/tests/integration/test_data/gomod_packages.yaml
@@ -196,3 +196,9 @@ vendored_with_flag:
   - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
   - "pkg:golang/rsc.io%2Fquote@v1.5.2"
   - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+# The test data for gomod package with vendor directory
+# and without `gomod-vendor` flag.
+vendored_without_flag:
+  repo: https://github.com/cachito-testing/gomod-vendored.git
+  ref:  ff1960095dd158d3d2a4f31d15b244c24930248b
+  pkg_managers: ["gomod"]

--- a/tests/integration/test_gomod_packages.py
+++ b/tests/integration/test_gomod_packages.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import utils
+
+
+def test_gomod_vendor_without_flag(test_env):
+    """
+    Validate failing of gomod vendor request without flag.
+
+    Checks:
+    * The request failed with expected error message
+    """
+    env_data = utils.load_test_data("gomod_packages.yaml")["vendored_without_flag"]
+    client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
+    initial_response = client.create_new_request(
+        payload={
+            "repo": env_data["repo"],
+            "ref": env_data["ref"],
+            "pkg_managers": env_data["pkg_managers"],
+        },
+    )
+    completed_response = client.wait_for_complete_request(initial_response)
+    if test_env.get("strict_mode_enabled"):
+        assert completed_response.status == 200
+        assert completed_response.data["state"] == "failed"
+        error_msg = (
+            'The "gomod-vendor" flag must be set when your repository has vendored dependencies'
+        )
+        assert error_msg in completed_response.data["state_reason"]
+    else:
+        utils.assert_properly_completed_response(completed_response)

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -5,8 +5,16 @@ import pytest
 import utils
 
 
-@pytest.mark.parametrize("env_name", ["without_deps", "with_deps"])
-@pytest.mark.parametrize("env_package", ["pip_packages", "gomod_packages"])
+@pytest.mark.parametrize(
+    "env_package,env_name",
+    [
+        ("pip_packages", "without_deps"),
+        ("pip_packages", "with_deps"),
+        ("gomod_packages", "without_deps"),
+        ("gomod_packages", "with_deps"),
+        ("gomod_packages", "vendored_with_flag"),
+    ],
+)
 def test_packages(env_package, env_name, test_env, tmpdir):
     """
     Validate data in the package request according to pytest env_name and env_package parameter.
@@ -31,6 +39,7 @@ def test_packages(env_package, env_name, test_env, tmpdir):
             "repo": env_data["repo"],
             "ref": env_data["ref"],
             "pkg_managers": env_data["pkg_managers"],
+            "flags": env_data.get("flags", []),
         },
     )
     completed_response = client.wait_for_complete_request(initial_response)


### PR DESCRIPTION
There are 2 tests:
1. Gomod vendored with flag `gomod-vendor`. The cachito request expected to complete successfully 
2. Gomod vendored without flag.  The cachito request expected to fail but right now it does not untill we will have enabled gomod strict mode. 
