### PR TITLE
Use Fedora images from registry.fedoraproject.org

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM registry.fedoraproject.org/fedora:33
 LABEL maintainer="Factory 2.0"
 
 WORKDIR /src

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM registry.fedoraproject.org/fedora:33
 LABEL maintainer="Factory 2.0"
 
 WORKDIR /src


### PR DESCRIPTION
Changing images to use Fedora registry instead of  DockerHub