### PR TITLE
Integration tests: add pip test with cached dependencies

### DIFF
--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -1,19 +1,118 @@
-# Test data for the Using cached dependencies test
-# The upstream git repository
-seed_repo:
-  https_url: "https://github.com/release-engineering/retrodep.git"
-# Repository that will be used for the test
-test_repo:
-  # Use local bare remote repository
-  # If this is used, the git urls below should be paths and should be available for the workers
+# Test data for the Using cached packages test
+cached_package:
+  # The upstream git repository
+  seed_repo:
+    https_url: "https://github.com/release-engineering/retrodep.git"
+  # Repository that will be used for the test
+  test_repo:
+    # Use local bare remote repository
+    # If this is used, the git urls below should be paths and should be available for the workers
+    use_local: True
+    # The tracked repository (remote)
+    ssh_url: "./tmp/cachito-archives/integration-tests-git-repo.git"
+    # The URL of the repository
+    https_url: "./tmp/cachito-archives/integration-tests-git-repo.git"
+    # test repo user
+    git_user: "Arthur Dent"
+    # test repo user email
+    git_email: "dent42@cachito.rocks"
+    # Package managers
+    pkg_managers: ["gomod"]
+# Test pip with cached dependencies
+cached_deps:
+  # Use local version of repos.
+  # <use_local: True> is not supported and will be skipped.
   use_local: True
-  # The tracked repository (remote)
-  ssh_url: "./tmp/cachito-archives/integration-tests-git-repo.git"
-  # The URL of the repository
-  https_url: "./tmp/cachito-archives/integration-tests-git-repo.git"
   # test repo user
   git_user: "Arthur Dent"
   # test repo user email
   git_email: "dent42@cachito.rocks"
-  # Package managers
-  pkg_managers: ["gomod"]
+  # HTTPS and SSH links to main and dependency repos respectively
+  https_main_repo: https://github.com/cachito-testing/cachito-pip-with-deps.git
+  https_dep_repo: https://github.com/cachito-testing/cachito-pip-without-deps.git
+  ssh_main_repo: "git@github.com:cachito-testing/cachito-pip-with-deps.git"
+  ssh_dep_repo: "git@github.com:cachito-testing/cachito-pip-without-deps.git"
+  # Base URL for downloading dependency archive
+  dep_archive_baseurl: "https://github.com/cachito-testing/cachito-pip-without-deps/archive/"
+  pkg_managers: [ "pip" ]
+  # Expected files <relative_path>: <file_URL>
+  expected_files:
+    deps/pip/aiowsgi/aiowsgi-0.7.tar.gz: https://files.pythonhosted.org/packages/f4/3d/1933776c5215c61e38968fedd73c41251e8752736e1cd9fbb73db44ff4e1/aiowsgi-0.7.tar.gz
+    deps/pip/external-appr/appr-external-sha256-ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c.zip: https://github.com/quay/appr/tarball/37ff9a487a54ad41b59855ecd76ee092fe206a84
+    deps/pip/external-appr/appr-external-sha256-FIRST_DEP_HASH.zip: https://github.com/cachito-testing/cachito-pip-without-deps/tarball/3fe2fc3cb8ffa36317cacbd9d356e35e17af2824
+    deps/pip/github.com/quay/appr/appr-external-gitcommit-58c88e4952e95935c0dd72d4a24b0c44f2249f5b.tar.gz: https://github.com/quay/appr/tarball/58c88e4952e95935c0dd72d4a24b0c44f2249f5b
+    deps/pip/github.com/cachito-testing/cachito-pip-without-deps/cachito-pip-without-deps-external-gitcommit-SECOND_DEP_COMMIT.tar.gz: https://github.com/cachito-testing/cachito-pip-without-deps/tarball/3fe2fc3cb8ffa36317cacbd9d356e35e17af2824
+  # Parts of the Cachito response to check
+  response_expectations:
+    dependencies:
+    - dev: false
+      name: "appr"
+      replaces: null
+      type: "pip"
+      version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+    - dev: false
+      name: "appr"
+      replaces: null
+      type: "pip"
+      version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+    - dev: false
+      name: "aiowsgi"
+      replaces: null
+      type: "pip"
+      version: "0.7"
+    - dev: false
+      name: "appr"
+      replaces: null
+      type: "pip"
+      version: "https://github.com/cachito-testing/cachito-pip-without-deps/archive/FIRST_DEP_COMMIT.zip#egg=appr&cachito_hash=sha256:FIRST_DEP_HASH"
+    - dev: false
+      name: "appr"
+      replaces: null
+      type: "pip"
+      version: "git+https://github.com/cachito-testing/cachito-pip-without-deps.git@SECOND_DEP_COMMIT"
+    packages:
+    - dependencies:
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+      - dev: false
+        name: "aiowsgi"
+        replaces: null
+        type: "pip"
+        version: "0.7"
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "git+https://github.com/cachito-testing/cachito-pip-without-deps.git@SECOND_DEP_COMMIT"
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "https://github.com/cachito-testing/cachito-pip-without-deps/archive/FIRST_DEP_COMMIT.zip#egg=appr&cachito_hash=sha256:FIRST_DEP_HASH"
+      name: "cachito-pip-with-deps"
+      type: "pip"
+      version: "1.0.0"
+  # PURL of the package
+  purl: "pkg:github/cachito-testing/cachito-pip-with-deps@MAIN_REPO_COMMIT"
+  # PURLs of dependencies
+  dep_purls:
+  - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-pip-without-deps%2Farchive%2FFIRST_DEP_COMMIT.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3AFIRST_DEP_HASH&checksum=sha256:FIRST_DEP_HASH"
+  - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+  - "pkg:github/cachito-testing/cachito-pip-without-deps@SECOND_DEP_COMMIT"
+  - "pkg:github/quay/appr@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+  - "pkg:pypi/aiowsgi@0.7"
+  # PURLs of source data
+  source_purls:
+  - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-pip-without-deps%2Farchive%2FFIRST_DEP_COMMIT.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3AFIRST_DEP_HASH&checksum=sha256:FIRST_DEP_HASH"
+  - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+  - "pkg:github/cachito-testing/cachito-pip-without-deps@SECOND_DEP_COMMIT"
+  - "pkg:github/quay/appr@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+  - "pkg:pypi/aiowsgi@0.7"

--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-
+import os
 from pathlib import Path
 import random
 import shutil
@@ -11,29 +11,14 @@ import pytest
 import utils
 
 
-def create_local_repository(repo_path):
-    """
-    Create a local git repoitory.
-
-    :param str repo_path: path to new bare git repository
-    :return: normalized bare git repository path
-    :rtype: str
-    """
-    bare_repo_dir = Path(repo_path)
-    bare_repo = git.Repo.init(str(bare_repo_dir), bare=True)
-    assert bare_repo.bare, f"{bare_repo} is not bare repository"
-    # We need to expand this for later usage from the original repo directory
-    return str(bare_repo_dir.resolve())
-
-
-class TestCachedDependencies:
-    """Test class for cached dependencies."""
+class TestCachedPackage:
+    """Test class for cached package."""
 
     @pytest.fixture(autouse=True)
     def setup_method_fixture(self, test_env):
         """Create bare git repo and a pool for removing shared directories."""
         self.directories = []
-        self.env_data = utils.load_test_data("cached_dependencies.yaml")
+        self.env_data = utils.load_test_data("cached_dependencies.yaml")["cached_package"]
         self.git_user = self.env_data["test_repo"].get("git_user")
         self.git_email = self.env_data["test_repo"].get("git_email")
         if self.env_data["test_repo"].get("use_local"):
@@ -47,9 +32,9 @@ class TestCachedDependencies:
         for directory in self.directories:
             shutil.rmtree(directory)
 
-    def test_using_cached_dependencies(self, tmpdir, test_env):
+    def test_using_cached_packages(self, tmpdir, test_env):
         """
-        Check that the cached dependencies are used instead of downloading them from repo again.
+        Check that the cached packages are used instead of downloading them from repo again.
 
         Preconditions:
         * On git instance prepare an empty repository
@@ -103,13 +88,7 @@ class TestCachedDependencies:
             ), f"Commit {commit} is not in branches (it should be there)."
 
         finally:
-            repo.git.push("--delete", remote.name, branch_name)
-
-        repo.heads.master.checkout()
-        repo.git.branch("-D", branch_name)
-        assert not repo.git.branch(
-            "-a", "--contains", commit
-        ), f"Commit {commit} is still in a branch (it shouldn't be there at this point)."
+            delete_branch_and_check(branch_name, repo, remote, [commit])
 
         response = client.create_new_request(
             payload={
@@ -129,3 +108,282 @@ class TestCachedDependencies:
         first_deps = utils.make_list_of_packages_hashable(first_response.data["dependencies"])
         second_deps = utils.make_list_of_packages_hashable(second_response.data["dependencies"])
         assert first_deps == second_deps
+
+
+class TestPipCachedDependencies:
+    """Test class for pip cached dependencies."""
+
+    def teardown_method(self, method):
+        """Delete branch with commit in the main repo."""
+        if not self.use_local:
+            delete_branch_and_check(
+                self.branch, self.cloned_main_repo, self.main_repo_origin, [self.main_repo_commit]
+            )
+
+    def test_pip_with_cached_deps(self, test_env, tmpdir):
+        """
+        Test pip package with cached dependency.
+
+        The test verifies that even after deleting dependency
+        Cachito will provide cached version.
+        The test supports only remote repos. Local version will be skipped.
+        Stages:
+        1. Make changes in dependency repository:
+            * create new branch
+            * push 2 new commits
+        2. Make changes in requirements.txt in original repository:
+            * add VCS and remote source archive dependencies
+            based on commits from 1.
+            * push changes with new commit
+        3. Create Cachito request and verify it [1]
+        4. Delete branch in dependency repository
+        5. Create Cachito request and verify it [1]
+        [1] Verifications:
+        * The request completes successfully.
+        * A single pip package is identified.
+        Dependencies are correctly listed under “.dependencies”
+        and under “.packages | select(.type == “pip”) | .dependencies”.
+        * The source tarball includes the application source code under the app directory.
+        * The source tarball includes the dependencies and dev dependencies source code
+        under deps/pip directory.
+        * The content manifest is successfully generated and contains correct content.
+        """
+        env_data = utils.load_test_data("cached_dependencies.yaml")["cached_deps"]
+        self.use_local = env_data["use_local"]
+        if self.use_local:
+            pytest.skip("The local repos are not supported for the test")
+
+        self.git_user = env_data.get("git_user")
+        self.git_email = env_data.get("git_email")
+
+        # Download dependency repo into a new directory
+        dep_repo_dir = os.path.join(tmpdir, "dep")
+        generated_suffix = "".join(
+            random.choice(string.ascii_letters + string.digits) for _ in range(10)
+        )
+        self.branch = f"test-{generated_suffix}"
+        self.cloned_dep_repo = clone_repo_in_new_dir(
+            env_data["ssh_dep_repo"], self.branch, dep_repo_dir
+        )
+        # set user configuration, if available
+        if self.git_user:
+            self.cloned_dep_repo.config_writer().set_value("user", "name", self.git_user).release()
+        if self.git_email:
+            self.cloned_dep_repo.config_writer().set_value(
+                "user", "email", self.git_email
+            ).release()
+
+        # Make changes in dependency repo
+        # We need 2 commits:
+        # 1st for remote source archive dependency
+        # 2nd for VCS dependency
+        new_dep_commits = []
+        for _ in range(2):
+            self.cloned_dep_repo.git.commit(
+                "--allow-empty", m="Commit created in integration test for Cachito"
+            )
+            new_dep_commits.append(self.cloned_dep_repo.head.object.hexsha)
+
+        # Push changes
+        self.dep_repo_origin = self.cloned_dep_repo.remote(name="origin")
+        self.dep_repo_origin.push(self.branch)
+
+        # Download the archive with first commit changes
+        archive_name = os.path.join(tmpdir, f"{new_dep_commits[0]}.zip")
+        utils.download_archive(
+            f"{env_data['dep_archive_baseurl']}{new_dep_commits[0]}.zip", archive_name
+        )
+        # Get the archive hash
+        dep_hash = utils.get_sha256_hash_from_file(archive_name)
+
+        # Download the main repo into a new dir
+        main_repo_dir = os.path.join(tmpdir, "main")
+        self.cloned_main_repo = clone_repo_in_new_dir(
+            env_data["ssh_main_repo"], self.branch, main_repo_dir
+        )
+        if self.git_user:
+            self.cloned_main_repo.config_writer().set_value("user", "name", self.git_user).release()
+        if self.git_email:
+            self.cloned_main_repo.config_writer().set_value(
+                "user", "email", self.git_email
+            ).release()
+
+        # Add new dependencies into the main repo
+        with open(os.path.join(main_repo_dir, "requirements.txt"), "a") as f:
+            f.write(
+                f"{env_data['dep_archive_baseurl']}{new_dep_commits[0]}"
+                f".zip#egg=appr&cachito_hash=sha256:{dep_hash}\n"
+            )
+            f.write(f"git+{env_data['https_dep_repo']}@{new_dep_commits[1]}#egg=appr\n")
+        diff_files = self.cloned_main_repo.git.diff(None, name_only=True)
+        self.cloned_main_repo.git.add(diff_files)
+        self.cloned_main_repo.git.commit("-m", "test commit")
+        self.main_repo_commit = self.cloned_main_repo.head.object.hexsha
+        self.main_repo_origin = self.cloned_main_repo.remote(name="origin")
+        self.main_repo_origin.push(self.branch)
+
+        # Create new Cachito request
+        client = utils.Client(
+            test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout")
+        )
+        payload = {
+            "repo": env_data["https_main_repo"],
+            "ref": self.main_repo_commit,
+            "pkg_managers": env_data["pkg_managers"],
+        }
+        try:
+            initial_response = client.create_new_request(payload=payload)
+            completed_response = client.wait_for_complete_request(initial_response)
+        finally:
+            # Delete the dependency branch
+            delete_branch_and_check(
+                self.branch, self.cloned_dep_repo, self.dep_repo_origin, new_dep_commits
+            )
+
+        replace_rules = {
+            "FIRST_DEP_COMMIT": new_dep_commits[0],
+            "SECOND_DEP_COMMIT": new_dep_commits[1],
+            "FIRST_DEP_HASH": dep_hash,
+            "MAIN_REPO_COMMIT": self.main_repo_commit,
+        }
+        update_expected_data(env_data, replace_rules)
+        assert_successful_cached_request(completed_response, env_data, tmpdir, client)
+        # Create new Cachito request to test cached deps
+        initial_response = client.create_new_request(payload=payload)
+        completed_response = client.wait_for_complete_request(initial_response)
+
+        assert_successful_cached_request(completed_response, env_data, tmpdir, client)
+
+
+def assert_successful_cached_request(response, env_data, tmpdir, client):
+    """
+    Provide all verifications for Cachito request with cached dependencies.
+
+    :param Response response: completed Cachito response
+    :param dict env_data: the test data
+    :param tmpdir: the path to directory with testing files
+    :param Client client: the Cachito client to make requests
+    """
+    utils.assert_properly_completed_response(response)
+
+    response_data = response.data
+    expected_response_data = env_data["response_expectations"]
+    utils.assert_elements_from_response(response_data, expected_response_data)
+
+    client.download_and_extract_archive(response.id, tmpdir)
+    source_path = tmpdir.join(f"download_{str(response.id)}")
+    expected_files = env_data["expected_files"]
+    utils.assert_expected_files(source_path, expected_files, tmpdir)
+
+    purl = env_data["purl"]
+    deps_purls = []
+    source_purls = []
+    if "dep_purls" in env_data:
+        deps_purls = [{"purl": x} for x in env_data["dep_purls"]]
+    if "source_purls" in env_data:
+        source_purls = [{"purl": x} for x in env_data["source_purls"]]
+
+    image_contents = [{"dependencies": deps_purls, "purl": purl, "sources": source_purls}]
+    utils.assert_content_manifest(client, response.id, image_contents)
+
+
+def clone_repo_in_new_dir(ssh_repo, branch, repo_dir):
+    """
+    Clone repo in new directory and open special branch.
+
+    :param str ssh_repo: SSH repository for cloning
+    :param str branch: The name of new branch to open
+    :param str repo_dir: Name of new directory to create
+    :return cloned_dep_repo: git.Repo what was cloned
+    """
+    os.mkdir(repo_dir)
+    cloned_dep_repo = git.Repo.clone_from(ssh_repo, repo_dir)
+    # Open a new branch in repo
+    cloned_dep_repo.git.checkout("-b", branch)
+    assert cloned_dep_repo.active_branch.name == branch
+    return cloned_dep_repo
+
+
+def create_local_repository(repo_path):
+    """
+    Create a local git repoitory.
+
+    :param str repo_path: path to new bare git repository
+    :return: normalized bare git repository path
+    :rtype: str
+    """
+    bare_repo_dir = Path(repo_path)
+    bare_repo = git.Repo.init(str(bare_repo_dir), bare=True)
+    assert bare_repo.bare, f"{bare_repo} is not bare repository"
+    # We need to expand this for later usage from the original repo directory
+    return str(bare_repo_dir.resolve())
+
+
+def delete_branch_and_check(branch, repo, remote, commits):
+    """
+    Delete remote branch and check that commits were deleted.
+
+    :param str branch: Remote branch to delete
+    :param git.Repo repo: Git repository
+    :param remote: Git remote with branch to delete
+    :param list commits: List of commits to check were deleted
+    """
+    repo.git.push("--delete", remote.name, branch)
+    repo.heads.master.checkout()
+    repo.git.branch("-D", branch)
+    for commit in commits:
+        assert not repo.git.branch(
+            "-a", "--contains", commit
+        ), f"Commit {commit} is still in a branch (it shouldn't be there at this point)."
+
+
+def replace_by_rules(orig_str, replace_rules):
+    """
+    Replace elements in string according to replace rules.
+
+    :param str orig_str: original string
+    :param dict replace_rules: replace rules as a dictionary:
+        {<ORIG_PART>: <NEW_PART>}
+    :return: string with replaced values
+    :rtype: str
+    """
+    res_string = orig_str
+    for s, r in replace_rules.items():
+        if s in res_string:
+            res_string = res_string.replace(s, r)
+    return res_string
+
+
+def update_expected_data(env_data, replace_rules):
+    """
+    Update expected data for the test in place.
+
+    Change commits and hashes in:
+    * expected_files
+    * response_expectations
+    * all purls in env_data
+    :param dict env_data: the test data
+    :param dict replace_rules: replace rules as a dictionary:
+        {<ORIG_PART>: <NEW_PART>}
+    """
+    new_expected_files = {}
+    for file, url in env_data["expected_files"].items():
+        new_expected_files[replace_by_rules(file, replace_rules)] = replace_by_rules(
+            url, replace_rules
+        )
+    env_data["expected_files"] = new_expected_files
+
+    for i, dep in enumerate(env_data["response_expectations"]["dependencies"]):
+        env_data["response_expectations"]["dependencies"][i]["version"] = replace_by_rules(
+            dep["version"], replace_rules
+        )
+    for i, dep in enumerate(env_data["response_expectations"]["packages"][0]["dependencies"]):
+        env_data["response_expectations"]["packages"][0]["dependencies"][i][
+            "version"
+        ] = replace_by_rules(dep["version"], replace_rules)
+
+    env_data["purl"] = replace_by_rules(env_data["purl"], replace_rules)
+    for i, p in enumerate(env_data["dep_purls"]):
+        env_data["dep_purls"][i] = replace_by_rules(p, replace_rules)
+    for i, p in enumerate(env_data["source_purls"]):
+        env_data["source_purls"][i] = replace_by_rules(p, replace_rules)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from collections import namedtuple
+import hashlib
 import json
 import os
 import shutil
@@ -180,6 +181,29 @@ def escape_path_go(dependency):
         return package_name
     else:
         return dependency
+
+
+def get_sha256_hash_from_file(filename):
+    """
+    Return sha256 hash of file.
+
+    :param str filename: The path to file
+    :return: sha256 hash of file
+    :rtype: str
+    """
+    # make a hash object
+    h = hashlib.sha256()
+
+    # open file for reading in binary mode
+    with open(filename, "rb") as file:
+        # loop till the end of the file, 1024 bytes at a time
+        chunk = file.read(1024)
+        while chunk:
+            h.update(chunk)
+            chunk = file.read(1024)
+
+    # return the hex representation of digest
+    return h.hexdigest()
 
 
 def load_test_data(file_name):


### PR DESCRIPTION
Test pip package with cached dependency.

The test verifies that even after deleting dependency Cachito will provide cached version.

    Stages:
    1. Make changes in dependency repository:
        * create new branch
        * push 2 new commits
    2. Make changes in requirements.txt in original repository:
        * add VCS and remote source archive dependencies
        based on commits from 1.
        * push changes with new commit
    3. Create Cachito request and verify it [1]
    4. Delete branch in dependency repository
    5. Create Cachito request and verify it [1]
   

 [1] Verifications:
   
-  The request completes successfully.
-   A single pip package is identified. Dependencies are correctly listed under “.dependencies” and under “.packages | select(.type == “pip”) | .dependencies”.
-   The source tarball includes the application source code under the app directory.
-   The source tarball includes the dependencies and dev dependencies source code under deps/pip directory.
-   The content manifest is successfully generated and contains correct content.