### PR TITLE
Add API handler for yarn requests

### DIFF
--- a/cachito/errors.py
+++ b/cachito/errors.py
@@ -15,3 +15,7 @@ class ConfigError(CachitoError):
 
 class ContentManifestError(CachitoError, ValueError):
     """An error was encountered during content manifest generation."""
+
+
+class CachitoNotImplementedError(CachitoError, ValueError):
+    """An error was encountered during request validation."""

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -11,7 +11,7 @@ from flask_login import current_user, login_required
 import kombu.exceptions
 from werkzeug.exceptions import Forbidden, InternalServerError, Gone, NotFound
 
-from cachito.errors import CachitoError, ValidationError
+from cachito.errors import CachitoError, ValidationError, CachitoNotImplementedError
 from cachito.web import db
 from cachito.web.models import (
     ConfigFileBase64,
@@ -274,6 +274,8 @@ def create_request():
         chain_tasks.append(
             tasks.add_git_submodules_as_package.si(request.id).on_error(error_callback)
         )
+    if "yarn" in pkg_manager_names:
+        raise CachitoNotImplementedError("Yarn is not yet supported")
 
     chain_tasks.append(tasks.create_bundle_archive.si(request.id).on_error(error_callback))
 

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -38,7 +38,7 @@ class DevelopmentConfig(Config):
     CACHITO_BUNDLES_DIR = os.path.join(tempfile.gettempdir(), "cachito-archives", "bundles")
     CACHITO_LOG_LEVEL = "DEBUG"
     CACHITO_MUTUALLY_EXCLUSIVE_PACKAGE_MANAGERS = [("npm", "yarn"), ("gomod", "git-submodule")]
-    CACHITO_PACKAGE_MANAGERS = ["gomod", "npm", "pip", "git-submodule"]
+    CACHITO_PACKAGE_MANAGERS = ["gomod", "npm", "pip", "git-submodule", "yarn"]
     CACHITO_REQUEST_FILE_LOGS_DIR = "/var/log/cachito/requests"
     SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://cachito:cachito@db:5432/cachito"
     SQLALCHEMY_TRACK_MODIFICATIONS = True

--- a/cachito/web/errors.py
+++ b/cachito/web/errors.py
@@ -2,7 +2,12 @@
 from flask import jsonify
 from werkzeug.exceptions import HTTPException
 
-from cachito.errors import CachitoError, ContentManifestError, ValidationError
+from cachito.errors import (
+    CachitoError,
+    ContentManifestError,
+    ValidationError,
+    CachitoNotImplementedError,
+)
 
 
 def json_error(error):
@@ -28,6 +33,9 @@ def json_error(error):
         elif isinstance(error, ContentManifestError):
             # If the request was completed and a ICM cannot be generated,
             # some package type or corner case is not yet implemented
+            status_code = 501
+        elif isinstance(error, CachitoNotImplementedError):
+            # If the request asks for not implemented functionality
             status_code = 501
         elif isinstance(error, CachitoError):
             # If a generic exception is raised, assume the service is unavailable

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -2161,3 +2161,15 @@ def test_validate_package_manager_exclusivity(
             _validate_package_manager_exclusivity(pkg_managers, package_configs, mutually_exclusive)
     else:
         _validate_package_manager_exclusivity(pkg_managers, package_configs, mutually_exclusive)
+
+
+def test_create_request_with_yarn(auth_env, client):
+    data = {
+        "repo": "https://github.com/seriousManual/dedupe",
+        "ref": "955aa2f0d2dedf1b04814e38ad80deb17a602b9c",
+        "pkg_managers": ["yarn"],
+    }
+
+    rv = client.post("/api/v1/requests", json=data, environ_base=auth_env)
+    assert rv.status_code == 501
+    assert rv.json == {"error": "Yarn is not yet supported"}


### PR DESCRIPTION
Add API handler for yarn requests, request to Cachito will return a 501 error (NotImplementedError).