### PR TITLE
Fix cached dependecy integration tests

### DIFF
--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -46,20 +46,20 @@ pip_cached_deps:
   response_expectations:
     dependencies:
     - dev: false
-      name: "appr"
-      replaces: null
-      type: "pip"
-      version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
-    - dev: false
-      name: "appr"
-      replaces: null
-      type: "pip"
-      version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
-    - dev: false
       name: "aiowsgi"
       replaces: null
       type: "pip"
       version: "0.7"
+    - dev: false
+      name: "appr"
+      replaces: null
+      type: "pip"
+      version: "git+https://github.com/cachito-testing/cachito-pip-without-deps.git@SECOND_DEP_COMMIT"
+    - dev: false
+      name: "appr"
+      replaces: null
+      type: "pip"
+      version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
     - dev: false
       name: "appr"
       replaces: null
@@ -69,19 +69,9 @@ pip_cached_deps:
       name: "appr"
       replaces: null
       type: "pip"
-      version: "git+https://github.com/cachito-testing/cachito-pip-without-deps.git@SECOND_DEP_COMMIT"
+      version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
     packages:
     - dependencies:
-      - dev: false
-        name: "appr"
-        replaces: null
-        type: "pip"
-        version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
-      - dev: false
-        name: "appr"
-        replaces: null
-        type: "pip"
-        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
       - dev: false
         name: "aiowsgi"
         replaces: null
@@ -96,7 +86,17 @@ pip_cached_deps:
         name: "appr"
         replaces: null
         type: "pip"
+        version: "git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b"
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
         version: "https://github.com/cachito-testing/cachito-pip-without-deps/archive/FIRST_DEP_COMMIT.zip#egg=appr&cachito_hash=sha256:FIRST_DEP_HASH"
+      - dev: false
+        name: "appr"
+        replaces: null
+        type: "pip"
+        version: "https://github.com/quay/appr/archive/37ff9a487a54ad41b59855ecd76ee092fe206a84.zip#egg=appr&cachito_hash=sha256:ee6a0a38bed8cff46a562ed3620bc453141a02262ab0c8dd055824af2829ee5c"
       name: "cachito-pip-with-deps"
       type: "pip"
       version: "1.0.0"
@@ -137,14 +137,14 @@ gomod_cached_deps:
   response_expectations:
     packages:
     - dependencies:
-      - name: "github.com/cachito-testing/cachito-gomod-without-deps"
+      - name: "golang.org/x/text/internal/tag"
         replaces: null
-        type: "gomod"
-        version: "DEP_VERSION"
-      name: "github.com/cachito-testing/cachito-gomod-with-deps"
-      type: "gomod"
-      version: "MAIN_VERSION"
-    - dependencies:
+        type: "go-package"
+        version: "v0.0.0-20170915032832-14c0d48ead0c"
+      - name: "golang.org/x/text/language"
+        replaces: null
+        type: "go-package"
+        version: "v0.0.0-20170915032832-14c0d48ead0c"
       - name: "rsc.io/quote"
         replaces: null
         type: "go-package"
@@ -153,16 +153,16 @@ gomod_cached_deps:
         replaces: null
         type: "go-package"
         version: "v1.3.0"
-      - name: "golang.org/x/text/language"
-        replaces: null
-        type: "go-package"
-        version: "v0.0.0-20170915032832-14c0d48ead0c"
-      - name: "golang.org/x/text/internal/tag"
-        replaces: null
-        type: "go-package"
-        version: "v0.0.0-20170915032832-14c0d48ead0c"
       name: "github.com/cachito-testing/cachito-gomod-with-deps"
       type: "go-package"
+      version: "MAIN_VERSION"
+    - dependencies:
+      - name: "github.com/cachito-testing/cachito-gomod-without-deps"
+        replaces: null
+        type: "gomod"
+        version: "DEP_VERSION"
+      name: "github.com/cachito-testing/cachito-gomod-with-deps"
+      type: "gomod"
       version: "MAIN_VERSION"
     dependencies:
     - name: "golang.org/x/text/internal/tag"
@@ -173,14 +173,14 @@ gomod_cached_deps:
       replaces: null
       type: "go-package"
       version: "v0.0.0-20170915032832-14c0d48ead0c"
-    - name: "rsc.io/sampler"
-      replaces: null
-      type: "go-package"
-      version: "v1.3.0"
     - name: "rsc.io/quote"
       replaces: null
       type: "go-package"
       version: "v1.5.2"
+    - name: "rsc.io/sampler"
+      replaces: null
+      type: "go-package"
+      version: "v1.3.0"
     - name: "github.com/cachito-testing/cachito-gomod-without-deps"
       replaces: null
       type: "gomod"

--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -380,14 +380,16 @@ def update_expected_data(env_data, replace_rules):
         env_data["response_expectations"]["packages"][pkg_idx]["version"] = replace_by_rules(
             env_data["response_expectations"]["packages"][pkg_idx]["version"], replace_rules
         )
+
+        for dep_idx, dep in enumerate(env_data["response_expectations"]["packages"][pkg_idx]["dependencies"]):
+            env_data["response_expectations"]["packages"][pkg_idx]["dependencies"][dep_idx][
+                "version"
+            ] = replace_by_rules(dep["version"], replace_rules)
+
     for i, dep in enumerate(env_data["response_expectations"]["dependencies"]):
         env_data["response_expectations"]["dependencies"][i]["version"] = replace_by_rules(
             dep["version"], replace_rules
         )
-    for i, dep in enumerate(env_data["response_expectations"]["packages"][0]["dependencies"]):
-        env_data["response_expectations"]["packages"][0]["dependencies"][i][
-            "version"
-        ] = replace_by_rules(dep["version"], replace_rules)
 
     env_data["content_manifest"]["purl"] = replace_by_rules(
         env_data["content_manifest"]["purl"], replace_rules


### PR DESCRIPTION
The gomod test repositories need to have their versions set during the cached dependency integration test. However, the replacement was only being made to the first package that appeared on the packages list (the replacement index was hard-coded).

This PR fixes that and sorts the dependencies so they match the copy on the [Gitlab repository](https://gitlab.cee.redhat.com/osbs/cachito-tests).

CLOUDBLD-3382
Signed-off-by: Bruno Pimentel bpimente@redhat.com