### PR TITLE
Skip 100% covered modules from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [report]
+skip_covered = True
 show_missing = True
 fail_under = 90
 exclude_lines =


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>

Many modules are covered 100% already. This PR proposes to not show those modules in the report in order to make the coverage report shorter.