### PR TITLE
Integration tests: change test_packages.py

### DIFF
--- a/tests/integration/test_data/gomod_packages.yaml
+++ b/tests/integration/test_data/gomod_packages.yaml
@@ -5,7 +5,7 @@
 # expected_files: Expected source files <relative_path>: <file_URL>
 # expected_deps_files: Expected dependencies files (empty)
 # response_expectations: Parts of the Cachito response to check
-# purl: PURL of the package
+# content_manifest: PURLs for image contents part
 without_deps:
   repo: https://github.com/cachito-testing/cachito-gomod-without-deps.git
   ref: a888f7261b9a9683972fbd77da2d12fe86faef5e
@@ -24,7 +24,8 @@ without_deps:
   expected_files:
     app: https://github.com/cachito-testing/cachito-gomod-without-deps/tarball/a888f7261b9a9683972fbd77da2d12fe86faef5e
     deps/gomod/pkg/mod/cache/download: null
-  purl: "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-without-deps@v0.0.0-20200925115855-a888f7261b9a"
+  content_manifest:
+  - purl: "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-without-deps@v0.0.0-20200925115855-a888f7261b9a"
 with_deps:
   repo: https://github.com/cachito-testing/cachito-gomod-with-deps.git
   ref: 4c65d49cae6bfbada4d479b321d8c0109fa1aa97
@@ -99,13 +100,14 @@ with_deps:
   expected_files:
     app: https://github.com/cachito-testing/cachito-gomod-with-deps/tarball/4c65d49cae6bfbada4d479b321d8c0109fa1aa97
     deps/gomod/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.2.zip: https://github.com/cachito-testing/test_files/raw/master/test_gomod_with_deps_quote.tar.gz
-  purl: "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-with-deps@v0.0.0-20201001160613-4c65d49cae6b"
-  dep_purls:
+  content_manifest:
+  - purl: "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-with-deps@v0.0.0-20201001160613-4c65d49cae6b"
+    dep_purls:
     - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/rsc.io%2Fquote@v1.5.2"
     - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
-  source_purls:
+    source_purls:
     - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/rsc.io%2Fquote@v1.5.2"
     - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
@@ -186,16 +188,17 @@ vendored_with_flag:
   expected_files:
     app: https://github.com/cachito-testing/gomod-vendored/tarball/ff1960095dd158d3d2a4f31d15b244c24930248b
     deps/gomod/pkg/mod/cache/download: null
-  purl: "pkg:golang/github.com%2Fcachito-testing%2Fgomod-vendored@v0.0.0-20200916135625-ff1960095dd1"
-  dep_purls:
-  - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
-  - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
-  - "pkg:golang/rsc.io%2Fquote@v1.5.2"
-  - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
-  source_purls:
-  - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
-  - "pkg:golang/rsc.io%2Fquote@v1.5.2"
-  - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+  content_manifest:
+  - purl: "pkg:golang/github.com%2Fcachito-testing%2Fgomod-vendored@v0.0.0-20200916135625-ff1960095dd1"
+    dep_purls:
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+    source_purls:
+    - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
 # The test data for gomod package with vendor directory
 # and without `gomod-vendor` flag.
 vendored_without_flag:
@@ -276,13 +279,14 @@ implicit_gomod:
   expected_files:
     app: https://github.com/cachito-testing/cachito-gomod-with-deps/tarball/4c65d49cae6bfbada4d479b321d8c0109fa1aa97
     deps/gomod/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.2.zip: https://github.com/cachito-testing/test_files/raw/master/test_gomod_with_deps_quote.tar.gz
-  purl: "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-with-deps@v0.0.0-20201001160613-4c65d49cae6b"
-  dep_purls:
+  content_manifest:
+  - purl: "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-with-deps@v0.0.0-20201001160613-4c65d49cae6b"
+    dep_purls:
     - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/rsc.io%2Fquote@v1.5.2"
     - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
-  source_purls:
+    source_purls:
     - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/rsc.io%2Fquote@v1.5.2"
     - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
@@ -297,4 +301,4 @@ missing_gomod:
   expected_files:
     app: https://github.com/cachito-testing/cachito-missing-gomod-file/tarball/0ae32a94a2a4f17b6702f8dddb1ddb88154f4473
     deps: null
-  image_contents: []
+  content_manifest: []

--- a/tests/integration/test_data/pip_packages.yaml
+++ b/tests/integration/test_data/pip_packages.yaml
@@ -91,3 +91,78 @@ with_deps:
 local_path:
   repo: https://github.com/cachito-testing/cachito-pip-local-path.git
   ref: d66f7e029a15e8dc96ced65865344e6088c3fdd5
+# Multiple pip packages
+# repo: The URL for the upstream git repository
+# ref: A git reference at the given git repository
+# expected_files: Expected source files <relative_path>: <file_URL>
+# expected_deps_files: Expected dependencies files <relative_path>
+# response_expectations: Parts of the Cachito response to check
+# purl: PURL of the package
+# dep_purls: PURLs if dependencies
+multiple:
+  repo: https://github.com/cachito-testing/cachito-pip-multiple.git
+  ref: 93c6c44b36075454a509d595850b81be29e53db0
+  pkg_managers: ["pip"]
+  packages:
+    pip: [{"path": "first_pkg"}, {"path": "second_pkg"}]
+  expected_files:
+    app: https://github.com/cachito-testing/cachito-pip-multiple/tarball/93c6c44b36075454a509d595850b81be29e53db0
+    deps/pip/aiowsgi/aiowsgi-0.7.tar.gz : https://files.pythonhosted.org/packages/f4/3d/1933776c5215c61e38968fedd73c41251e8752736e1cd9fbb73db44ff4e1/aiowsgi-0.7.tar.gz
+    deps/pip/external-appr/appr-external-sha256-ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c.zip: https://github.com/quay/appr/tarball/37ff9a487a54ad41b59855ecd76ee092fe206a84
+    deps/pip/github.com/quay/appr/appr-external-gitcommit-58c88e4952e95935c0dd72d4a24b0c44f2249f5b.tar.gz: https://github.com/quay/appr/tarball/58c88e4952e95935c0dd72d4a24b0c44f2249f5b
+  response_expectations:
+    dependencies:
+    - dev: false
+      name: "appr"
+      replaces: null
+      type: "pip"
+      version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+    - dev: false
+      name: "appr"
+      replaces: null
+      type: "pip"
+      version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+    - dev: false
+      name: "aiowsgi"
+      replaces: null
+      type: "pip"
+      version: "0.7"
+    packages:
+    - dependencies:
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+      - dev: false
+        name: "aiowsgi"
+        replaces: null
+        type: "pip"
+        version: "0.7"
+      name: "first_pkg"
+      path: "first_pkg"
+      type: "pip"
+      version: "1.0.0"
+    - dependencies:
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+      name: "second_pkg"
+      path: "second_pkg"
+      type: "pip"
+      version: "1.0.0"
+  content_manifest:
+  - purl: "pkg:github/cachito-testing/cachito-pip-multiple@93c6c44b36075454a509d595850b81be29e53db0#first_pkg"
+    dep_purls:
+    - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+    - "pkg:pypi/aiowsgi@0.7"
+    source_purls:
+    - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+    - "pkg:pypi/aiowsgi@0.7"
+  - purl: "pkg:github/cachito-testing/cachito-pip-multiple@93c6c44b36075454a509d595850b81be29e53db0#second_pkg"
+    dep_purls:
+    - "pkg:github/quay/appr@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+    source_purls:
+    - "pkg:github/quay/appr@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"

--- a/tests/integration/test_data/pip_packages.yaml
+++ b/tests/integration/test_data/pip_packages.yaml
@@ -5,7 +5,7 @@
 # expected_files: Expected source files <relative_path>: <file_URL>
 # expected_deps_files: Expected dependencies files (empty)
 # response_expectations: Parts of the Cachito response to check
-# purl: PURL of the package
+# content_manifest: PURLs for image contents part
 without_deps:
   repo: https://github.com/cachito-testing/cachito-pip-without-deps.git
   ref: fb07c8492432631d557aba15e1715af9cef9c844
@@ -20,15 +20,15 @@ without_deps:
         name: "cachito-pip-empty"
         type: "pip"
         version: "1.0.0"
-  purl: "pkg:github/cachito-testing/cachito-pip-without-deps@fb07c8492432631d557aba15e1715af9cef9c844"
+  content_manifest:
+  - purl: "pkg:github/cachito-testing/cachito-pip-without-deps@fb07c8492432631d557aba15e1715af9cef9c844"
 # pip package with dependencies in requirements.txt
 # repo: The URL for the upstream git repository
 # ref: A git reference at the given git repository
 # expected_files: Expected source files <relative_path>: <file_URL>
 # expected_deps_files: Expected dependencies files <relative_path>
 # response_expectations: Parts of the Cachito response to check
-# purl: PURL of the package
-# dep_purls: PURLs if dependencies
+# content_manifest: PURLs for image contents part
 with_deps:
   repo: https://github.com/cachito-testing/cachito-pip-with-deps.git
   ref: 83b387568b6287f6829403cff1e1377b0fb2f5d8
@@ -75,15 +75,19 @@ with_deps:
         name: "cachito-pip-with-deps"
         type: "pip"
         version: "1.0.0"
-  purl: "pkg:github/cachito-testing/cachito-pip-with-deps@83b387568b6287f6829403cff1e1377b0fb2f5d8"
-  dep_purls:
-  - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
-  - "pkg:github/quay/appr@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
-  - "pkg:pypi/aiowsgi@0.7"
-  source_purls:
+  content_manifest:
+  - purl: "pkg:github/cachito-testing/cachito-pip-with-deps@83b387568b6287f6829403cff1e1377b0fb2f5d8"
+    dep_purls:
     - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
     - "pkg:github/quay/appr@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
     - "pkg:pypi/aiowsgi@0.7"
+    source_purls:
+      - "pkg:generic/appr?download_url=https%3A%2F%2Fgithub.com%2Fquay%2Fappr%2Farchive%2F37ff9a487a54ad41b59855ecd76ee092fe206a84.zip%23egg%3Dappr%26cachito_hash%3Dsha256%3Aee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c&checksum=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
+      - "pkg:github/quay/appr@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+      - "pkg:pypi/aiowsgi@0.7"
+# pip package with local path
+# repo: The URL for the upstream git repository
+# ref: A git reference at the given git repository
 local_path:
   repo: https://github.com/cachito-testing/cachito-pip-local-path.git
   ref: d66f7e029a15e8dc96ced65865344e6088c3fdd5

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -43,6 +43,7 @@ def test_packages(env_package, env_name, test_env, tmpdir):
         "pkg_managers": env_data.get("pkg_managers", []),
         "flags": env_data.get("flags", []),
     }
+
     if env_name == "implicit_gomod":
         payload.pop("pkg_managers")
 
@@ -57,16 +58,17 @@ def test_packages(env_package, env_name, test_env, tmpdir):
     expected_files = env_data["expected_files"]
     utils.assert_expected_files(source_path, expected_files, tmpdir)
 
-    purl = env_data.get("purl", "")
-    deps_purls = []
-    source_purls = []
-    if "dep_purls" in env_data:
-        deps_purls = [{"purl": x} for x in env_data["dep_purls"]]
-    if "source_purls" in env_data:
-        source_purls = [{"purl": x} for x in env_data["source_purls"]]
-
-    if purl:
-        image_contents = [{"dependencies": deps_purls, "purl": purl, "sources": source_purls}]
-    else:
-        image_contents = env_data["image_contents"]
+    image_contents = []
+    for pkg in env_data.get("content_manifest"):
+        purl = pkg.get("purl", "")
+        dep_purls = []
+        source_purls = []
+        if "dep_purls" in pkg:
+            dep_purls = [{"purl": x} for x in pkg["dep_purls"]]
+        if "source_purls" in pkg:
+            source_purls = [{"purl": x} for x in pkg["source_purls"]]
+        if purl:
+            image_contents.append(
+                {"dependencies": dep_purls, "purl": purl, "sources": source_purls}
+            )
     utils.assert_content_manifest(client, completed_response.id, image_contents)

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -10,6 +10,7 @@ import utils
     [
         ("pip_packages", "without_deps"),
         ("pip_packages", "with_deps"),
+        ("pip_packages", "multiple"),
         ("gomod_packages", "without_deps"),
         ("gomod_packages", "with_deps"),
         ("gomod_packages", "vendored_with_flag"),
@@ -43,6 +44,9 @@ def test_packages(env_package, env_name, test_env, tmpdir):
         "pkg_managers": env_data.get("pkg_managers", []),
         "flags": env_data.get("flags", []),
     }
+    # Add packages to Cachito request if possible
+    if "packages" in env_data:
+        payload["packages"] = env_data["packages"]
 
     if env_name == "implicit_gomod":
         payload.pop("pkg_managers")


### PR DESCRIPTION
### -  Add new test data: multiple pip packages
The application repository contains two subdirectories. Each has a setup.cfg file which defines a different name, and version. For each subdirectories, there should be a requirements.txt file. The dependencies should be different between the two packages. This will ensure the accuracy of the test.
**Verification**
1. The request completes successfully.
2. Two pip packages are identified. Dependencies are correctly listed under “.dependencies” and under the corresponding “.packages | select(.type == “pip”) | .dependencies”.
3. The source tarball includes the application source code under the app directory.
4. The source tarball includes the dependencies and dev dependencies source code from both packages under the deps/pip directory.

The content manifest is successfully generated and contains correct content.

### - Update content manifest test data
Change test data to support multiple packages in content manifest data:
```
content_manifest:
- <PURLs for first package>
- ...
```