### PR TITLE
Store and present subpaths for go packages

### DIFF
--- a/cachito/web/content_manifest.py
+++ b/cachito/web/content_manifest.py
@@ -2,6 +2,7 @@
 import flask
 
 from cachito.web.utils import deep_sort_icm
+from cachito.workers.pkg_managers import gomod
 
 
 PARENT_PURL_PLACEHOLDER = "PARENT_PURL"
@@ -77,12 +78,7 @@ class ContentManifest:
             if pkg_name in self._gomod_data:
                 module_name = pkg_name
             else:
-                # We use the longest module available in the request that matches the package name
-                module_name = max(
-                    (mod_name for mod_name in self._gomod_data if pkg_name.startswith(mod_name)),
-                    key=len,
-                    default=None,
-                )
+                module_name = gomod.match_parent_module(pkg_name, self._gomod_data.keys())
 
             if module_name is not None:
                 module = self._gomod_data[module_name]

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -12,6 +12,7 @@ from cachito.workers.pkg_managers.gomod import (
     get_golang_version,
     resolve_gomod,
     path_to_subpackage,
+    match_parent_module,
     _merge_bundle_dirs,
     _merge_files,
     _parse_name_and_version,
@@ -862,3 +863,21 @@ def test_path_to_subpackage_not_a_subpackage():
     with pytest.raises(ValueError, match="Package github.com/b does not belong to github.com/a"):
         path_to_subpackage("github.com/a", "github.com/b")
 
+
+@pytest.mark.parametrize(
+    "package_name, module_names, expect_parent_module",
+    [
+        ("github.com/foo/bar", ["github.com/foo/bar"], "github.com/foo/bar"),
+        ("github.com/foo/bar", [], None),
+        ("github.com/foo/bar", ["github.com/spam/eggs"], None),
+        ("github.com/foo/bar/baz", ["github.com/foo/bar"], "github.com/foo/bar"),
+        (
+            "github.com/foo/bar/baz",
+            ["github.com/foo/bar", "github.com/foo/bar/baz"],
+            "github.com/foo/bar/baz",
+        ),
+        ("github.com/foo/bar", {"github.com/foo/bar": 1}, "github.com/foo/bar"),
+    ],
+)
+def test_match_parent_module(package_name, module_names, expect_parent_module):
+    assert match_parent_module(package_name, module_names) == expect_parent_module

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -11,6 +11,7 @@ import pytest
 from cachito.workers.pkg_managers.gomod import (
     get_golang_version,
     resolve_gomod,
+    path_to_subpackage,
     _merge_bundle_dirs,
     _merge_files,
     _parse_name_and_version,
@@ -841,3 +842,23 @@ def test_set_full_local_dep_relpaths_no_match():
 def test_get_allowed_local_deps(mock_worker_config, allowlist, module_name, expect_allowed):
     mock_worker_config.return_value.cachito_gomod_file_deps_allowlist = allowlist
     assert _get_allowed_local_deps(module_name) == expect_allowed
+
+
+@pytest.mark.parametrize(
+    "parent, subpackage, expect_path",
+    [
+        ("github.com/foo", "github.com/foo", ""),
+        ("github.com/foo", "github.com/foo/bar", "bar"),
+        ("github.com/foo", "github.com/foo/bar/baz", "bar/baz"),
+        ("github.com/foo/bar", "github.com/foo/bar/baz", "baz"),
+        ("github.com/foo", "github.com/foo/github.com/foo", "github.com/foo"),
+    ],
+)
+def test_path_to_subpackage(parent, subpackage, expect_path):
+    assert path_to_subpackage(parent, subpackage) == expect_path
+
+
+def test_path_to_subpackage_not_a_subpackage():
+    with pytest.raises(ValueError, match="Package github.com/b does not belong to github.com/a"):
+        path_to_subpackage("github.com/a", "github.com/b")
+


### PR DESCRIPTION
Store subpaths for non-root go modules and packages. Present them in the /requests/{id} JSON