### PR TITLE
Change Cachito worker URL for flower setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       dockerfile: ./docker/Dockerfile-flower
     entrypoint:
       - /usr/local/bin/flower-waits-for-cachito.sh
-      - http://cachito-api:8080
+      - http://cachito-api:8080/api/v1/
     command:
       - /usr/local/bin/flower
       - --port=5555

--- a/docker/flower-waits-for-cachito.sh
+++ b/docker/flower-waits-for-cachito.sh
@@ -4,7 +4,7 @@ set -eu
 cachito_api=$1
 shift
 
-until curl --fail --silent --show-error "${cachito_api}/api/v1/status/short"; do
+until curl --fail --silent --show-error "${cachito_api}status/short"; do
     echo "Cachito is unavailable - sleeping"
     sleep 3
 done


### PR DESCRIPTION
It is better to use the whole URL of Cachito worker API to reuse variables in deployment process.

