### PR TITLE
Add support for setuptools >= 49

### DIFF
--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1066,7 +1066,11 @@ class PipRequirement:
 
         try:
             parsed = list(pkg_resources.parse_requirements(to_be_parsed))
-        except pkg_resources.RequirementParseError as exc:
+        except (
+            pkg_resources.RequirementParseError,
+            pkg_resources.extern.packaging.requirements.InvalidRequirement,
+        ) as exc:
+            # see https://github.com/pypa/setuptools/pull/2137
             raise ValidationError(f"Unable to parse the requirement {to_be_parsed!r}: {exc}")
 
         if not parsed:


### PR DESCRIPTION
setuptools 49 removed RequirementParseError in favor of
packaging.requirements.InvalidRequirement. The former name was kept for
backwards compatibility but InvalidRequirement should be used instead.

Not performing this change leads to breakage when using setuptools >=
49, which is shipped in Fedora 33.

Moreover, this change should not break deployments using setuptools <
49, since the InvalidRequirement error is not new in "packaging".

* https://setuptools.readthedocs.io/en/latest/history.html#id67

Signed-off-by: Athos Ribeiro <athos@redhat.com>