### PR TITLE
Do not return data from PATCH endpoint

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -526,7 +526,7 @@ def patch_request(request_id):
     else:
         flask.current_app.logger.info("An anonymous user patched request %d", request.id)
 
-    return flask.jsonify(request.to_json()), 200
+    return "", 200
 
 
 @api_v1.route("/requests/<int:request_id>/configuration-files", methods=["POST"])

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -257,10 +257,6 @@ paths:
       responses:
         "200":
           description: The request was updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RequestVerbose'
         "403":
           description: The requester is not allowed to modify a request
           content:

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -10,7 +10,7 @@ from cachito.workers.pkg_managers.general import (
 )
 from cachito.workers.pkg_managers.gomod import resolve_gomod, path_to_subpackage
 from cachito.workers.tasks.celery import app
-from cachito.workers.tasks.utils import runs_if_request_in_progress
+from cachito.workers.tasks.utils import runs_if_request_in_progress, get_request
 from cachito.workers.tasks.general import set_request_state
 from cachito.workers.paths import RequestBundleDir
 
@@ -89,11 +89,12 @@ def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
         log.info(
             "Fetching the gomod dependencies for request %d in subpath %s", request_id, subpath
         )
-        request = set_request_state(
+        set_request_state(
             request_id,
             "in_progress",
             f'Fetching the gomod dependencies at the "{subpath}" directory',
         )
+        request = get_request(request_id)
         gomod_source_path = str(bundle_dir.app_subpath(subpath).source_dir)
         try:
             gomod = resolve_gomod(

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -26,7 +26,11 @@ from cachito.workers.pkg_managers.npm import (
 )
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.general import set_request_state
-from cachito.workers.tasks.utils import make_base64_config_file, runs_if_request_in_progress
+from cachito.workers.tasks.utils import (
+    make_base64_config_file,
+    runs_if_request_in_progress,
+    get_request,
+)
 
 __all__ = ["cleanup_npm_request", "fetch_npm_source"]
 log = logging.getLogger(__name__)
@@ -121,11 +125,12 @@ def fetch_npm_source(request_id, package_configs=None):
     downloaded_deps = set()
     for i, subpath in enumerate(subpaths):
         log.info("Fetching the npm dependencies for request %d in subpath %s", request_id, subpath)
-        request = set_request_state(
+        set_request_state(
             request_id,
             "in_progress",
             f'Fetching the npm dependencies at the "{subpath}" directory"',
         )
+        request = get_request(request_id)
         package_source_path = str(bundle_dir.app_subpath(subpath).source_dir)
         try:
             package_and_deps_info = resolve_npm(

--- a/cachito/workers/tasks/pip.py
+++ b/cachito/workers/tasks/pip.py
@@ -26,7 +26,11 @@ from cachito.workers.pkg_managers.pip import (
 )
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.general import set_request_state
-from cachito.workers.tasks.utils import make_base64_config_file, runs_if_request_in_progress
+from cachito.workers.tasks.utils import (
+    make_base64_config_file,
+    runs_if_request_in_progress,
+    get_request,
+)
 
 
 log = logging.getLogger(__name__)
@@ -69,9 +73,10 @@ def fetch_pip_source(request_id, package_configs=None):
     for pkg_cfg in package_configs:
         pkg_path = pkg_cfg.get("path", ".")
         source_dir = bundle_dir.app_subpath(pkg_path).source_dir
-        request = set_request_state(
+        set_request_state(
             request_id, "in_progress", f"Fetching dependencies at the {pkg_path!r} directory",
         )
+        request = get_request(request_id)
         pkg_and_deps_info = resolve_pip(
             source_dir,
             request,

--- a/cachito/workers/tasks/yarn.py
+++ b/cachito/workers/tasks/yarn.py
@@ -32,6 +32,7 @@ from cachito.workers.tasks.utils import (
     make_base64_config_file,
     AssertPackageFiles,
     runs_if_request_in_progress,
+    get_request,
 )
 
 __all__ = ["cleanup_yarn_request", "fetch_yarn_source"]
@@ -117,11 +118,12 @@ def fetch_yarn_source(request_id: int, package_configs: List[dict] = None):
     downloaded_deps = set()
     for i, subpath in enumerate(subpaths):
         log.info("Fetching the yarn dependencies for request %d in subpath %s", request_id, subpath)
-        request = set_request_state(
+        set_request_state(
             request_id,
             "in_progress",
             f'Fetching the yarn dependencies at the "{subpath}" directory',
         )
+        request = get_request(request_id)
         package_source_path = str(bundle_dir.app_subpath(subpath).source_dir)
         try:
             package_and_deps_info = resolve_yarn(

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -133,12 +133,19 @@ def test_failed_request_callback_not_cachitoerror(mock_set_request_state, task_p
 @pytest.mark.parametrize("deps_present", (True, False))
 @pytest.mark.parametrize("include_git_dir", (True, False))
 @mock.patch("cachito.workers.tasks.general.set_request_state")
+@mock.patch("cachito.workers.tasks.general.get_request")
 @mock.patch("cachito.workers.paths.get_worker_config")
 def test_create_bundle_archive(
-    mock_gwc, mock_set_request, deps_present, include_git_dir, tmpdir, task_passes_state_check
+    mock_gwc,
+    mock_get_request,
+    mock_set_request,
+    deps_present,
+    include_git_dir,
+    tmpdir,
+    task_passes_state_check,
 ):
     flags = ["include-git-dir"] if include_git_dir else []
-    mock_set_request.return_value = {"flags": flags}
+    mock_get_request.return_value = {"flags": flags}
 
     # Make the bundles and sources dir configs point to under the pytest managed temp dir
     bundles_dir = tmpdir.mkdir("bundles")
@@ -202,3 +209,4 @@ def test_create_bundle_archive(
     calls = [call1, call2]
     assert mock_set_request.call_count == len(calls)
     mock_set_request.assert_has_calls(calls)
+    mock_get_request.assert_called_once_with(request_id)

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -66,9 +66,11 @@ from cachito.workers.tasks import gomod
 @mock.patch("cachito.workers.tasks.gomod.update_request_with_package")
 @mock.patch("cachito.workers.tasks.gomod.update_request_with_deps")
 @mock.patch("cachito.workers.tasks.gomod.set_request_state")
+@mock.patch("cachito.workers.tasks.gomod.get_request")
 @mock.patch("cachito.workers.tasks.gomod.resolve_gomod")
 def test_fetch_gomod_source(
     mock_resolve_gomod,
+    mock_get_request,
     mock_set_request_state,
     mock_update_request_with_deps,
     mock_update_request_with_package,
@@ -102,7 +104,7 @@ def test_fetch_gomod_source(
     }
     sample_env_vars.update(env_vars)
     mock_request = mock.Mock()
-    mock_set_request_state.return_value = mock_request
+    mock_get_request.return_value = mock_request
     pkg_lvl_deps = []
     if has_pkg_lvl_deps:
         pkg_lvl_deps = sample_pkg_deps
@@ -150,6 +152,7 @@ def test_fetch_gomod_source(
                 dep_calls.append(mock.call(1, sample_pkg_lvl_pkg, sample_pkg_deps))
 
         mock_set_request_state.assert_has_calls(state_calls)
+        mock_get_request.assert_has_calls(mock.call(1) for _ in state_calls)
         mock_update_request_with_package.assert_has_calls(pkg_calls)
         assert mock_update_request_with_package.call_count == len(pkg_calls)
         mock_update_request_with_deps.assert_has_calls(dep_calls)

--- a/tests/test_workers/test_tasks/test_pip.py
+++ b/tests/test_workers/test_tasks/test_pip.py
@@ -29,6 +29,7 @@ def test_cleanup_pip_request(mock_exec_script):
 @mock.patch("cachito.workers.tasks.pip.finalize_nexus_for_pip_request")
 @mock.patch("cachito.workers.tasks.pip.prepare_nexus_for_pip_request")
 @mock.patch("cachito.workers.tasks.pip.set_request_state")
+@mock.patch("cachito.workers.tasks.pip.get_request")
 @mock.patch("cachito.workers.tasks.pip.update_request_with_deps")
 @mock.patch("cachito.workers.tasks.pip.update_request_with_package")
 @mock.patch("cachito.workers.tasks.pip.update_request_with_config_files")
@@ -42,6 +43,7 @@ def test_fetch_pip_source(
     mock_update_cfg,
     mock_update_pkg,
     mock_update_deps,
+    mock_get_request,
     mock_set_state,
     mock_prepare_nexus,
     mock_finalize_nexus,
@@ -99,7 +101,7 @@ def test_fetch_pip_source(
 
     mock_resolve.return_value = pkg_data
     mock_finalize_nexus.return_value = password
-    mock_set_state.return_value = request
+    mock_get_request.return_value = request
 
     if package_subpath:
         package_configs = [{"path": package_subpath}]

--- a/tests/test_workers/test_tasks/test_yarn.py
+++ b/tests/test_workers/test_tasks/test_yarn.py
@@ -130,6 +130,7 @@ def test_yarn_lock_to_str(mock_lockfile):
 @mock.patch("cachito.workers.tasks.yarn.validate_yarn_config")
 @mock.patch("cachito.workers.tasks.yarn._verify_yarn_files")
 @mock.patch("cachito.workers.tasks.yarn.set_request_state")
+@mock.patch("cachito.workers.tasks.yarn.get_request")
 @mock.patch("cachito.workers.tasks.yarn.get_yarn_proxy_repo_name")
 @mock.patch("cachito.workers.tasks.yarn.prepare_nexus_for_js_request")
 @mock.patch("cachito.workers.tasks.yarn.resolve_yarn")
@@ -157,6 +158,7 @@ def test_fetch_yarn(
     mock_resolve_yarn,
     mock_prepare_nexus,
     mock_get_yarn_repo_name,
+    mock_get_request,
     mock_set_state,
     mock_verify_files,
     mock_validate_config,
@@ -239,12 +241,13 @@ def test_fetch_yarn(
             mock.call(1, "in_progress", "Finalizing the Nexus configuration for yarn"),
         ]
     )
+    mock_get_request.assert_has_calls(mock.call(1) for _ in range(2))
     mock_get_yarn_repo_name.assert_called_once_with(1)
     mock_prepare_nexus.assert_called_once_with(mock_get_yarn_repo_name.return_value)
     mock_resolve_yarn.assert_has_calls(
         [
-            mock.call(str(root), mock_set_state.return_value, skip_deps=set()),
-            mock.call(str(sub), mock_set_state.return_value, skip_deps=rv1["downloaded_deps"]),
+            mock.call(str(root), mock_get_request.return_value, skip_deps=set()),
+            mock.call(str(sub), mock_get_request.return_value, skip_deps=rv1["downloaded_deps"]),
         ]
     )
     mock_worker_config.assert_called_once()
@@ -286,6 +289,7 @@ def test_fetch_yarn(
 @mock.patch("cachito.workers.tasks.yarn.validate_yarn_config")
 @mock.patch("cachito.workers.tasks.yarn._verify_yarn_files")
 @mock.patch("cachito.workers.tasks.yarn.set_request_state")
+@mock.patch("cachito.workers.tasks.yarn.get_request")
 @mock.patch("cachito.workers.tasks.yarn.get_yarn_proxy_repo_name")
 @mock.patch("cachito.workers.tasks.yarn.prepare_nexus_for_js_request")
 @mock.patch("cachito.workers.tasks.yarn.resolve_yarn")
@@ -313,6 +317,7 @@ def test_fetch_yarn_no_configs(
     mock_resolve_yarn,
     mock_prepare_nexus,
     mock_get_yarn_repo_name,
+    mock_get_request,
     mock_set_state,
     mock_verify_files,
     mock_validate_config,
@@ -337,7 +342,7 @@ def test_fetch_yarn_no_configs(
     # Just do a sanity-check on calls where subpaths are relevant
     mock_verify_files.assert_called_once_with(bundle_dir, ["."])
     mock_resolve_yarn.assert_called_once_with(
-        str(root), mock_set_state.return_value, skip_deps=set()
+        str(root), mock_get_request.return_value, skip_deps=set()
     )
     mock_generate_npmrc.assert_called_once_with(
         mock_get_yarn_repo_url.return_value,
@@ -352,6 +357,7 @@ def test_fetch_yarn_no_configs(
 @mock.patch("cachito.workers.tasks.yarn.validate_yarn_config")
 @mock.patch("cachito.workers.tasks.yarn._verify_yarn_files")
 @mock.patch("cachito.workers.tasks.yarn.set_request_state")
+@mock.patch("cachito.workers.tasks.yarn.get_request")
 @mock.patch("cachito.workers.tasks.yarn.get_yarn_proxy_repo_name")
 @mock.patch("cachito.workers.tasks.yarn.prepare_nexus_for_js_request")
 @mock.patch("cachito.workers.tasks.yarn.resolve_yarn")


### PR DESCRIPTION
CLOUDBLD-5734

The PATCH endpoint takes a JSON payload and updates the Cachito DB based
on that payload. One seemingly innocent thing that this endpoint does is
return the JSON representation of the request that was just updated.

One of the many barely related use cases of this endpoint is adding
dependencies to requests. We add dependencies in batches of 50. Every
time we add a dependency, it becomes part of the JSON representation of
that request. For requests with a large number of dependencies, the JSON
can quickly grow in size to the point where downloading the data takes
up the *majority* of the processing time of the entire request.

Most of the use cases of this endpoint do not utilize the returned JSON
data at all. The few that do are tied to the set_request_state() method.
Those use cases are replaced by a new get_request() method. The endpoint
no longer returns any data.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>