### PR TITLE
Add cachito-download.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,35 @@ may mount a
 by adding the volume mount `- /path/to/.netrc:/root/.netrc:ro,z` in your `docker-compose.yml`
 file under the `cachito-worker` container.
 
+### Using Cachito Requests Locally
+
+When testing new functionality or debugging a failure, you may want to take a completed Cachito
+request and try to install the processed packages locally (using `pip`, `gomod`, `npm` etc.). You
+can use the [cachito-download.sh](bin/cachito-download.sh) script to download the source archive
+for a request and inject the configuration files and environment variables.
+
+Here is how you would use it with the example request
+[above](#run-a-containerized-development-environment) (assuming it is request #1)
+
+```shell
+bin/cachito-download.sh localhost:8080/api/v1/requests/1 /tmp/cachito-test
+
+cd /tmp/cachito-test/remote-source/
+# sed will sometimes be needed for requests from the dev environment
+sed 's/nexus:8081/localhost:8082/g' --in-place cachito.env app/requirements.txt
+
+# you don't *have* to use a container but having a clean environment is usually desirable
+podman run --net=host --rm -ti -v "$PWD:/remote-source:z" -w "/remote-source" fedora:33
+# <inside the container>
+dnf -y install python3-pip
+source cachito.env
+cd app
+pip install -r requirements.txt
+python3 setup.py install
+```
+
+You need to have [jq](https://stedolan.github.io/jq/) installed for the script to work.
+
 ## Database Migrations
 
 Follow the steps below for database data and/or schema migrations:

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ curl -X POST -H "Content-Type: application/json" http://localhost:8080/api/v1/re
 '{
 "repo": "https://github.com/athos-ribeiro/cachito-sample-pip-package.git",
 "ref": "51ffb9c2412d50953ed9732c67267e5d2ff9aa68",
-"pkg_managers": ["pip"]
+"pkg_managers": ["pip"],
 "packages": {"pip": [{"path": "."}, {"path": "subpackage"}]}
 }'
 ```

--- a/bin/cachito-download.sh
+++ b/bin/cachito-download.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -euo pipefail
+
+usage () {
+    echo "Usage: $(basename "$0") <request_url> <output_dir>"
+}
+
+description () {
+    cat << EOF
+Download a Cachito request, inject its configuration files and cachito.env
+
+$(usage)
+
+Example:
+    $(basename "$0") localhost:8080/api/v1/requests/1 /tmp/cachito-test
+EOF
+}
+
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    description
+    exit 0
+fi
+
+if [ $# -ne 2 ]; then
+    usage >&2
+    exit 1
+fi
+
+request_url=$1
+output_dir=$2
+
+error () {
+    echo "$1" >&2
+    return 1
+}
+
+check_dependencies () {
+    command -v jq >/dev/null || error "Missing dependency: jq"
+}
+
+prepare_output_dir () {
+    local output_dir=$1
+
+    if [ -e "$output_dir" ]; then
+        if [ ! -d "$output_dir" ]; then
+            error "Cannot download to $output_dir: not a directory"
+        fi
+
+        if [ -n "$(ls -A "$output_dir")" ]; then
+            error "Cannot download to $output_dir: already exists and is not empty"
+        fi
+
+        echo "Using existing output directory $output_dir"
+    else
+        echo "Using new output directory $output_dir"
+        mkdir -p "$output_dir"
+    fi
+}
+
+download_and_extract () {
+    local request_url=$1
+    local output_dir=$2
+
+    echo "Downloading archive"
+    # -f: fail on HTTP error code, -s: silent, -S: show error even when silent
+    curl -fsS "$request_url/download" > "$output_dir/remote-source.tar.gz"
+
+    echo "Extracting downloaded archive to remote-source/"
+    mkdir "$output_dir/remote-source"
+    tar -xf "$output_dir/remote-source.tar.gz" -C "$output_dir/remote-source"
+}
+
+inject_config_files () {
+    local request_url=$1
+    local output_dir=$2
+
+    local config_json="$output_dir/configuration-files.json"
+
+    echo "Getting configuration files"
+    curl -fsS "$request_url/configuration-files" > "$config_json"
+
+    echo "Injecting configuration files to remote-source/"
+    # According to shellcheck, this is the proper way to save lines in an array
+    mapfile -t paths < <(jq '.[].path' -r < "$config_json")
+
+    for path in "${paths[@]}"; do
+        # Show the path indented by 4 spaces
+        echo "    $path"
+
+        jq '.[] | select(.path == "'"$path"'") | .content' -r < "$config_json" |
+            base64 --decode > "$output_dir/remote-source/$path"
+    done
+}
+
+generate_cachito_env () {
+    local request_url=$1
+    local output_dir=$2
+
+    local env_json="$output_dir/environment-variables.json"
+    local cachito_env="$output_dir/remote-source/cachito.env"
+
+    echo "Getting environment variables"
+    curl -fsS "$request_url/environment-variables" > "$env_json"
+
+    echo "Injecting cachito.env to remote-source/"
+    echo "#/bin/bash" > "$cachito_env"
+
+    jq 'to_entries[] | "\(.value.kind) \(.key) \(.value.value)"' -r < "$env_json" |
+        while read -r kind key value; do
+            if [ "$kind" = "path" ]; then
+                value="$(realpath "$output_dir")/remote-source/$value"
+            fi
+            printf "export %s=%q\n" "$key" "$value"
+        done >> "$cachito_env"
+
+    # Show the generated env file indented by 4 spaces
+    sed 's/^/    /' "$cachito_env"
+}
+
+check_dependencies
+prepare_output_dir "$output_dir"
+download_and_extract "$request_url" "$output_dir"
+inject_config_files "$request_url" "$output_dir"
+generate_cachito_env "$request_url" "$output_dir"


### PR DESCRIPTION
Downloads the archive for a request, then injects all the configuration
files and environment variables (as cachito.env). Should match current
OSBS behavior.

It is written in bash and has one non-standard dependency which is jq.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>