### PR TITLE
Fix how JS code searches for Nexus components

### DIFF
--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -340,7 +340,7 @@ def _get_js_component_info_from_nexus(
         component_group = component_group[1:]
     else:
         component_name = name
-        component_group = None
+        component_group = nexus.NULL_GROUP
 
     return nexus.get_component_info_from_nexus(
         repository,

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -360,6 +360,33 @@ def test_get_component_info_from_nexus_no_results(mock_search_components, mock_s
 
 
 @mock.patch("cachito.workers.nexus.search_components")
+def test_get_component_info_from_nexus_null_group(mock_search_components):
+    mock_search_components.return_value = [
+        {"name": "foo", "group": "some", "version": "1.0.0"},
+        {"name": "foo", "group": None, "version": "1.0.0"},
+    ]
+
+    result = nexus.get_component_info_from_nexus(
+        "cachito-js-proxy", "npm", "foo", version="1.0.0", group=nexus.NULL_GROUP
+    )
+
+    assert result == mock_search_components.return_value[1]
+
+
+@mock.patch("cachito.workers.nexus.search_components")
+def test_get_component_info_from_nexus_any_group(mock_search_components):
+    mock_search_components.return_value = [
+        {"name": "foo", "group": "some", "version": "1.0.0"},
+    ]
+
+    result = nexus.get_component_info_from_nexus(
+        "cachito-js-proxy", "npm", "foo", version="1.0.0", group=None
+    )
+
+    assert result == mock_search_components.return_value[0]
+
+
+@mock.patch("cachito.workers.nexus.search_components")
 def test_get_component_info_from_nexus_multiple_results(
     mock_search_components, components_search_results
 ):

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 
 from cachito.errors import CachitoError
+from cachito.workers import nexus
 from cachito.workers.errors import NexusScriptError
 from cachito.workers.pkg_managers import general, general_js, npm
 from cachito.workers.paths import RequestBundleDir
@@ -357,7 +358,7 @@ def test_get_js_component_info_from_nexus(mock_gcifn, group, repository, is_host
             "npm",
             "rxjs",
             "6.5.5-external-gitcommit-78032157f5c1655436829017bbda787565b48c30",
-            None,
+            nexus.NULL_GROUP,
             3,
             from_nexus_hoster=is_hosted,
         )


### PR DESCRIPTION
CLOUDBLD-4938

The Nexus search API does not allow the user to search specifically for
components without groups. If no group is specified, Nexus returns all
the matching components regardless of group.

In some cases, this causes Cachito to fail. For example, if a Yarn
package requires both `some-package` and `@types/some-package` (at the
same version), Cachito will eventually search for `some-package` and
fail because 2 different results are found.

Implement an ad-hoc workaround where the search result is filtered by
None afterwards. Keep the default behaviour the same as before (match
regardless of group).

Signed-off-by: Adam Cmiel <acmiel@redhat.com>