### PR TITLE
Temporarily downgrade required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,5 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     license="GPLv3+",
-    python_requires=">=3.7",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
For infrastructure reasons, set required python version to >=3.6. This
should be a temporary measure.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>