### PR TITLE
Add cgo-disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,11 @@ with the `mod_auth_gssapi` module.
 * `include-git-dir` - when used, `.git` file objects are not removed from the source bundle created
   by Cachito. This is useful when the git history is important to the build process.
 
+* `cgo-disable` - use this flag to make Cachito set `CGO_ENABLED=0` while processing gomod packages.
+  This environment variable will only be used internally by Cachito, it will *not* be set in the
+  environment variables for the completed request. Typically, you will only want to use this if your
+  package *does* use C files, and the Cachito request is failing.
+
 ## Nexus
 
 ### Nexus For npm

--- a/cachito/web/migrations/versions/07d89c5778f2_add_cgo_disable_flag.py
+++ b/cachito/web/migrations/versions/07d89c5778f2_add_cgo_disable_flag.py
@@ -1,0 +1,43 @@
+"""Add the cgo-disable flag
+
+Revision ID: 07d89c5778f2
+Revises: 97d5df7fca86
+Create Date: 2021-02-12 10:04:40.989666
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "07d89c5778f2"
+down_revision = "97d5df7fca86"
+branch_labels = None
+depends_on = None
+
+
+flag_table = sa.Table(
+    "flag",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer(), primary_key=True),
+    sa.Column("name", sa.String(), nullable=False),
+    sa.Column("active", sa.Boolean(), nullable=False, default=True),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    res = connection.execute(
+        flag_table.select().where(flag_table.c.name == "cgo-disable")
+    ).fetchone()
+    if res is None:
+        connection.execute(flag_table.insert().values(name="cgo-disable", active=True))
+    else:
+        connection.execute(
+            flag_table.update().where(flag_table.c.name == "cgo-disable").values(active=True)
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    connection.execute(flag_table.update().values(name="cgo-disable", active=False))

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -74,6 +74,8 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
             "PATH": os.environ.get("PATH", ""),
             "GOMODCACHE": "{}/pkg/mod".format(temp_dir),
         }
+        if "cgo-disable" in request.get("flags", []):
+            env["CGO_ENABLED"] = "0"
 
         run_params = {"env": env, "cwd": app_source_path}
 


### PR DESCRIPTION
Use this flag to make Cachito set CGO_ENABLED=0 while processing gomod
packages. Typically, you will only want to use this if your package
*does* use C files and the Cachito request is failing. Correct results
not guaranteed.