### PR TITLE
Run performance tests

### DIFF
--- a/cachito/web/manage.py
+++ b/cachito/web/manage.py
@@ -31,5 +31,180 @@ def wait_for_db():
             break
 
 
+@cli.command(name="test-performance")
+def test_performance():
+    """Run performance tests."""
+    import copy
+    import os.path
+    from collections import defaultdict
+    from contextlib import contextmanager
+    from functools import cache
+    import json
+    import requests
+    from cachito.web.models import Dependency, Package, Request
+
+    @contextmanager
+    def measure_duration(durations, name):
+        start = time.time()
+        try:
+            yield
+        finally:
+            duration = time.time() - start
+            durations[name] += duration
+
+    @cache
+    def download_packages_json(url):
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()['packages']
+
+    def single_update(request, package, deps_json, durations):
+        for dep_and_replaces in deps_json:
+            dep_json = copy.deepcopy(dep_and_replaces)
+            replaces_json = dep_json.pop("replaces", None)
+
+            with measure_duration(durations, 'get_or_create_dep'):
+                dep = Dependency.get_or_create(dep_json)
+
+            replaces = None
+            if replaces_json:
+                with measure_duration(durations, 'get_or_create_dep'):
+                    replaces = Dependency.get_or_create(replaces_json)
+
+            with measure_duration(durations, 'add_dep'):
+                request.add_dependency(package, dep, replaces)
+
+    def bulk_update(request, package, deps_json, durations):
+        bulk_dependencies = []
+        mapped_bulk_dependencies = {}
+        relationships = []
+        for dep_and_replaces in deps_json:
+            dep_json = copy.deepcopy(dep_and_replaces)
+            replaces_json = dep_json.pop("replaces", None)
+            bulk_dependencies.append(dep_json)
+            if replaces_json:
+                bulk_dependencies.append(replaces_json)
+
+        bulk_package_dependencies = []
+        if bulk_dependencies:
+            with measure_duration(durations, 'get_or_create_dep'):
+                created_bulk_dependencies = Dependency.bulk_get_or_create(bulk_dependencies)
+            mapped_bulk_dependencies = {
+                (dep.name, dep.version, dep.type, dep.dev): dep for dep in created_bulk_dependencies
+            }
+            for dep_and_replaces in deps_json:
+                dep_key = (
+                    dep_and_replaces['name'],
+                    dep_and_replaces['version'],
+                    dep_and_replaces['type'],
+                    dep_and_replaces.get('dev', False),
+                )
+                dep = mapped_bulk_dependencies[dep_key]
+
+                replaces = None
+                replaces_json = dep_and_replaces.get("replaces", None)
+                if replaces_json:
+                    replaces_key = (
+                        replaces_json['name'],
+                        replaces_json['version'],
+                        replaces_json['type'],
+                        replaces_json.get('dev', False),
+                    )
+                    replaces = mapped_bulk_dependencies[replaces_key]
+                bulk_package_dependencies.append(
+                    (
+                        dep,
+                        replaces,
+                    )
+                )
+
+        if bulk_package_dependencies:
+            with measure_duration(durations, 'add_dep'):
+                request.bulk_add_dependency(package, bulk_package_dependencies)
+
+    large_url = (
+        'https://gist.githubusercontent.com/lcarva/8af91ba1cd630386997728cb663dc69b/raw/'
+        'd32c71446346125ab2c58a63fd215aec550da861/large-cachito-request.json'
+    )
+
+    small_url = (
+        'https://gist.githubusercontent.com/lcarva/7df2d7b152e2622a5290412e8cc7fb4b/raw/'
+        'ffe43d16dd00f9a678b0abe73b2c55059db3c7a6/small-cachito-request.json'
+    )
+
+    scenarios = (
+        (small_url, bulk_update, 30),
+        (small_url, bulk_update, 50),
+        (small_url, bulk_update, 300),
+        (small_url, bulk_update, 500),
+        (small_url, bulk_update, 1000),
+        (small_url, single_update, 30),
+        (small_url, single_update, 50),
+        (small_url, single_update, 300),
+        (small_url, single_update, 500),
+        (small_url, single_update, 1000),
+        (large_url, bulk_update, 30),
+        (large_url, bulk_update, 50),
+        (large_url, bulk_update, 300),
+        (large_url, bulk_update, 500),
+        (large_url, bulk_update, 1000),
+        (large_url, single_update, 30),
+        (large_url, single_update, 50),
+        (large_url, single_update, 300),
+        (large_url, single_update, 500),
+        (large_url, single_update, 1000),
+    )
+
+    results = []
+
+    for url, update, batch_size in scenarios:
+        packages = copy.deepcopy(download_packages_json(url))
+        size = os.path.basename(url).split('.')[0].replace('-cachito-request', '')
+        scenario_name = f'{size}_{update.__name__}_{batch_size}'
+        durations = defaultdict(int)
+        request = Request.from_json(
+            {
+                'repo': scenario_name,
+                'ref': '2ba62c8cfc98b74a6d02e692ce181add8b2184cd',
+                'pkg_managers': ['gomod'],
+            }
+        )
+        db.session.add(request)
+        db.session.commit()
+
+        print(f'Running scenario {scenario_name} on request {request.id}')
+
+        with measure_duration(durations, 'deps_overall'):
+            for package_json in copy.deepcopy(packages):
+                all_deps = package_json.pop('dependencies', [])
+                package = Package.get_or_create(package_json)
+                for index in range(0, len(all_deps), batch_size):
+                    batch_upper_limit = index + batch_size
+                    deps_chunk = all_deps[index:batch_upper_limit]
+                    update(request, package, deps_chunk, durations)
+                    with measure_duration(durations, 'deps_commit'):
+                        db.session.commit()
+
+        request.add_state('complete', json.dumps(durations))
+        db.session.commit()
+        results.append((scenario_name, durations))
+
+    if results:
+        print()
+        headers = ['Scenario'.ljust(24)] + [key.ljust(17) for key in results[0][1].keys()]
+        headers_line = ' | '.join(headers)
+        print(headers_line)
+        print('_' * len(headers_line))
+
+        for result in results:
+            # import pdb
+
+            # pdb.set_trace()
+            row = [result[0].ljust(24)] + [
+                f'{result[1][key.strip()]:.4f}'.ljust(17) for key in headers[1:]
+            ]
+            print(' | '.join(row))
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
**This is very much a draft!**

The main change here is in `models.py` and `api_v1.py` to support bulk operations instead of processing one dependency at a time.

The results for running this against my local development instance is as follows:
| Scenario                 | get_or_create_dep | add_dep           | deps_commit       | deps_overall     |
| --- | --- | --- | --- | --- |
| small_bulk_update_30     | 0.0132            | 0.0209            | 0.0018            | 0.0427            |
| small_bulk_update_50     | 0.0107            | 0.0397            | 0.0019            | 0.0555            |
| small_bulk_update_300    | 0.0104            | 0.0155            | 0.0021            | 0.0313            |
| small_bulk_update_500    | 0.0103            | 0.0153            | 0.0019            | 0.0309            |
| small_bulk_update_1000   | 0.0105            | 0.0150            | 0.0018            | 0.0307            |
| small_single_update_30   | 0.0558            | 0.0730            | 0.0049            | 0.1374            |
| small_single_update_50   | 0.0448            | 0.0602            | 0.0051            | 0.1135            |
| small_single_update_300  | 0.0541            | 0.0760            | 0.0053            | 0.1424            |
| small_single_update_500  | 0.0504            | 0.0663            | 0.0047            | 0.1249            |
| small_single_update_1000 | 0.0605            | 0.0772            | 0.0059            | 0.1478            |
| large_bulk_update_30     | 8.3260            | 11.8212           | 0.7970            | 21.4277           |
| large_bulk_update_50     | 7.2226            | 9.2437            | 0.5015            | 17.3605           |
| large_bulk_update_300    | 6.3200            | 5.8793            | 0.1453            | 12.6846           |
| large_bulk_update_500    | 6.5995            | 5.5716            | 0.1271            | 12.6810           |
| large_bulk_update_1000   | 6.5346            | 5.2714            | 0.0970            | 12.2814           |
| large_single_update_30   | 52.2667           | 67.7917           | 2.0673            | 122.9351          |
| large_single_update_50   | 44.7120           | 57.6657           | 1.2301            | 104.3097          |
| large_single_update_300  | 40.9292           | 52.4725           | 0.3211            | 94.3223           |
| large_single_update_500  | 48.7412           | 61.8422           | 0.2998            | 111.6252          |
| large_single_update_1000 | 41.2431           | 52.6765           | 0.2113            | 94.7579           |

I'd like to run these tests against our stage instance as it will provide more realistic results.