### PR TITLE
Commit DB operations after celery errors

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -294,6 +294,7 @@ def create_request():
         )
         error = "Failed to schedule the task to the workers. Please try again."
         request.add_state("failed", error)
+        db.session.commit()
         raise CachitoError(error)
 
     flask.current_app.logger.debug("Successfully scheduled request %d", request.id)

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -936,8 +936,20 @@ def test_create_request_connection_error(mock_chain, app, auth_env, client, db):
     )
     rv = client.post("/api/v1/requests", json=data, environ_base=auth_env)
 
+    engine = db.create_engine(app.config["SQLALCHEMY_DATABASE_URI"], {})
+    connection = engine.connect()
+    request_state = db.Table("request_state", db.MetaData(), autoload=True, autoload_with=engine)
+    query = db.select([request_state]).where(request_state.columns.request_id == 1)
+
+    state_reasons = []
+    for res in connection.execute(query):
+        state_reasons.append(res[2])
+
+    error = "Failed to schedule the task to the workers. Please try again."
+    assert any(elem == error for elem in state_reasons)
+
     assert rv.status_code == 503
-    assert rv.json == {"error": "Failed to schedule the task to the workers. Please try again."}
+    assert rv.json == {"error": error}
     # Verify that the request is in the failed state
     assert Request.query.get(1).state.state_name == "failed"
 


### PR DESCRIPTION
In case of celery errors, create_request function commit operations to
DB and mark request as failed.