### PR TITLE
Set the GOMODCACHE environment variable

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -69,6 +69,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
             "GOCACHE": temp_dir,
             "GOPROXY": worker_config.cachito_athens_url,
             "PATH": os.environ.get("PATH", ""),
+            "GOMODCACHE": "{}/pkg/mod".format(temp_dir),
         }
 
         run_params = {"env": env, "cwd": app_source_path}

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -105,6 +105,7 @@ def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
             env_vars = {
                 "GOCACHE": {"value": "deps/gomod", "kind": "path"},
                 "GOPATH": {"value": "deps/gomod", "kind": "path"},
+                "GOMODCACHE": {"value": "deps/gomod/pkg/mod", "kind": "path"},
             }
             env_vars.update(config.cachito_default_environment_variables.get("gomod", {}))
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,6 +224,7 @@ def sample_package():
 def sample_env_vars():
     sample = {}
     sample["GOPATH"] = sample["GOCACHE"] = {"value": "deps/gomod", "kind": "path"}
+    sample["GOMODCACHE"] = {"value": "deps/gomod/pkg/mod", "kind": "path"}
     return sample
 
 

--- a/tests/integration/test_run_app_from_bundle.py
+++ b/tests/integration/test_run_app_from_bundle.py
@@ -38,6 +38,7 @@ def test_run_app_from_bundle(test_env, default_requests, tmpdir):
         env={
             "GOPATH": str(bundle_dir.join("deps", "gomod")),
             "GOCACHE": str(bundle_dir.join("deps", "gomod")),
+            "GOMODCACHE": "{}/pkg/mod".format(str(bundle_dir.join("deps", "gomod"))),
         },
         cwd=str(bundle_dir.join("app")),
         check=True,

--- a/tests/test_workers/test_pkg_managers/test_general.py
+++ b/tests/test_workers/test_pkg_managers/test_general.py
@@ -56,6 +56,7 @@ def test_update_request_with_package(mock_requests, package_subpath, include_sub
     env_vars = {
         "GOCACHE": {"value": "deps/gomod", "kind": "path"},
         "GOPATH": {"value": "deps/gomod", "kind": "path"},
+        "GOMODCACHE": {"value": "deps/gomod/pkg/mod", "kind": "path"},
     }
     expected_json = {
         "environment_variables": env_vars,


### PR DESCRIPTION
GOMODCACHE was introduced in go 1.15. We should make sure to set it to
make sure that the cache can be found.

The default value for GOMODCACHE is GOPATH[0]/pkg/mod according to https://golang.org/doc/go1.15

Signed-off-by: arewm <arewm@users.noreply.github.com>