### PR TITLE
Pin py-amqp version

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -25,6 +25,12 @@ RUN dnf -y install \
     python3-setuptools \
     && dnf clean all
 COPY . .
+
+# FIXME: there was a regression in py-amqp. It was supposed to be fixed in
+# https://github.com/celery/py-amqp/pull/350
+# but cachito is still being affected by the regression
+RUN rpm -e --nodeps python3-amqp && pip3 install amqp==5.0.2
+
 COPY ./docker/cachito-httpd.conf /etc/httpd/conf/httpd.conf
 # All the requirements except pyarn should already be installed
 RUN pip3 install pyarn && \

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -22,6 +22,12 @@ RUN dnf -y install \
     python3-setuptools \
     && dnf clean all
 COPY . .
+
+# FIXME: there was a regression in py-amqp. It was supposed to be fixed in
+# https://github.com/celery/py-amqp/pull/350
+# but cachito is still being affected by the regression
+RUN rpm -e --nodeps python3-amqp && pip3 install amqp==5.0.2
+
 # All the requirements except pyarn should already be installed
 RUN pip3 install pyarn && \
     pip3 install . --no-deps


### PR DESCRIPTION
A recent py-ampq update is causing cachito workers to fail to get local
certificates:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)
```

This has been reported upstream on
https://github.com/celery/py-amqp/issues/349 and fixed on
https://github.com/celery/py-amqp/pull/350.

However, even with the fix, provided by Fedora on
https://bodhi.fedoraproject.org/updates/FEDORA-2021-904397f5c4, Cachito
workers still fail to connect to rabbitmq (with the same error) when
enforcing SSL connections.

Let's pin py-amqp version to the latest version known to work with
Cachito so we do not need to halt development/deployments while we deal
with the amqp issue.

Signed-off-by: Athos Ribeiro <athos@redhat.com>