### PR TITLE
Check for changes after vendoring go deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,9 @@ with the `mod_auth_gssapi` module.
 * `gomod-vendor` - the flag to indicate the vendoring requirement for gomod dependencies. If present in the
   Cachito request, Cachito will run `go mod vendor` instead of `go mod download` to gather dependencies.
 
+* `gomod-vendor-check` - like `gomod-vendor`, but if the `vendor/` directory is already present,
+  Cachito will refuse to make changes in your repository. Should be preferred over `gomod-vendor`.
+
 * `include-git-dir` - when used, `.git` file objects are not removed from the source bundle created
   by Cachito. This is useful when the git history is important to the build process.
 

--- a/cachito/web/migrations/versions/c6ac095d8e9f_add_gomod_vendor_check_flag.py
+++ b/cachito/web/migrations/versions/c6ac095d8e9f_add_gomod_vendor_check_flag.py
@@ -1,0 +1,43 @@
+"""Add the gomod-vendor-check flag
+
+Revision ID: c6ac095d8e9f
+Revises: 07d89c5778f2
+Create Date: 2021-04-15 13:45:44.761284
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c6ac095d8e9f"
+down_revision = "07d89c5778f2"
+branch_labels = None
+depends_on = None
+
+
+flag_table = sa.Table(
+    "flag",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer(), primary_key=True),
+    sa.Column("name", sa.String(), nullable=False),
+    sa.Column("active", sa.Boolean(), nullable=False, default=True),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    res = connection.execute(
+        flag_table.select().where(flag_table.c.name == "gomod-vendor-check")
+    ).fetchone()
+    if res is None:
+        connection.execute(flag_table.insert().values(name="gomod-vendor-check", active=True))
+    else:
+        connection.execute(
+            flag_table.update().where(flag_table.c.name == "gomod-vendor-check").values(active=True)
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    connection.execute(flag_table.update().values(name="gomod-vendor-check", active=False))

--- a/tests/helper_utils/__init__.py
+++ b/tests/helper_utils/__init__.py
@@ -1,6 +1,7 @@
 import filecmp
 import os
 from pathlib import Path
+from typing import Union
 
 
 def assert_directories_equal(dir_a, dir_b):
@@ -38,12 +39,13 @@ class Symlink(str):
     """
 
 
-def write_file_tree(tree_def, rooted_at):
+def write_file_tree(tree_def: dict, rooted_at: Union[str, Path], exist_ok: bool = False):
     """
     Write a file tree to disk.
 
-    :param dict tree_def: Definition of file tree, see usage for intuitive examples
-    :param (str | Path) rooted_at: Root of file tree, must be an existing directory
+    :param tree_def: Definition of file tree, see usage for intuitive examples
+    :param rooted_at: Root of file tree, must be an existing directory
+    :param exist_ok: If True, existing directories will not cause this function to fail
     """
     root = Path(rooted_at)
     for entry, value in tree_def.items():
@@ -53,5 +55,5 @@ def write_file_tree(tree_def, rooted_at):
         elif isinstance(value, str):
             entry_path.write_text(value)
         else:
-            entry_path.mkdir()
+            entry_path.mkdir(exist_ok=exist_ok)
             write_file_tree(value, entry_path)


### PR DESCRIPTION
CLOUDBLD-3282

When the gomod-vendor-check flag is used, Cachito will check the vendor
directory after running `go mod vendor`. If Cachito made any changes,
the request will fail with a ValidationError.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>