### PR TITLE
Add yarn Nexus cleanup task

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -385,10 +385,9 @@ def patch_request(request_id):
         new_state = payload["state"]
         delete_bundle = new_state == "stale" and request.state.state_name != "failed"
         if new_state in ("stale", "failed"):
-            if any(p.name == "npm" for p in request.pkg_managers):
-                cleanup_nexus.append("npm")
-            if any(p.name == "pip" for p in request.pkg_managers):
-                cleanup_nexus.append("pip")
+            for pkg_manager in ["npm", "pip", "yarn"]:
+                if any(p.name == pkg_manager for p in request.pkg_managers):
+                    cleanup_nexus.append(pkg_manager)
         delete_bundle_temp = new_state in ("complete", "failed")
         delete_logs = new_state == "stale"
         new_state_reason = payload["state_reason"]

--- a/cachito/workers/tasks/yarn.py
+++ b/cachito/workers/tasks/yarn.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from cachito.workers import nexus
+from cachito.workers.pkg_managers.yarn import (
+    get_yarn_proxy_repo_name,
+    get_yarn_proxy_repo_username,
+)
+from cachito.workers.tasks.celery import app
+
+__all__ = ["cleanup_yarn_request"]
+
+
+@app.task
+def cleanup_yarn_request(request_id):
+    """Clean up the Nexus yarn content for the Cachito request."""
+    payload = {
+        "repository_name": get_yarn_proxy_repo_name(request_id),
+        "username": get_yarn_proxy_repo_username(request_id),
+    }
+    nexus.execute_script("js_cleanup", payload)

--- a/tests/test_workers/test_tasks/test_yarn.py
+++ b/tests/test_workers/test_tasks/test_yarn.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from unittest import mock
+
+from cachito.workers.tasks import yarn
+
+
+@mock.patch("cachito.workers.tasks.yarn.nexus.execute_script")
+def test_cleanup_yarn_request(mock_exec_script):
+    yarn.cleanup_yarn_request(42)
+
+    expected_payload = {
+        "repository_name": "cachito-yarn-42",
+        "username": "cachito-yarn-42",
+    }
+    mock_exec_script.assert_called_once_with("js_cleanup", expected_payload)


### PR DESCRIPTION
Remove temporary Nexus data for stale or
failed requests that uses "yarn" as package manager.

I am not really sure how to add a unit test, because for pip we have a magic number 42 [there](https://github.com/release-engineering/cachito/commit/925bcf626cce6ab08934963d86e480fbb16f6d31#diff-7544b2a9130cd35897671b973f103897f7d2ca241fe9ff3efbb482829d5d801aR9) 