### PR TITLE
Fix pip docs reference to build requirements configuration key

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -208,7 +208,7 @@ that uses all the available configuration options.
       },
       {
         "path": "some/subpackage",
-        "build_requirements_files": ["requirements-build-only.txt"]
+        "requirements_build_files": ["requirements-build-only.txt"]
       }
     ]
   }


### PR DESCRIPTION
requirements_build_files is the key actually used by Cachito when looking for that value.