### PR TITLE
Set task priorities

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -76,6 +76,8 @@ class Config(object):
         kombu.Queue("cachito_gomod", routing_key="cachito.gomod"),
         kombu.Queue("cachito_npm", routing_key="cachito.npm"),
     )
+    task_queue_max_priority = 10
+    task_default_priority = 5
     # Requeue the message if the worker abruptly exits or is signaled
     task_reject_on_worker_lost = True
     # Route gomod tasks and npm tasks to separate queues. This is useful if workers are dedicated

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -22,7 +22,7 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-@app.task
+@app.task(priority=0)
 def fetch_app_source(url, ref, request_id, gitsubmodule=False):
     """
     Fetch the application source code that was requested and put it in long-term storage.
@@ -141,7 +141,7 @@ def failed_request_callback(context, exc, traceback, request_id):
     set_request_state(request_id, "failed", msg)
 
 
-@app.task
+@app.task(priority=10)
 def create_bundle_archive(request_id):
     """
     Create the bundle archive to be downloaded by the user.


### PR DESCRIPTION
Cachito tasks are processed in a breadth first approach. This is not
optimal because starting the next steps after fetching the requested app
sources requires that no other requests to fetch app sources (for a
different Cachito request) is queued. As a consequence, Cachito could
get completely blocked (no Requests being completed) if a user submits a
large number of requests (and if new requests keep coming).

This patch changes Cachito's approach by introducing priorities on how
tasks in our queues get processed. The tasks shall be processed in a
depth first approach, where the first task for a new request will only
be processed after there are no other tasks (from requests being
executed) left to be picked up.

Signed-off-by: Athos Ribeiro <athos@redhat.com>