### PR TITLE
Don't fail on local gomod dependencies

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -230,7 +230,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
                 # If the line did not contain a version, we'll use the module version
                 version = version or module_version
                 if version.startswith("."):
-                    raise CachitoError(f"Local gomod dependencies are not yet supported: {version}")
+                    continue
                 elif version.startswith("/") or PureWindowsPath(version).root:
                     # This will disallow paths starting with '/', '\' or '<drive letter>:\'
                     raise CachitoError(

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -320,42 +320,6 @@ def test_resolve_gomod_unused_dep(mock_run, mock_temp_dir, tmpdir):
 @mock.patch("cachito.workers.pkg_managers.gomod.GoCacheTemporaryDirectory")
 @mock.patch("cachito.workers.pkg_managers.gomod.RequestBundleDir")
 @mock.patch("subprocess.run")
-def test_resolve_gomod_disallow_local_dependencies(
-    mock_run, mock_bundle_dir, mock_temp_dir, mock_golang_version, mock_merge_tree, tmpdir
-):
-    # Mock the tempfile.TemporaryDirectory context manager
-    mock_temp_dir.return_value.__enter__.return_value = str(tmpdir)
-
-    # Mock the "subprocess.run" calls
-    mock_run.side_effect = [
-        # go mod download
-        mock.Mock(returncode=0, stdout=None),
-        # go list -m all
-        mock.Mock(returncode=0, stdout="k8s.io/kubectl"),
-        # go list -find ./...
-        mock.Mock(returncode=0, stdout="k8s.io/kubernetes/cmd/kubectl"),
-        # go list -deps
-        mock.Mock(
-            returncode=0,
-            stdout="k8s.io/kubectl/pkg/apps k8s.io/kubectl => ./staging/src/k8s.io/kubectl",
-        ),
-    ]
-
-    archive_path = "/this/is/path/to/archive.tar.gz"
-    request = {
-        "id": 3,
-        "ref": "c50b93a32df1c9d700e3e80996845bc2e13be848",
-    }
-    err_msg = "Local gomod dependencies are not yet supported: ./staging/src/k8s.io/kubectl"
-    with pytest.raises(CachitoError, match=err_msg):
-        resolve_gomod(archive_path, request)
-
-
-@mock.patch("cachito.workers.pkg_managers.gomod._merge_bundle_dirs")
-@mock.patch("cachito.workers.pkg_managers.gomod.get_golang_version")
-@mock.patch("cachito.workers.pkg_managers.gomod.GoCacheTemporaryDirectory")
-@mock.patch("cachito.workers.pkg_managers.gomod.RequestBundleDir")
-@mock.patch("subprocess.run")
 @pytest.mark.parametrize(
     "platform_specific_path",
     [


### PR DESCRIPTION
We want to add local dependencies in https://github.com/openshift/assisted-service, this "Local gomod dependencies are not yet supported" exception is blocking us from doing so. 

Is there any reason for this exception to be raised? Can it just be ignored like in the diff of this PR?

The local dependencies are always relative to the root of the repo anyway, so they get pulled along with all other repository files - it doesn't require any special handling by cachito, at-least to the best of my knowledge. 

What do you think?