### PR TITLE
Set proper CA bundle for python requests

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -23,6 +23,9 @@ RUN pip3 install -r requirements.txt --no-deps --require-hashes
 RUN pip3 install -r requirements-web.txt --no-deps --require-hashes
 RUN pip3 install . --no-deps
 
+# Use the system CA bundle for the requests library
+ENV REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+
 # Disable gitpython check for the git executable, cachito-api doesn't use git
 ENV GIT_PYTHON_REFRESH=quiet
 

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -20,10 +20,12 @@ RUN dnf -y install \
     && dnf clean all
 COPY . .
 
-
 # All the requirements except pyarn should already be installed
 RUN pip3 install -r requirements.txt --no-deps --require-hashes
 RUN pip3 install . --no-deps
+
+# Use the system CA bundle for the requests library
+ENV REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
 # Set git user configuration for GitPython
 ENV GIT_COMMITTER_NAME=cachito \


### PR DESCRIPTION
The Fedora package patches requests like this:

```diff
-from certifi import where
+def where():
+    """Return the absolute path to the system CA bundle."""
+    return '/etc/pki/tls/certs/ca-bundle.crt'
```

Now that we are installing requests from PyPI, we will need to set the
REQUESTS_CA_BUNDLE variable to achieve the same results.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>