### PR TITLE
Add yarn to the /status endpoint

### DIFF
--- a/cachito/web/status.py
+++ b/cachito/web/status.py
@@ -21,6 +21,7 @@ PKG_MANAGER_REQUIRES = {
     "gomod": {ATHENS},
     "npm": {NEXUS, NEXUS_HOSTER},
     "pip": {NEXUS, NEXUS_HOSTER},
+    "yarn": {NEXUS, NEXUS_HOSTER},
     "*": {DATABASE, RABBITMQ},
 }
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -9,7 +9,7 @@ from requests import RequestException
 from cachito.errors import CachitoError
 from cachito.web import status
 
-TEST_PACKAGE_MANAGERS = ["gomod", "npm", "pip", "git-submodule"]
+TEST_PACKAGE_MANAGERS = ["gomod", "npm", "pip", "git-submodule", "yarn"]
 
 
 @pytest.fixture
@@ -201,20 +201,40 @@ def test_workers_status(mock_ping_workers, retries, ping_result, expect_result):
 @pytest.mark.parametrize(
     "worker_ok, failing_services, expect_result",
     [
-        (False, [], {"gomod": False, "npm": False, "pip": False, "git-submodule": False}),
-        (True, ["rabbitmq"], {"gomod": False, "npm": False, "pip": False, "git-submodule": False}),
-        (True, ["database"], {"gomod": False, "npm": False, "pip": False, "git-submodule": False}),
-        (True, ["athens"], {"gomod": False, "npm": True, "pip": True, "git-submodule": True}),
-        (True, ["nexus"], {"gomod": True, "npm": False, "pip": False, "git-submodule": True}),
+        (
+            False,
+            [],
+            {"gomod": False, "npm": False, "pip": False, "git-submodule": False, "yarn": False},
+        ),
+        (
+            True,
+            ["rabbitmq"],
+            {"gomod": False, "npm": False, "pip": False, "git-submodule": False, "yarn": False},
+        ),
+        (
+            True,
+            ["database"],
+            {"gomod": False, "npm": False, "pip": False, "git-submodule": False, "yarn": False},
+        ),
+        (
+            True,
+            ["athens"],
+            {"gomod": False, "npm": True, "pip": True, "git-submodule": True, "yarn": True},
+        ),
+        (
+            True,
+            ["nexus"],
+            {"gomod": True, "npm": False, "pip": False, "git-submodule": True, "yarn": False},
+        ),
         (
             True,
             ["nexus-hoster"],
-            {"gomod": True, "npm": False, "pip": False, "git-submodule": True},
+            {"gomod": True, "npm": False, "pip": False, "git-submodule": True, "yarn": False},
         ),
         (
             True,
             ["athens", "nexus"],
-            {"gomod": False, "npm": False, "pip": False, "git-submodule": True},
+            {"gomod": False, "npm": False, "pip": False, "git-submodule": True, "yarn": False},
         ),
     ],
 )


### PR DESCRIPTION
Add yarn package manager to the /status endpoint and add nexus
dependencies to it.

Signed-off-by: Tereza Hrbkova <thrbkova@redhat.com>