### PR TITLE
Run black on python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ jobs:
   include:
     - python: "3.9"
       env: TOXENV=py39
+      # as soon as black > 20.8b1 is released, we start using it and this bug is
+      # fixed: https://bugs.python.org/issue43498, we can move these tests to the python 3.9 job
     - python: "3.8"
-      env: TOXENV=black,flake8  # as soon as black > 20.8b1 is released and we start using it, we can move these tests to the python 3.9 job
+      env: TOXENV=black,flake8
     - python: "3.8"
       env: TOXENV=py38
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,9 @@ commands =
         --cov-report xml --cov-report html {posargs}
 
 [testenv:black]
+# a bug in python3.9 is causing occasional failures: https://bugs.python.org/issue43498,
+# after this is fixed, basepython can be removed
+basepython = python3.8
 description = black checks [Mandatory]
 skip_install = true
 deps =


### PR DESCRIPTION
We encountered a bug in python3.9 that is causing occasional failures
when running black.
https://bugs.python.org/issue43498