### PR TITLE
Revert "Bump amqp from 5.0.2 to 5.0.6"

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,9 +10,9 @@ alembic==1.5.6 \
     # via
     #   -r requirements-web.txt
     #   flask-migrate
-amqp==5.0.6 \
-    --hash=sha256:03e16e94f2b34c31f8bf1206d8ddd3ccaa4c315f7f6a1879b7b1210d229568c2 \
-    --hash=sha256:493a2ac6788ce270a2f6a765b017299f60c1998f5a8617908ee9be082f7300fb
+amqp==5.0.2 \
+    --hash=sha256:5b9062d5c0812335c75434bf17ce33d7a20ecfedaa0733faec7379868eb4068a \
+    --hash=sha256:fcd5b3baeeb7fc19b3486ff6d10543099d40ae1f5c9196eae695d1cde1b2f784
     # via
     #   -r requirements.txt
     #   kombu

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # FIXME: there was a regression in py-amqp. It was supposed to be fixed in
 # https://github.com/celery/py-amqp/pull/350
 # but cachito is still being affected by the regression
-amqp==5.0.6
+amqp==5.0.2
 celery>=5
 gitpython
 kombu>=5 # A celery dependency but it's directly imported

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 #
-amqp==5.0.6 \
-    --hash=sha256:03e16e94f2b34c31f8bf1206d8ddd3ccaa4c315f7f6a1879b7b1210d229568c2 \
-    --hash=sha256:493a2ac6788ce270a2f6a765b017299f60c1998f5a8617908ee9be082f7300fb
+amqp==5.0.2 \
+    --hash=sha256:5b9062d5c0812335c75434bf17ce33d7a20ecfedaa0733faec7379868eb4068a \
+    --hash=sha256:fcd5b3baeeb7fc19b3486ff6d10543099d40ae1f5c9196eae695d1cde1b2f784
     # via
     #   -r requirements.in
     #   kombu


### PR DESCRIPTION
This reverts commit cfd586c5e2d610559940a4ec386a3392d12aa02e.

Apparently, we are still affected by the issue fixed in commit
91ef95c3debe72e7b40b8464c100e2676c776b18.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>