### PR TITLE
Read request packages and dependencies from packages.json

### DIFF
--- a/cachito/utils.py
+++ b/cachito/utils.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Tuple, Union
+
+from cachito.errors import CachitoError
+
+log = logging.getLogger(__name__)
+
+
+def package_sort_key(package: Dict[str, Any]) -> Tuple[str, bool, str, str]:
+    """Return the sort key for sorting packages.
+
+    :param package: a mapping representing a package information. It must
+        contain four keys, type, dev, name and version.
+    :type package: dict[str, any]
+    :return: a four-elements tuple as the sort key in the order of type, dev,
+        name and version.
+    :rtype: tuple[str, bool, str, str]
+    """
+    return package["type"], package.get("dev", False), package["name"], package["version"]
+
+
+def sort_packages_and_deps_in_place(packages: List[Dict[str, Any]]) -> None:
+    """
+    Sorts lists of packages in place.
+
+    Sorting order: type -> dev -> name -> version.
+    If a package has a "dependencies" list, the packages inside it will be sorted as well.
+
+    :param list packages: the list of packages
+    """
+    packages.sort(key=package_sort_key)
+    for package in packages:
+        if "dependencies" in package:
+            package["dependencies"].sort(key=package_sort_key)
+
+
+def _package_equal(left: Union[Dict[str, Any], None], right: Dict[str, Any]) -> bool:
+    """Check if left package equals to the right.
+
+    Used by unique_packages internally.
+    """
+    if left is None:
+        return False
+    return (
+        left["name"] == right["name"]
+        and left["type"] == right["type"]
+        and left["version"] == right["version"]
+        and left.get("dev", False) == right.get("dev", False)
+    )
+
+
+def unique_packages(packages: List[Dict[str, Any]]) -> Iterator:
+    """Remove duplicate packages.
+
+    If two packages as well as dependencies have same name, type, version and
+    dev, they are duplicated. This function assumes the packages have been
+    sorted already.
+
+    :param packages: a list of sorted packages to be deduplicated. If two
+        packages have same name, type, version and dev, they will be considered
+        as duplicate package.
+    :type packages: list[dict[str, any]]
+    """
+    i = -1
+    j = 0
+    while j < len(packages):
+        left = None if i < 0 else packages[i]
+        right = packages[j]
+        if _package_equal(left, right):
+            j += 1
+        else:
+            yield right
+            i = j
+            j += 1
+
+
+class PackagesData:
+    """A collection of resolved packages."""
+
+    def __init__(self) -> None:
+        """Initialize an empty PackagesData instance."""
+        self._index = set()
+        self._packages = []
+
+    @property
+    def packages(self) -> List[Dict[str, Any]]:
+        """Get added packages."""
+        return self._packages
+
+    @property
+    def all_dependencies(self) -> List[Dict[str, Any]]:
+        """Gather dependencies together from every package.
+
+        :return: a list of sorted and deduplicated dependencies gathered from
+            every package. If no package is added, an empty list will be returned.
+        :rtype: list[dict[str, any]]
+        """
+        return list(
+            unique_packages(
+                sorted(
+                    (dep for pkg in self._packages for dep in pkg["dependencies"]),
+                    key=package_sort_key,
+                )
+            )
+        )
+
+    def add_package(self, pkg_info: Dict[str, str], path: str, deps: List[Dict[str, Any]]) -> None:
+        """Add a package with deps.
+
+        :param dict[str, str] pkg_info: a mapping containing a package information.
+            It must have ``name``, ``type`` and ``version`` key/value pairs.
+        :param str path: the path where the package is retreived. Consult with the
+            ``fetch_*_source`` for the defailed information about a package's path.
+        :param deps: a list of depencencies the package has.
+        :type deps: list[dict[str, any]]
+        :raises CachitoError: if there is a package with same name, type and version
+            has been added already.
+        """
+        key = (pkg_info["name"], pkg_info["type"], pkg_info["version"])
+        if key in self._index:
+            raise CachitoError(f"Duplicate package: {pkg_info!r}")
+        self._index.add(key)
+        package = {
+            "name": pkg_info["name"],
+            "type": pkg_info["type"],
+            "version": pkg_info["version"],
+            "dependencies": deps,
+        }
+        if path != os.curdir:
+            package["path"] = path
+        self._packages.append(package)
+
+    def write_to_file(self, file_name: Union[str, Path]) -> None:
+        """Write the added packages to a file as JSON data.
+
+        It ensures that the packages and every package's dependencies are sorted
+        by the combination in the order of type, dev, name and version.
+
+        :param file_name: an absolute or relative filename to write the added packages into.
+            When a relative path is used, it will be opened directly and depends on the
+            ``os.curdir``.
+        :type file_name: str or pathlib.Path
+        """
+        sort_packages_and_deps_in_place(self._packages)
+
+        log.debug("Write packages with dependencies into file %s.", file_name)
+        with open(file_name, "w", encoding="utf-8") as f:
+            json.dump({"packages": self._packages}, f)
+
+    def load(self, file_name: Union[str, Path]) -> None:
+        """Load data from a specified file written by write_to_file method.
+
+        :param file_name: an absolute or relative filename to write the added packages into.
+            When a relative path is used, it will be opened directly and depends on the
+            ``os.curdir``. If the file does not exist, nothing is changed internally.
+        :type file_name: str or pathlib.Path
+        """
+        if not os.path.exists(file_name):
+            log.debug("No data is loaded from non-existing file %s.", file_name)
+            return
+        with open(file_name, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            packages = data.get("packages")
+            if packages is None:
+                log.warning("Packages data file does not include key 'packages'.")
+                return
+            for p in packages:
+                self.add_package(p, p.get("path", os.curdir), p["dependencies"])

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -9,11 +9,11 @@ from typing import List
 import requests
 
 from cachito.errors import CachitoError, ValidationError
+from cachito.utils import PackagesData
 from cachito.workers.scm import Git
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.utils import (
-    PackagesData,
     runs_if_request_in_progress,
     get_request,
     set_request_state,

--- a/cachito/workers/tasks/gitsubmodule.py
+++ b/cachito/workers/tasks/gitsubmodule.py
@@ -3,10 +3,11 @@ import logging
 
 import git
 
+from cachito.utils import PackagesData
 from cachito.workers.pkg_managers.general import update_request_with_package
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.tasks.celery import app
-from cachito.workers.tasks.utils import PackagesData, runs_if_request_in_progress
+from cachito.workers.tasks.utils import runs_if_request_in_progress
 
 __all__ = ["add_git_submodules_as_package"]
 log = logging.getLogger(__name__)

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from cachito.errors import CachitoError
+from cachito.utils import PackagesData
 from cachito.workers.config import get_worker_config
 from cachito.workers.pkg_managers.general import (
     update_request_with_deps,
@@ -11,7 +12,6 @@ from cachito.workers.pkg_managers.general import (
 from cachito.workers.pkg_managers.gomod import resolve_gomod, path_to_subpackage
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.utils import (
-    PackagesData,
     runs_if_request_in_progress,
     get_request,
     set_request_state,

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -5,6 +5,7 @@ import os
 from typing import List
 
 from cachito.errors import CachitoError
+from cachito.utils import PackagesData
 from cachito.workers import nexus
 from cachito.workers.config import get_worker_config, validate_npm_config
 from cachito.workers.paths import RequestBundleDir
@@ -26,7 +27,6 @@ from cachito.workers.pkg_managers.npm import (
 )
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.utils import (
-    PackagesData,
     make_base64_config_file,
     runs_if_request_in_progress,
     get_request,

--- a/cachito/workers/tasks/pip.py
+++ b/cachito/workers/tasks/pip.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 from cachito.errors import CachitoError
+from cachito.utils import PackagesData
 from cachito.workers import nexus
 from cachito.workers.config import get_worker_config, validate_pip_config
 from cachito.workers.paths import RequestBundleDir
@@ -26,7 +27,6 @@ from cachito.workers.pkg_managers.pip import (
 )
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.utils import (
-    PackagesData,
     make_base64_config_file,
     runs_if_request_in_progress,
     get_request,

--- a/cachito/workers/tasks/yarn.py
+++ b/cachito/workers/tasks/yarn.py
@@ -7,6 +7,7 @@ from typing import List
 import pyarn.lockfile
 
 from cachito.errors import CachitoError
+from cachito.utils import PackagesData
 from cachito.workers import nexus
 from cachito.workers.config import get_worker_config, validate_yarn_config
 from cachito.workers.paths import RequestBundleDir
@@ -28,7 +29,6 @@ from cachito.workers.pkg_managers.yarn import (
 from cachito.workers.tasks.celery import app
 from cachito.workers.tasks.npm import generate_npmrc_config_files
 from cachito.workers.tasks.utils import (
-    PackagesData,
     make_base64_config_file,
     AssertPackageFiles,
     runs_if_request_in_progress,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import json
+import os
 from collections import OrderedDict
 
 import pytest
 
+from cachito.errors import CachitoError
+from cachito.utils import sort_packages_and_deps_in_place, unique_packages, PackagesData
 from cachito.web.utils import deep_sort_icm
 
 
@@ -72,3 +76,340 @@ def test_deep_sort_icm(orig_items):
         ),
     ]
     assert deep_sort_icm(orig_items) == expected
+
+
+@pytest.mark.parametrize(
+    "packages,expected",
+    [
+        [[], []],
+        [
+            [{"name": "p1", "type": "gomod", "version": "1"}],
+            [{"name": "p1", "type": "gomod", "version": "1"}],
+        ],
+        [
+            # Unsorted packages
+            [
+                {"name": "p3", "type": "npm", "version": "3"},
+                {"name": "p1", "type": "gomod", "version": "1"},
+                {"name": "p2", "type": "go-package", "version": "2"},
+                {"name": "p3", "type": "npm", "version": "3"},
+            ],
+            [
+                {"name": "p3", "type": "npm", "version": "3"},
+                {"name": "p1", "type": "gomod", "version": "1"},
+                {"name": "p2", "type": "go-package", "version": "2"},
+                {"name": "p3", "type": "npm", "version": "3"},
+            ],
+        ],
+        [
+            # Sorted packages
+            [
+                {"name": "p1", "type": "gomod", "version": "1"},
+                {"name": "p1", "type": "gomod", "version": "1"},
+                {"name": "p2", "type": "go-package", "version": "2"},
+                {"name": "p4", "type": "yarn", "version": "4", "dev": True},
+                {"name": "p4", "type": "yarn", "version": "4"},
+                {"name": "p3", "type": "npm", "version": "3"},
+                {"name": "p3", "type": "npm", "version": "3"},
+            ],
+            [
+                {"name": "p1", "type": "gomod", "version": "1"},
+                {"name": "p2", "type": "go-package", "version": "2"},
+                {"name": "p4", "type": "yarn", "version": "4", "dev": True},
+                {"name": "p4", "type": "yarn", "version": "4"},
+                {"name": "p3", "type": "npm", "version": "3"},
+            ],
+        ],
+    ],
+)
+def test_unique_packages(packages, expected):
+    assert expected == list(unique_packages(packages))
+
+
+def test_sort_packages_and_deps_in_place():
+    # using different package managers to test sorting by type
+    packages = [
+        # test sorting by dev
+        {"name": "pkg6", "type": "pip", "version": "1.0.0", "dev": False},
+        {"name": "pkg5", "type": "pip", "version": "1.0.0", "dev": True},
+        # test sorting by name
+        {"name": "pkg3", "type": "npm", "version": "1.0.0", "dev": False},
+        {"name": "pkg2", "type": "npm", "version": "1.2.3", "dev": False},
+        # test sorting by version
+        {"name": "pkg4", "type": "npm", "version": "1.2.5", "dev": False},
+        {"name": "pkg4", "type": "npm", "version": "1.2.0", "dev": False},
+        {
+            "name": "pkg1",
+            "type": "gomod",
+            "version": "1.0.0",
+            "dependencies": [
+                # test sorting of dependencies
+                {"name": "pkg1-dep2", "type": "gomod", "version": "1.0.0"},
+                {"name": "pkg1-dep1", "type": "gomod", "version": "1.0.0"},
+            ],
+        },
+    ]
+
+    sorted_packages = [
+        {
+            "name": "pkg1",
+            "type": "gomod",
+            "version": "1.0.0",
+            "dependencies": [
+                {"name": "pkg1-dep1", "type": "gomod", "version": "1.0.0"},
+                {"name": "pkg1-dep2", "type": "gomod", "version": "1.0.0"},
+            ],
+        },
+        {"name": "pkg2", "type": "npm", "version": "1.2.3", "dev": False},
+        {"name": "pkg3", "type": "npm", "version": "1.0.0", "dev": False},
+        {"name": "pkg4", "type": "npm", "version": "1.2.0", "dev": False},
+        {"name": "pkg4", "type": "npm", "version": "1.2.5", "dev": False},
+        {"name": "pkg6", "type": "pip", "version": "1.0.0", "dev": False},
+        {"name": "pkg5", "type": "pip", "version": "1.0.0", "dev": True},
+    ]
+
+    sort_packages_and_deps_in_place(packages)
+
+    assert packages == sorted_packages
+
+
+class TestPackagesData:
+    """Test class PackagesData."""
+
+    @pytest.mark.parametrize(
+        "params,expected",
+        [
+            [
+                [[{"name": "pkg1", "type": "gomod", "version": "1.0.0"}, "path1", []]],
+                [
+                    {
+                        "name": "pkg1",
+                        "type": "gomod",
+                        "version": "1.0.0",
+                        "path": "path1",
+                        "dependencies": [],
+                    },
+                ],
+            ],
+            [
+                [
+                    [{"name": "pkg1", "type": "gomod", "version": "1.0.0"}, "path1", []],
+                    [{"name": "pkg2", "type": "yarn", "version": "2.3.1"}, os.curdir, []],
+                    [
+                        {"name": "pkg3", "type": "npm", "version": "1.2.3"},
+                        os.curdir,
+                        [{"name": "async@15.0.0"}],
+                    ],
+                ],
+                [
+                    {
+                        "name": "pkg1",
+                        "type": "gomod",
+                        "version": "1.0.0",
+                        "path": "path1",
+                        "dependencies": [],
+                    },
+                    {"name": "pkg2", "type": "yarn", "version": "2.3.1", "dependencies": []},
+                    {
+                        "name": "pkg3",
+                        "type": "npm",
+                        "version": "1.2.3",
+                        "dependencies": [{"name": "async@15.0.0"}],
+                    },
+                ],
+            ],
+            [
+                [
+                    [{"name": "pkg1", "type": "gomod", "version": "1.0.0"}, "path1", []],
+                    [
+                        {"name": "pkg1", "type": "gomod", "version": "1.0.0"},
+                        "somewhere/",
+                        [{"name": "golang.org/x/text/internal/tag"}],
+                    ],
+                ],
+                pytest.raises(CachitoError, match="Duplicate package"),
+            ],
+        ],
+    )
+    def test_add_package(self, params, expected):
+        """Test method add_package."""
+        pd = PackagesData()
+        if isinstance(expected, list):
+            for pkg_info, path, deps in params:
+                pd.add_package(pkg_info, path, deps)
+            assert expected == pd._packages
+        else:
+            with expected:
+                for pkg_info, path, deps in params:
+                    pd.add_package(pkg_info, path, deps)
+
+    @pytest.mark.parametrize(
+        "params,expected",
+        [
+            [[], {"packages": []}],
+            [
+                [
+                    [{"name": "pkg1", "type": "gomod", "version": "1.0.0"}, "path1", []],
+                    [
+                        {"name": "pkg3", "type": "npm", "version": "1.2.3"},
+                        os.curdir,
+                        [{"name": "async", "type": "npm", "version": "15.0.0"}],
+                    ],
+                ],
+                {
+                    "packages": [
+                        {
+                            "name": "pkg1",
+                            "type": "gomod",
+                            "version": "1.0.0",
+                            "path": "path1",
+                            "dependencies": [],
+                        },
+                        {
+                            "name": "pkg3",
+                            "type": "npm",
+                            "version": "1.2.3",
+                            "dependencies": [{"name": "async", "type": "npm", "version": "15.0.0"}],
+                        },
+                    ],
+                },
+            ],
+        ],
+    )
+    def test_write_to_file(self, params, expected, tmpdir):
+        """Test method write_to_file."""
+        pd = PackagesData()
+        for pkg_info, path, deps in params:
+            pd.add_package(pkg_info, path, deps)
+        filename = os.path.join(tmpdir, "data.json")
+        pd.write_to_file(filename)
+        with open(filename, "r") as f:
+            assert expected == json.load(f)
+
+    @pytest.mark.parametrize(
+        "packages_data,expected",
+        [
+            [None, []],
+            [{}, []],
+            [{"data": []}, []],
+            [
+                {
+                    "packages": [
+                        {
+                            "name": "pkg1",
+                            "type": "gomod",
+                            "version": "1.0.0",
+                            "path": "path1",
+                            "dependencies": [],
+                        },
+                        {
+                            "name": "pkg3",
+                            "type": "npm",
+                            "version": "1.2.3",
+                            "dependencies": [{"name": "async@15.0.0"}],
+                        },
+                    ],
+                },
+                [
+                    {
+                        "name": "pkg1",
+                        "type": "gomod",
+                        "version": "1.0.0",
+                        "path": "path1",
+                        "dependencies": [],
+                    },
+                    {
+                        "name": "pkg3",
+                        "type": "npm",
+                        "version": "1.2.3",
+                        "dependencies": [{"name": "async@15.0.0"}],
+                    },
+                ],
+            ],
+        ],
+    )
+    def test_load_from_file(self, packages_data, expected, tmpdir):
+        """Test method load."""
+        filename = os.path.join(tmpdir, "data.json")
+        if packages_data is not None:
+            with open(filename, "w") as f:
+                f.write(json.dumps(packages_data))
+        pd = PackagesData()
+        pd.load(filename)
+        assert expected == pd._packages
+
+    @pytest.mark.parametrize(
+        "packages_data,expected_dependencies",
+        [
+            [
+                {
+                    "packages": [
+                        {"name": "n2", "type": "go-package", "version": "v2", "dependencies": []},
+                        {"name": "n1", "type": "gomod", "version": "v1", "dependencies": []},
+                    ],
+                },
+                [],
+            ],
+            [
+                {
+                    "packages": [
+                        {
+                            "name": "n2",
+                            "type": "go-package",
+                            "version": "v2",
+                            "dependencies": [
+                                {"name": "d1", "type": "go-package", "version": "1"},
+                                {
+                                    "name": "d2",
+                                    "replaces": None,
+                                    "type": "go-package",
+                                    "version": "2",
+                                },
+                            ],
+                        },
+                        {
+                            "name": "n1",
+                            "type": "gomod",
+                            "version": "v1",
+                            "dependencies": [
+                                {"name": "d1", "type": "gomod", "version": "1"},
+                                {"name": "d2", "replaces": None, "type": "gomod", "version": "2"},
+                            ],
+                        },
+                        {
+                            "name": "p1",
+                            "type": "npm",
+                            "version": "v2",
+                            "dependencies": [{"name": "async", "type": "npm", "version": "1.2.0"}],
+                        },
+                        {
+                            "name": "p2",
+                            "type": "npm",
+                            "version": "20210621",
+                            "dependencies": [
+                                {"name": "async", "type": "npm", "version": "1.2.0"},
+                                {"name": "underscore", "type": "npm", "version": "1.13.0"},
+                            ],
+                        },
+                    ],
+                },
+                [
+                    {"name": "d1", "type": "go-package", "version": "1"},
+                    {"name": "d2", "replaces": None, "type": "go-package", "version": "2"},
+                    {"name": "d1", "type": "gomod", "version": "1"},
+                    {"name": "d2", "replaces": None, "type": "gomod", "version": "2"},
+                    # Only one async in the final dependencies list
+                    {"name": "async", "type": "npm", "version": "1.2.0"},
+                    {"name": "underscore", "type": "npm", "version": "1.13.0"},
+                ],
+            ],
+        ],
+    )
+    def test_all_dependencies(self, packages_data, expected_dependencies, tmpdir):
+        """Test property all_dependencies."""
+        filename = os.path.join(tmpdir, "data.json")
+        with open(filename, "w") as f:
+            f.write(json.dumps(packages_data))
+        pd = PackagesData()
+        pd.load(filename)
+        assert expected_dependencies == pd.all_dependencies

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -266,6 +266,8 @@ def test_finalize_request(
         "dependencies": [pkg, pkg],
     }
 
+    mock_aggregate_data.return_value = mock.Mock(packages=[pkg], all_dependencies=[pkg, pkg])
+
     tasks.finalize_request(42)
 
     mock_get_request.assert_called_once_with(42)

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from cachito.workers.tasks.utils import PackagesData, sort_packages_and_deps_in_place
 import copy
 import json
 from pathlib import Path
@@ -10,6 +9,7 @@ import pytest
 from cachito.errors import CachitoError
 from cachito.workers import tasks
 from cachito.workers.tasks import gomod
+from cachito.utils import PackagesData, sort_packages_and_deps_in_place
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -1,7 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import os
-import os.path
-import json
 from pathlib import Path
 from unittest import mock
 
@@ -9,8 +6,8 @@ import pytest
 import requests
 
 from cachito.errors import ValidationError, CachitoError
-from cachito.workers.tasks import utils
 from cachito.workers.requests import requests_session, requests_auth_session
+from cachito.workers.tasks import utils
 
 from tests.helper_utils import write_file_tree
 
@@ -188,53 +185,6 @@ def test_set_packages_and_deps_counts(
     )
 
 
-def test_sort_packages_and_deps_in_place():
-    # using different package managers to test sorting by type
-    packages = [
-        # test sorting by dev
-        {"name": "pkg6", "type": "pip", "version": "1.0.0", "dev": False},
-        {"name": "pkg5", "type": "pip", "version": "1.0.0", "dev": True},
-        # test sorting by name
-        {"name": "pkg3", "type": "npm", "version": "1.0.0", "dev": False},
-        {"name": "pkg2", "type": "npm", "version": "1.2.3", "dev": False},
-        # test sorting by version
-        {"name": "pkg4", "type": "npm", "version": "1.2.5", "dev": False},
-        {"name": "pkg4", "type": "npm", "version": "1.2.0", "dev": False},
-        {
-            "name": "pkg1",
-            "type": "gomod",
-            "version": "1.0.0",
-            "dependencies": [
-                # test sorting of dependencies
-                {"name": "pkg1-dep2", "type": "gomod", "version": "1.0.0"},
-                {"name": "pkg1-dep1", "type": "gomod", "version": "1.0.0"},
-            ],
-        },
-    ]
-
-    sorted_packages = [
-        {
-            "name": "pkg1",
-            "type": "gomod",
-            "version": "1.0.0",
-            "dependencies": [
-                {"name": "pkg1-dep1", "type": "gomod", "version": "1.0.0"},
-                {"name": "pkg1-dep2", "type": "gomod", "version": "1.0.0"},
-            ],
-        },
-        {"name": "pkg2", "type": "npm", "version": "1.2.3", "dev": False},
-        {"name": "pkg3", "type": "npm", "version": "1.0.0", "dev": False},
-        {"name": "pkg4", "type": "npm", "version": "1.2.0", "dev": False},
-        {"name": "pkg4", "type": "npm", "version": "1.2.5", "dev": False},
-        {"name": "pkg6", "type": "pip", "version": "1.0.0", "dev": False},
-        {"name": "pkg5", "type": "pip", "version": "1.0.0", "dev": True},
-    ]
-
-    utils.sort_packages_and_deps_in_place(packages)
-
-    assert packages == sorted_packages
-
-
 @pytest.mark.parametrize(
     "connect_error, status_error, expect_error",
     [
@@ -354,169 +304,3 @@ def test_runs_if_request_in_progress(mock_get_state, id, state):
     else:
         assert dummy_task(id) is None
     mock_get_state.assert_called_once_with(id)
-
-
-class TestPackagesData:
-    """Test class PackagesData."""
-
-    @pytest.mark.parametrize(
-        "params,expected",
-        [
-            [
-                [[{"name": "pkg1", "type": "gomod", "version": "1.0.0"}, "path1", []]],
-                [
-                    {
-                        "name": "pkg1",
-                        "type": "gomod",
-                        "version": "1.0.0",
-                        "path": "path1",
-                        "dependencies": [],
-                    },
-                ],
-            ],
-            [
-                [
-                    [{"name": "pkg1", "type": "gomod", "version": "1.0.0"}, "path1", []],
-                    [{"name": "pkg2", "type": "yarn", "version": "2.3.1"}, os.curdir, []],
-                    [
-                        {"name": "pkg3", "type": "npm", "version": "1.2.3"},
-                        os.curdir,
-                        [{"name": "async@15.0.0"}],
-                    ],
-                ],
-                [
-                    {
-                        "name": "pkg1",
-                        "type": "gomod",
-                        "version": "1.0.0",
-                        "path": "path1",
-                        "dependencies": [],
-                    },
-                    {"name": "pkg2", "type": "yarn", "version": "2.3.1", "dependencies": []},
-                    {
-                        "name": "pkg3",
-                        "type": "npm",
-                        "version": "1.2.3",
-                        "dependencies": [{"name": "async@15.0.0"}],
-                    },
-                ],
-            ],
-            [
-                [
-                    [{"name": "pkg1", "type": "gomod", "version": "1.0.0"}, "path1", []],
-                    [
-                        {"name": "pkg1", "type": "gomod", "version": "1.0.0"},
-                        "somewhere/",
-                        [{"name": "golang.org/x/text/internal/tag"}],
-                    ],
-                ],
-                pytest.raises(CachitoError, match="Duplicate package"),
-            ],
-        ],
-    )
-    def test_add_package(self, params, expected):
-        """Test method add_package."""
-        pd = utils.PackagesData()
-        if isinstance(expected, list):
-            for pkg_info, path, deps in params:
-                pd.add_package(pkg_info, path, deps)
-            assert expected == pd._packages
-        else:
-            with expected:
-                for pkg_info, path, deps in params:
-                    pd.add_package(pkg_info, path, deps)
-
-    @pytest.mark.parametrize(
-        "params,expected",
-        [
-            [[], {"packages": []}],
-            [
-                [
-                    [{"name": "pkg1", "type": "gomod", "version": "1.0.0"}, "path1", []],
-                    [
-                        {"name": "pkg3", "type": "npm", "version": "1.2.3"},
-                        os.curdir,
-                        [{"name": "async", "type": "npm", "version": "15.0.0"}],
-                    ],
-                ],
-                {
-                    "packages": [
-                        {
-                            "name": "pkg1",
-                            "type": "gomod",
-                            "version": "1.0.0",
-                            "path": "path1",
-                            "dependencies": [],
-                        },
-                        {
-                            "name": "pkg3",
-                            "type": "npm",
-                            "version": "1.2.3",
-                            "dependencies": [{"name": "async", "type": "npm", "version": "15.0.0"}],
-                        },
-                    ],
-                },
-            ],
-        ],
-    )
-    def test_write_to_file(self, params, expected, tmpdir):
-        """Test method write_to_file."""
-        pd = utils.PackagesData()
-        for pkg_info, path, deps in params:
-            pd.add_package(pkg_info, path, deps)
-        filename = os.path.join(tmpdir, "data.json")
-        pd.write_to_file(filename)
-        with open(filename, "r") as f:
-            assert expected == json.load(f)
-
-    @pytest.mark.parametrize(
-        "packages_data,expected",
-        [
-            [None, []],
-            [{}, []],
-            [{"data": []}, []],
-            [
-                {
-                    "packages": [
-                        {
-                            "name": "pkg1",
-                            "type": "gomod",
-                            "version": "1.0.0",
-                            "path": "path1",
-                            "dependencies": [],
-                        },
-                        {
-                            "name": "pkg3",
-                            "type": "npm",
-                            "version": "1.2.3",
-                            "dependencies": [{"name": "async@15.0.0"}],
-                        },
-                    ],
-                },
-                [
-                    {
-                        "name": "pkg1",
-                        "type": "gomod",
-                        "version": "1.0.0",
-                        "path": "path1",
-                        "dependencies": [],
-                    },
-                    {
-                        "name": "pkg3",
-                        "type": "npm",
-                        "version": "1.2.3",
-                        "dependencies": [{"name": "async@15.0.0"}],
-                    },
-                ],
-            ],
-        ],
-    )
-    def test_load_from_file(self, packages_data, expected, tmpdir):
-        """Test method load."""
-        filename = os.path.join(tmpdir, "data.json")
-        if packages_data is not None:
-            with open(filename, "w") as f:
-                f.write(json.dumps(packages_data))
-        pd = utils.PackagesData()
-        pd.load(filename)
-        assert expected == pd._packages


### PR DESCRIPTION
CLBOUDBLD-4728
CLBOUDBLD-4729

Both endpoints /requests and /requests/id response the Request JSON
serialized from Request.to_json. Cachito starts to read a request's
packages and dependencies from the packages.json instead of from the
database.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>