### PR TITLE
Fix the modified yarn.lock provided by Cachito

### DIFF
--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -136,12 +136,9 @@ def test_convert_to_nexus_hosted(
 
     rv = yarn._convert_to_nexus_hosted(dep_name, dep_source, dep_info)
     assert rv == {
-        **dep_info,
         "version": mock_process_dep.return_value.version,
-        "resolved": mock_process_dep.return_value.source,
         "integrity": mock_process_dep.return_value.integrity,
     }
-    assert rv is not dep_info  # make sure original dict was copied
 
     mock_process_dep.assert_called_once_with(expected_jsdep)
     if "integrity" in dep_info:
@@ -389,14 +386,8 @@ def test_get_package_and_deps(
 @mock.patch("cachito.workers.pkg_managers.yarn.get_yarn_component_info_from_non_hosted_nexus")
 def test_set_non_hosted_resolved_urls(mock_get_component, components_exist):
     nexus_replacements = {
-        f"fecha@{HTTP_DEP_URL}": {
-            "version": HTTP_DEP_NEXUS_VERSION,
-            "resolved": HTTP_DEP_NEXUS_URL,
-        },
-        f"leftpad@{GIT_DEP_URL}": {
-            "version": GIT_DEP_NEXUS_VERSION,
-            "resolved": GIT_DEP_NEXUS_URL,
-        },
+        f"fecha@{HTTP_DEP_URL}": {"version": HTTP_DEP_NEXUS_VERSION},
+        f"leftpad@{GIT_DEP_URL}": {"version": GIT_DEP_NEXUS_VERSION},
     }
 
     non_hosted_url_1 = "http://nexus.example.org/repository/cachito-yarn-42/fecha.tar.gz"
@@ -550,10 +541,7 @@ def test_replace_deps_in_yarn_lock_dependencies():
     }
 
     nexus_replacements = {
-        "bar@external-1, bar@external-2": {
-            "version": "external-in-nexus-1",
-            "dependencies": original["bar@external-1, bar@external-2"]["dependencies"],
-        },
+        "bar@external-1, bar@external-2": {"version": "external-in-nexus-1"},
         "baz@external-3": {"version": "external-in-nexus-2"},
     }
 

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -498,16 +498,48 @@ def test_replace_deps_in_yarn_lock():
             "resolved": REGISTRY_DEP_URL,
             "integrity": MOCK_INTEGRITY,
         },
-        f"fecha@{HTTP_DEP_URL}": {
+        f"fecha@{http_dep_nexus_version}": {
             "version": http_dep_nexus_version,
             "resolved": http_dep_nexus_url,
             "integrity": http_dep_nexus_integrity,
         },
-        f"leftpad@{GIT_DEP_URL}": {
+        f"leftpad@{git_dep_nexus_version}": {
             "version": git_dep_nexus_version,
             "resolved": git_dep_nexus_url,
             "integrity": git_dep_nexus_integrity,
         },
+    }
+
+
+def test_replace_deps_in_yarn_lock_dependencies():
+    original = {
+        "foo@not-external-1": {"version": "not-external-1", "dependencies": {"bar": "external-2"}},
+        "bar@external-1, bar@external-2": {
+            "version": "external-1",
+            "dependencies": {"baz": "external-3"},
+        },
+        "baz@external-3": {"version": "external-3"},
+    }
+
+    nexus_replacements = {
+        "bar@external-1, bar@external-2": {
+            "version": "external-in-nexus-1",
+            "dependencies": original["bar@external-1, bar@external-2"]["dependencies"],
+        },
+        "baz@external-3": {"version": "external-in-nexus-2"},
+    }
+
+    replaced = yarn._replace_deps_in_yarn_lock(original, nexus_replacements)
+    assert replaced == {
+        "foo@not-external-1": {
+            "version": "not-external-1",
+            "dependencies": {"bar": "external-in-nexus-1"},
+        },
+        "bar@external-in-nexus-1": {
+            "version": "external-in-nexus-1",
+            "dependencies": {"baz": "external-in-nexus-2"},
+        },
+        "baz@external-in-nexus-2": {"version": "external-in-nexus-2"},
     }
 
 


### PR DESCRIPTION
All the changes combined have 2 main goals:

1. use correct top-level keys in the lockfile (1st commit)
2. use correct resolved urls in the lockfile (2nd and 3rd commit)

The 4th commit is just minor refactoring.

Example of 1.
```diff
< "fecha@https://github.com/taylorhakes/fecha/archive/91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz":
---
> fecha@4.2.0-external-sha1-f09ea0b8115b9733dddc88227086c73ba4ddc926:
```

Example of 2.
```diff
<   resolved "http://nexus:8081/repository/cachito-js-hosted/fecha/-/fecha-4.2.0-external-sha1-f09ea0b8115b9733dddc88227086c73ba4ddc926.tgz"
---
>   resolved "http://nexus:8081/repository/cachito-yarn-2/fecha/-/fecha-4.2.0-external-sha1-f09ea0b8115b9733dddc88227086c73ba4ddc926.tgz"
```

There is a 3rd issue which needs to be fixed, this one will be a change in pyarn:
```diff
< "type-detect@^4.0.0, type-detect@^4.0.5":
---
> type-detect@^4.0.0, type-detect@^4.0.5:
```