### PR TITLE
Forward yarn Cachito requests to workers

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -531,7 +531,7 @@ def _validate_request_package_configs(request_kwargs, pkg_managers_names):
             + ", ".join(invalid_package_managers)
         )
 
-    supported_packages_configs = {"npm", "pip", "gomod"}
+    supported_packages_configs = {"npm", "pip", "gomod", "yarn"}
     unsupported_packages_managers = packages_configs.keys() - supported_packages_configs
     if unsupported_packages_managers:
         raise ValidationError(
@@ -544,6 +544,7 @@ def _validate_request_package_configs(request_kwargs, pkg_managers_names):
         "npm": {"path"},
         "pip": {"path", "requirements_build_files", "requirements_files"},
         "gomod": {"path"},
+        "yarn": {"path"},
     }
     for pkg_manager, packages_config in packages_configs.items():
         invalid_format_error = (


### PR DESCRIPTION
Cachito request including the yarn package manager triggers the fetch_yarn_source celery task