### PR TITLE
Check request state at the beginning of tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ settings.py
 
 # Local deployment storage
 /tmp
+
+# idea files
+.idea/

--- a/cachito/workers/celery_logging.py
+++ b/cachito/workers/celery_logging.py
@@ -33,7 +33,7 @@ class AddRequestIDFilter(logging.Filter):
         return True
 
 
-def _get_function_arg_value(arg_name, func, args, kwargs):
+def get_function_arg_value(arg_name, func, args, kwargs):
     """
     Get the value of the given argument name.
 
@@ -115,7 +115,7 @@ def setup_task_logging(task_id, task, **kwargs):
     request_log_handler = None
     if log_dir:
         log_formatter = logging.Formatter(log_format)
-        request_id = _get_function_arg_value(
+        request_id = get_function_arg_value(
             "request_id", task.__wrapped__, kwargs["args"], kwargs["kwargs"]
         )
         if not request_id:
@@ -142,7 +142,7 @@ def setup_task_logging_customization(task_id, task, **kwargs):
     """
     conf = get_worker_config()
 
-    request_id = _get_function_arg_value("request_id", task, kwargs["args"], kwargs["kwargs"])
+    request_id = get_function_arg_value("request_id", task, kwargs["args"], kwargs["kwargs"])
     log_filter = AddRequestIDFilter(str(request_id) or "unknown")
     root_logger = logging.getLogger()
     for handler in root_logger.handlers:

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -12,6 +12,7 @@ from cachito.workers.config import get_worker_config
 from cachito.workers.scm import Git
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.tasks.celery import app
+from cachito.workers.tasks.utils import runs_if_request_in_progress
 
 __all__ = [
     "create_bundle_archive",
@@ -23,6 +24,7 @@ log = logging.getLogger(__name__)
 
 
 @app.task(priority=0)
+@runs_if_request_in_progress
 def fetch_app_source(url, ref, request_id, gitsubmodule=False):
     """
     Fetch the application source code that was requested and put it in long-term storage.
@@ -125,6 +127,7 @@ def set_request_state(request_id, state, state_reason):
 
 
 @app.task
+@runs_if_request_in_progress
 def failed_request_callback(context, exc, traceback, request_id):
     """
     Wrap set_request_state for task error callbacks.
@@ -142,6 +145,7 @@ def failed_request_callback(context, exc, traceback, request_id):
 
 
 @app.task(priority=10)
+@runs_if_request_in_progress
 def create_bundle_archive(request_id):
     """
     Create the bundle archive to be downloaded by the user.

--- a/cachito/workers/tasks/gitsubmodule.py
+++ b/cachito/workers/tasks/gitsubmodule.py
@@ -6,12 +6,14 @@ import git
 from cachito.workers.pkg_managers.general import update_request_with_package
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.tasks.celery import app
+from cachito.workers.tasks.utils import runs_if_request_in_progress
 
 __all__ = ["add_git_submodules_as_package"]
 log = logging.getLogger(__name__)
 
 
 @app.task
+@runs_if_request_in_progress
 def add_git_submodules_as_package(request_id):
     """
     Add git submodules as package to the Cachtio request.

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -10,6 +10,7 @@ from cachito.workers.pkg_managers.general import (
 )
 from cachito.workers.pkg_managers.gomod import resolve_gomod, path_to_subpackage
 from cachito.workers.tasks.celery import app
+from cachito.workers.tasks.utils import runs_if_request_in_progress
 from cachito.workers.tasks.general import set_request_state
 from cachito.workers.paths import RequestBundleDir
 
@@ -41,6 +42,7 @@ def _find_missing_gomod_files(bundle_dir, subpaths):
 
 
 @app.task
+@runs_if_request_in_progress
 def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
     """
     Resolve and fetch gomod dependencies for a given request.

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -26,8 +26,7 @@ from cachito.workers.pkg_managers.npm import (
 )
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.general import set_request_state
-from cachito.workers.tasks.utils import make_base64_config_file
-
+from cachito.workers.tasks.utils import make_base64_config_file, runs_if_request_in_progress
 
 __all__ = ["cleanup_npm_request", "fetch_npm_source"]
 log = logging.getLogger(__name__)
@@ -85,6 +84,7 @@ def cleanup_npm_request(request_id):
 
 
 @app.task
+@runs_if_request_in_progress
 def fetch_npm_source(request_id, package_configs=None):
     """
     Resolve and fetch npm dependencies for a given request.

--- a/cachito/workers/tasks/pip.py
+++ b/cachito/workers/tasks/pip.py
@@ -26,7 +26,7 @@ from cachito.workers.pkg_managers.pip import (
 )
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.general import set_request_state
-from cachito.workers.tasks.utils import make_base64_config_file
+from cachito.workers.tasks.utils import make_base64_config_file, runs_if_request_in_progress
 
 
 log = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ def cleanup_pip_request(request_id):
 
 
 @app.task
+@runs_if_request_in_progress
 def fetch_pip_source(request_id, package_configs=None):
     """
     Resolve and fetch pip dependencies for a given request.

--- a/cachito/workers/tasks/yarn.py
+++ b/cachito/workers/tasks/yarn.py
@@ -28,7 +28,11 @@ from cachito.workers.pkg_managers.yarn import (
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.general import set_request_state
 from cachito.workers.tasks.npm import generate_npmrc_config_files
-from cachito.workers.tasks.utils import make_base64_config_file, AssertPackageFiles
+from cachito.workers.tasks.utils import (
+    make_base64_config_file,
+    AssertPackageFiles,
+    runs_if_request_in_progress,
+)
 
 __all__ = ["cleanup_yarn_request", "fetch_yarn_source"]
 
@@ -77,6 +81,7 @@ def _yarn_lock_to_str(yarn_lock_data: dict) -> str:
 
 
 @app.task
+@runs_if_request_in_progress
 def fetch_yarn_source(request_id: int, package_configs: List[dict] = None):
     """
     Resolve and fetch yarn dependencies for a given request.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import copy
 import os
 import tempfile
+from unittest import mock
 
 import git
 import pytest
@@ -259,3 +260,18 @@ def fake_repo():
         r.index.add(["main.py"])
         r.index.commit("add main source")
         yield repo_dir, repo_dir.lstrip("/")
+
+
+@pytest.fixture
+def task_passes_state_check():
+    """
+    Patch the get_request_state util method to make it return "in_progress".
+
+    Use this in test functions where you call tasks decorated with @runs_if_request_in_progress.
+    The fixture will automatically verify that get_request_state was called at least once.
+    """
+    with mock.patch("cachito.workers.tasks.utils.get_request_state") as mock_get_state:
+        mock_get_state.return_value = "in_progress"
+        yield
+
+    mock_get_state.assert_called()

--- a/tests/test_workers/test_celery_logging.py
+++ b/tests/test_workers/test_celery_logging.py
@@ -85,7 +85,7 @@ def test_setup_logging(mock_gwc, tmpdir):
         assert "Test log message" in f.read()
 
 
-@mock.patch("cachito.workers.celery_logging._get_function_arg_value")
+@mock.patch("cachito.workers.celery_logging.get_function_arg_value")
 @mock.patch("cachito.workers.celery_logging.get_worker_config")
 def test_setup_logging_request_id_not_found(mock_gwc, mock_get_func_arg_val, tmpdir):
     mock_gwc.return_value.cachito_request_file_logs_dir = str(tmpdir)

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -20,7 +20,9 @@ from tests.helper_utils import Symlink, write_file_tree
 @pytest.mark.parametrize("gitsubmodule", [True, False])
 @mock.patch("cachito.workers.tasks.general.set_request_state")
 @mock.patch("cachito.workers.tasks.general._enforce_sandbox")
-def test_fetch_app_source(mock_enforce_sandbox, mock_set_request_state, fake_repo, gitsubmodule):
+def test_fetch_app_source(
+    mock_enforce_sandbox, mock_set_request_state, fake_repo, gitsubmodule, task_passes_state_check
+):
     request_id = 1
 
     repo_dir, repo_name = fake_repo
@@ -78,7 +80,9 @@ def test_enforce_sandbox(file_tree, error, tmp_path):
 @pytest.mark.parametrize("gitsubmodule", [True, False])
 @mock.patch("cachito.workers.tasks.general.set_request_state")
 @mock.patch("cachito.workers.tasks.general.Git")
-def test_fetch_app_source_request_timed_out(mock_git, mock_set_request_state, gitsubmodule):
+def test_fetch_app_source_request_timed_out(
+    mock_git, mock_set_request_state, gitsubmodule, task_passes_state_check
+):
     url = "https://github.com/release-engineering/retrodep.git"
     ref = "c50b93a32df1c9d700e3e80996845bc2e13be848"
     mock_git.return_value.fetch_source.side_effect = Timeout("The request timed out")
@@ -113,14 +117,14 @@ def test_set_request_state_bad_status_code(mock_requests):
 
 
 @mock.patch("cachito.workers.tasks.general.set_request_state")
-def test_failed_request_callback(mock_set_request_state):
+def test_failed_request_callback(mock_set_request_state, task_passes_state_check):
     exc = CachitoError("some error")
     tasks.failed_request_callback(None, exc, None, 1)
     mock_set_request_state.assert_called_once_with(1, "failed", "some error")
 
 
 @mock.patch("cachito.workers.tasks.general.set_request_state")
-def test_failed_request_callback_not_cachitoerror(mock_set_request_state):
+def test_failed_request_callback_not_cachitoerror(mock_set_request_state, task_passes_state_check):
     exc = ValueError("some error")
     tasks.failed_request_callback(None, exc, None, 1)
     mock_set_request_state.assert_called_once_with(1, "failed", "An unknown error occurred")
@@ -130,7 +134,9 @@ def test_failed_request_callback_not_cachitoerror(mock_set_request_state):
 @pytest.mark.parametrize("include_git_dir", (True, False))
 @mock.patch("cachito.workers.tasks.general.set_request_state")
 @mock.patch("cachito.workers.paths.get_worker_config")
-def test_create_bundle_archive(mock_gwc, mock_set_request, deps_present, include_git_dir, tmpdir):
+def test_create_bundle_archive(
+    mock_gwc, mock_set_request, deps_present, include_git_dir, tmpdir, task_passes_state_check
+):
     flags = ["include-git-dir"] if include_git_dir else []
     mock_set_request.return_value = {"flags": flags}
 

--- a/tests/test_workers/test_tasks/test_gitsubmodule.py
+++ b/tests/test_workers/test_tasks/test_gitsubmodule.py
@@ -9,7 +9,9 @@ archive_path = f"/tmp/cachito-archives/release-engineering/retrodep/{ref}.tar.gz
 
 @mock.patch("git.Repo")
 @mock.patch("cachito.workers.tasks.gitsubmodule.update_request_with_package")
-def test_add_git_submodules_as_package(mock_update_with_package, mock_repo):
+def test_add_git_submodules_as_package(
+    mock_update_with_package, mock_repo, task_passes_state_check
+):
     submodule = mock.Mock()
     submodule.name = "tour"
     submodule.hexsha = "522fb816eec295ad58bc488c74b2b46748d471b2"

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -83,6 +83,7 @@ def test_fetch_gomod_source(
     sample_pkg_deps,
     sample_pkg_lvl_pkg,
     sample_env_vars,
+    task_passes_state_check,
 ):
     def directory_present(*args, **kwargs):
         mock_subpath = mock.Mock()
@@ -237,6 +238,7 @@ def test_fetch_gomod_source_no_go_mod_file(
     exception_expected,
     pkg_config,
     pkg_results,
+    task_passes_state_check,
 ):
     def directory_present(*args, **kwargs):
         mock_subpath = mock.Mock()

--- a/tests/test_workers/test_tasks/test_npm.py
+++ b/tests/test_workers/test_tasks/test_npm.py
@@ -98,6 +98,7 @@ def test_fetch_npm_source(
     package_subpath,
     subpath_as_path_component,
     reverse_path_component,
+    task_passes_state_check,
 ):
     request_id = 6
     request = {"id": request_id}
@@ -216,6 +217,7 @@ def test_fetch_npm_source_multiple_paths(
     mock_srs,
     mock_vnf,
     mock_rbd,
+    task_passes_state_check,
 ):
     request_id = 6
     request = {"id": request_id}
@@ -328,7 +330,9 @@ def test_fetch_npm_source_multiple_paths(
 @mock.patch("cachito.workers.tasks.npm.set_request_state")
 @mock.patch("cachito.workers.tasks.npm.prepare_nexus_for_js_request")
 @mock.patch("cachito.workers.tasks.npm.resolve_npm")
-def test_fetch_npm_source_resolve_fails(mock_rn, mock_pnfjr, mock_srs, mock_vnf, mock_rbd):
+def test_fetch_npm_source_resolve_fails(
+    mock_rn, mock_pnfjr, mock_srs, mock_vnf, mock_rbd, task_passes_state_check
+):
     request_id = 6
     request = {"id": request_id}
     mock_srs.return_value = request

--- a/tests/test_workers/test_tasks/test_pip.py
+++ b/tests/test_workers/test_tasks/test_pip.py
@@ -50,6 +50,7 @@ def test_fetch_pip_source(
     with_req,
     package_subpath,
     tmp_path,
+    task_passes_state_check,
 ):
     pkg_data = {
         "package": {"name": "foo", "version": "1", "type": "pip"},

--- a/tests/test_workers/test_tasks/test_yarn.py
+++ b/tests/test_workers/test_tasks/test_yarn.py
@@ -162,6 +162,7 @@ def test_fetch_yarn(
     mock_validate_config,
     mock_request_bundle_dir,
     tmp_path,
+    task_passes_state_check,
 ):
     # SETUP
     bundle_dir, root, sub = mock_bundle_dir(tmp_path)
@@ -317,6 +318,7 @@ def test_fetch_yarn_no_configs(
     mock_validate_config,
     mock_request_bundle_dir,
     tmp_path,
+    task_passes_state_check,
 ):
     bundle_dir, root, sub = mock_bundle_dir(tmp_path)
     mock_request_bundle_dir.return_value = bundle_dir
@@ -362,6 +364,7 @@ def test_fetch_yarn_resolve_fails(
     mock_validate_config,
     mock_request_bundle_dir,
     tmp_path,
+    task_passes_state_check,
 ):
     bundle_dir, root, sub = mock_bundle_dir(tmp_path)
     mock_request_bundle_dir.return_value = bundle_dir


### PR DESCRIPTION
Verify that request state is in the expected state (in_progress), otherwise log a warning.
This ensures the message will not be put back in the celery queue.