### PR TITLE
Adjust unique constraint on Flag table

### DIFF
--- a/cachito/web/migrations/versions/4d17dec0cfc3_adjust_flag_unique_constraint.py
+++ b/cachito/web/migrations/versions/4d17dec0cfc3_adjust_flag_unique_constraint.py
@@ -1,0 +1,28 @@
+"""Adjust unique constraint on Flag table
+
+Revision ID: 4d17dec0cfc3
+Revises: c6ac095d8e9f
+Create Date: 2021-05-25 13:21:48.298960
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4d17dec0cfc3"
+down_revision = "c6ac095d8e9f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("flag") as batch_op:
+        batch_op.create_unique_constraint("flag_name_key", ["name"])
+        batch_op.drop_constraint("flag_id_name_key", type_="unique")
+
+
+def downgrade():
+    with op.batch_alter_table("flag") as batch_op:
+        batch_op.drop_constraint("flag_name_key", type_="unique")
+        batch_op.create_unique_constraint("flag_id_name_key", ["id", "name"])

--- a/cachito/web/migrations/versions/a655a299e967_request_flags.py
+++ b/cachito/web/migrations/versions/a655a299e967_request_flags.py
@@ -23,7 +23,7 @@ def upgrade():
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("active", sa.Boolean(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("id", "name"),
+        sa.UniqueConstraint("id", "name", name="flag_id_name_key"),
     )
 
     op.create_table(

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -1236,10 +1236,8 @@ class Flag(db.Model):
     """A flag to enable a feature on the Cachito request."""
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String, nullable=False)
+    name = db.Column(db.String, unique=True, nullable=False)
     active = db.Column(db.Boolean, nullable=False, default=True)
-
-    __table_args__ = (db.UniqueConstraint("id", "name"),)
 
     @classmethod
     def from_json(cls, name):


### PR DESCRIPTION
The unique constraint for the Flag table was set for "id" and "name". That was not desired because there could be multiple flag entries with the same name. The unique constraint is now only on the name column.

Signed-off-by: Tereza Hrbkova <thrbkova@redhat.com>