### PR TITLE
Flake8 update

### DIFF
--- a/requirements-test.in
+++ b/requirements-test.in
@@ -2,7 +2,7 @@
 -r requirements-web.txt
 
 # Pin these versions to avoid newer versions causing tox to fail
-flake8==3.7.9
+flake8==3.9.0
 flake8-docstrings==1.6.0
 jsonschema
 pytest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -183,17 +183,13 @@ cryptography==3.4.6 \
     # via
     #   -r requirements.txt
     #   requests-kerberos
-entrypoints==0.3 \
-    --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
-    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451
-    # via flake8
 flake8-docstrings==1.6.0 \
     --hash=sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde \
     --hash=sha256:9fe7c6a306064af8e62a055c2f61e9eb1da55f84bb39caef2b84ce53708ac34b
     # via -r requirements-test.in
-flake8==3.7.9 \
-    --hash=sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb \
-    --hash=sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca
+flake8==3.9.0 \
+    --hash=sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff \
+    --hash=sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0
     # via
     #   -r requirements-test.in
     #   flake8-docstrings
@@ -395,9 +391,9 @@ pyarn==0.1.0 \
     --hash=sha256:266d3caf59070b1622861f20847b17b761ea43cb18c59eed48b8c85b8920afeb \
     --hash=sha256:55a8feb1b355396a51e84ac62997f1bfefd202e6de6d1fd3ce49e623e63dfac7
     # via -r requirements.txt
-pycodestyle==2.5.0 \
-    --hash=sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56 \
-    --hash=sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c
+pycodestyle==2.7.0 \
+    --hash=sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068 \
+    --hash=sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef
     # via flake8
 pycparser==2.20 \
     --hash=sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0 \
@@ -409,9 +405,9 @@ pydocstyle==5.1.1 \
     --hash=sha256:19b86fa8617ed916776a11cd8bc0197e5b9856d5433b777f51a3defe13075325 \
     --hash=sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678
     # via flake8-docstrings
-pyflakes==2.1.1 \
-    --hash=sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0 \
-    --hash=sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2
+pyflakes==2.3.1 \
+    --hash=sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3 \
+    --hash=sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db
     # via flake8
 pykerberos==1.2.1 \
     --hash=sha256:4f2dca8df5f84a3be039c026893850d731a8bb38395292e1610ffb0a08ba876c

--- a/tests/integration/test_http_get_all.py
+++ b/tests/integration/test_http_get_all.py
@@ -76,13 +76,13 @@ def assert_no_requests_in_progress_state(client: utils.Client, requests_amount, 
 
     assert all(
         item["state"] == "in_progress" for item in response.data["items"]
-    ), f"At least one of requests was not in in_progress state"
+    ), "At least one of requests was not in in_progress state"
 
     response_ids = set(item["id"] for item in response.data["items"])
     # Check there are no completed requests in the response.
     assert not any(request_id in response_ids for request_id in submitted_requests), (
         f"At least one of requests {response_ids} was in completed state. ",
-        f"All requests are expected to be in other state than completed.",
+        "All requests are expected to be in other state than completed.",
     )
     assert 0 <= len(response.data["items"]) <= requests_amount, (
         f"Number of obtained responses ({len(response.data['items'])}) "

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1857,12 +1857,12 @@ def test_fetch_request_content_manifest_npm_or_pip(
         "dependencies": deps[:2],
         "package": pkgs[0],
     }
-    client.patch(f"/api/v1/requests/1", json=payload, environ_base=worker_auth_env)
+    client.patch("/api/v1/requests/1", json=payload, environ_base=worker_auth_env)
     payload = {
         "dependencies": deps[2:],
         "package": pkgs[1],
     }
-    client.patch(f"/api/v1/requests/1", json=payload, environ_base=worker_auth_env)
+    client.patch("/api/v1/requests/1", json=payload, environ_base=worker_auth_env)
 
     rv = client.get("/api/v1/requests/1")
     assert rv.status_code == 200

--- a/tests/test_content_manifest.py
+++ b/tests/test_content_manifest.py
@@ -499,12 +499,12 @@ def test_set_go_package_sources_replace_parent_purl(
     pre_replaced_dependencies = [
         {"purl": f"{PARENT_PURL_PLACEHOLDER}#staging/src/k8s.io/foo"},
         {"purl": f"{PARENT_PURL_PLACEHOLDER}#staging/src/k8s.io/bar"},
-        {"purl": f"pkg:golang/example.com/some-other-project@v1.0.0"},
+        {"purl": "pkg:golang/example.com/some-other-project@v1.0.0"},
     ]
     post_replaced_dependencies = [
         {"purl": f"{expected_parent_purl}#staging/src/k8s.io/foo"},
         {"purl": f"{expected_parent_purl}#staging/src/k8s.io/bar"},
-        {"purl": f"pkg:golang/example.com/some-other-project@v1.0.0"},
+        {"purl": "pkg:golang/example.com/some-other-project@v1.0.0"},
     ]
 
     cm = ContentManifest(default_request)
@@ -756,7 +756,7 @@ def test_purl_conversion(package, expected_purl, defined, known_protocol):
 
 
 def test_purl_conversion_bogus_forge():
-    package = {"name": "odd", "type": "npm", "version": f"github:something/odd"}
+    package = {"name": "odd", "type": "npm", "version": "github:something/odd"}
     pkg = Package.from_json(package)
 
     msg = f"Could not convert version {pkg.version} to purl"

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -276,7 +276,7 @@ def test_generate_npmrc_content(custom_ca_path):
     )
 
     expected = textwrap.dedent(
-        f"""\
+        """\
         registry=http://nexus:8081/repository/cachito-npm-1/
         email=noreply@domain.local
         always-auth=true

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -28,14 +28,14 @@ ref = "c50b93a32df1c9d700e3e80996845bc2e13be848"
 archive_path = f"/tmp/cachito-archives/release-engineering/retrodep/{ref}.tar.gz"
 
 mock_pkg_list = dedent(
-    f"""\
+    """\
     github.com/release-engineering/retrodep/v2
     github.com/release-engineering/retrodep/v2/retrodep
     github.com/release-engineering/retrodep/v2/retrodep/glide
     """
 )
 mock_pkg_deps = dedent(
-    f"""\
+    """\
     github.com/op/go-logging github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
     github.com/Masterminds/semver github.com/Masterminds/semver v1.4.2
     github.com/pkg/errors github.com/pkg/errors v0.8.1

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -1857,7 +1857,7 @@ class TestPipRequirementsFile:
         }
 
         expected_new_file = dedent(
-            f"""\
+            """\
             cnr_server @ https://cachito/nexus/58c88.tar.gz#egg=cnr_server --hash=sha256:123
             spam @ https://cachito/nexus/spam-123456.tar.gz --hash=sha256:45678
             aiowsgi==0.7 --hash=sha256:90123
@@ -2596,7 +2596,7 @@ class TestDownload:
     ):
         """Test downloading of a single VCS package."""
         vcs_url = f"git+https://github.com/spam/eggs@{GIT_REF}"
-        raw_url = f"https://nexus:8081/repository/cachito-pip-raw/eggs.tar.gz"
+        raw_url = "https://nexus:8081/repository/cachito-pip-raw/eggs.tar.gz"
 
         mock_requirement = self.mock_requirement(
             "eggs", "vcs", url=vcs_url, download_line=f"eggs @ {vcs_url}"
@@ -2642,7 +2642,7 @@ class TestDownload:
         else:
             assert "Raw component not found, will fetch from git" in caplog.text
             mock_download_file.assert_not_called()
-            mock_git.assert_called_once_with(f"https://github.com/spam/eggs", GIT_REF)
+            mock_git.assert_called_once_with("https://github.com/spam/eggs", GIT_REF)
             mock_git.return_value.fetch_source.assert_called_once_with(gitsubmodule=False)
             mock_shutil_copy.assert_called_once_with(git_archive_path, download_path)
 
@@ -2759,7 +2759,7 @@ class TestDownload:
         if hash_as_qualifier:
             original_url = url_with_hash
 
-        raw_url = f"https://nexus:8081/repository/cachito-pip-raw/foo.tar.gz"
+        raw_url = "https://nexus:8081/repository/cachito-pip-raw/foo.tar.gz"
 
         mock_requirement = self.mock_requirement(
             "foo",
@@ -2780,7 +2780,7 @@ class TestDownload:
             set(trusted_hosts),
         )
 
-        raw_component = f"foo/foo-external-sha256-abcdef.tar.gz"
+        raw_component = "foo/foo-external-sha256-abcdef.tar.gz"
 
         assert download_info == {
             "package": "foo",
@@ -3436,7 +3436,7 @@ def test_push_downloaded_requirement_non_pypi(mock_upload, dev, kind):
         url = "https://example.org/eggs.tar.gz"
         url_with_hash = f"{url}#cachito_hash=sha256:abcdef"
         version = url_with_hash
-        raw_component = f"eggs/eggs.tar.gz"
+        raw_component = "eggs/eggs.tar.gz"
 
     dest_dir, filename = raw_component.rsplit("/", 1)
     req = {
@@ -3485,7 +3485,7 @@ def test_push_downloaded_requirement_non_pypi_duplicated(
         url = "https://example.org/eggs.tar.gz"
         url_with_hash = f"{url}#cachito_hash=sha256:abcdef"
         version = url_with_hash
-        raw_component = f"eggs/eggs.tar.gz"
+        raw_component = "eggs/eggs.tar.gz"
 
     dest_dir, filename = raw_component.rsplit("/", 1)
     req = {

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -240,7 +240,7 @@ def test_convert_to_nexus_hosted(
         # allowlisted file dependency
         (
             # yarn_lock
-            {f"subpackage@file:./subpath": {"version": "4.0.0"}},
+            {"subpackage@file:./subpath": {"version": "4.0.0"}},
             # allowlist
             {"subpath"},
             # expected_deps
@@ -338,11 +338,11 @@ def test_get_deps(
 @mock.patch("cachito.workers.pkg_managers.yarn._convert_to_nexus_hosted")
 def test_get_deps_disallowed_file_dep(mock_convert_hosted):
     yarn_lock = {
-        f"subpackage@file:./subpath": {"version": "1.0.0"},
+        "subpackage@file:./subpath": {"version": "1.0.0"},
     }
     allowlist = set()
 
-    err_msg = f"The dependency ./subpath is hosted in an unsupported location"
+    err_msg = "The dependency ./subpath is hosted in an unsupported location"
     mock_convert_hosted.side_effect = [CachitoError(err_msg)]
 
     with pytest.raises(CachitoError, match=err_msg):


### PR DESCRIPTION
Picks up the dependabot update from https://github.com/release-engineering/cachito/pull/397 and fixes the newly introduced violations.