### PR TITLE
Set proxy resolved urls for all yarn deps 

### DIFF
--- a/cachito/workers/pkg_managers/yarn.py
+++ b/cachito/workers/pkg_managers/yarn.py
@@ -420,20 +420,13 @@ def resolve_yarn(app_source_path, request, skip_deps=None):
         pkg_manager="yarn",
     )
 
-    nexus_replacements = package_and_deps_info.pop("nexus_replacements")
-    if nexus_replacements:
-        package_and_deps_info["package.json"] = _replace_deps_in_package_json(
-            package_and_deps_info["package.json"], nexus_replacements
-        )
-        package_and_deps_info["lock_file"] = _replace_deps_in_yarn_lock(
-            package_and_deps_info["lock_file"], nexus_replacements
-        )
-    else:
-        package_and_deps_info["package.json"] = None
+    replacements = package_and_deps_info.pop("nexus_replacements")
+    pkg_json = _replace_deps_in_package_json(package_and_deps_info["package.json"], replacements)
+    yarn_lock = _replace_deps_in_yarn_lock(package_and_deps_info["lock_file"], replacements)
+    _set_proxy_resolved_urls(yarn_lock, get_yarn_proxy_repo_name(request["id"]))
 
-    _set_proxy_resolved_urls(
-        package_and_deps_info["lock_file"], get_yarn_proxy_repo_name(request["id"])
-    )
+    package_and_deps_info["package.json"] = pkg_json
+    package_and_deps_info["lock_file"] = yarn_lock
 
     # Remove all the "bundled" and "version_in_nexus" keys since they are implementation details
     for dep in package_and_deps_info["deps"]:

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -625,14 +625,12 @@ def test_resolve_yarn(
     }
 
     rv = yarn.resolve_yarn("/some/path", {"id": 1}, skip_deps={"foobar"})
-    expect_yarn_lock = (
-        mock_replace_yarnlock.return_value if have_nexus_replacements else mock_yarn_lock
-    )
+    expect_yarn_lock = mock_replace_yarnlock.return_value
     assert rv == {
         "package": mock_package,
         "deps": mock_deps,
         "downloaded_deps": mock_download_deps.return_value,
-        "package.json": mock_replace_packjson.return_value if have_nexus_replacements else None,
+        "package.json": mock_replace_packjson.return_value,
         "lock_file": expect_yarn_lock,
     }
 


### PR DESCRIPTION
Cachito only sets resolved urls for external dependencies. We also need
to set them for registry dependencies. The only dependencies that do not
need a proxy resolved url are 'file:' dependencies.