### PR TITLE
Migrate Cachito to Fedora 33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 jobs:
   include:
+    - python: "3.9"
+      env: TOXENV=py39
     - python: "3.8"
-      env: TOXENV=black,flake8
+      env: TOXENV=black,flake8  # as soon as black > 20.8b1 is released and we start using it, we can move these tests to the python 3.9 job
     - python: "3.8"
       env: TOXENV=py38
-    - python: "3.7"
-      env: TOXENV=py37
 install:
   - pip install tox
 script:

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:33
 LABEL maintainer="Factory 2.0"
 
 WORKDIR /src

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:33
 LABEL maintainer="Factory 2.0"
 
 WORKDIR /src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38']
+target-version = ['py38']  # as soon as black > 20.8b1 is released and we start using it, we can include py39 here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-celery<5
+celery>=5
 gitpython
-kombu<5 # A celery dependency but it's directly imported
+kombu>=5 # A celery dependency but it's directly imported
 packaging
 pyarn @ git+https://github.com/containerbuildsystem/pyarn.git
 requests_kerberos

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "celery<5",
+        "celery>=5",
         "gitpython",
-        "kombu<5",  # A celery dependency but it's directly imported
+        "kombu>=5",  # A celery dependency but it's directly imported
         "packaging",
         "pyarn",
         "requests_kerberos",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black,flake8,py38
+envlist = black,flake8,py39
 
 [testenv]
 deps =


### PR DESCRIPTION
Update base images of cachito-workers and cachito-api to Fedora 33.