### PR TITLE
Increase timeout value for cachito requests

### DIFF
--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -4,7 +4,7 @@ api_url: http://localhost:8080/api/v1
 # Authentication type, user either null for no authentication or kerberos
 api_auth_type: null
 # Time in minutes at which the request must be completed
-timeout: 15
+timeout: 45
 # The flag cachito_gomod_strict_vendor is enabled on the environment
 strict_mode_enabled: false
 # Package that will be used for testing


### PR DESCRIPTION
CLOUDBLD-4723

Change timeout value to reflect time needed to process max number of
dependencies in a request.

Signed-off-by: Daniel Cho <dacho@redhat.com>