### PR TITLE
Explicitly support Python 3.8 and 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup(
     },
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     license="GPLv3+",
     python_requires=">=3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black,flake8,py37
+envlist = black,flake8,py37,py38,py39
 
 [testenv]
 deps =


### PR DESCRIPTION
Before moving Cachito container images to new Fedora releases, we should
make sure the code base supports the Python version shipped in those new
releases. Let's start running our unit tests for new Python versions.

Signed-off-by: Athos Ribeiro <athos@redhat.com>