### PR TITLE
Add PATCH and POST to allowed HTTP methods for retrying requests

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -4,12 +4,14 @@ import tempfile
 import logging
 from typing import Dict, List, Optional
 
+import celery
 import kombu
 
 from cachito.errors import ConfigError
 
-
 ARCHIVES_VOLUME = os.path.join(tempfile.gettempdir(), "cachito-archives")
+
+app = celery.Celery()
 
 
 class Config(object):
@@ -302,7 +304,7 @@ def validate_pip_config():
 
 def get_worker_config():
     """Get the Celery worker configuration."""
-    # Import this here to avoid a circular import
-    import cachito.workers.tasks.celery
+    return app.conf
 
-    return cachito.workers.tasks.celery.app.conf
+
+configure_celery(app)

--- a/cachito/workers/nexus.py
+++ b/cachito/workers/nexus.py
@@ -9,6 +9,7 @@ import requests.auth
 from cachito.errors import CachitoError
 from cachito.workers.config import get_worker_config
 from cachito.workers.errors import NexusScriptError
+from cachito.workers.requests import requests_session
 
 
 log = logging.getLogger(__name__)
@@ -62,9 +63,6 @@ def create_or_update_script(script_name, script_path):
     :param str script_path: the path of the script
     :raise CachitoError: if the request fails
     """
-    # Import this here to avoid a circular import
-    from cachito.workers.requests import requests_session
-
     config = get_worker_config()
     auth = requests.auth.HTTPBasicAuth(config.cachito_nexus_username, config.cachito_nexus_password)
 
@@ -150,9 +148,6 @@ def execute_script(script_name, payload):
     :param dict payload: the JSON payload to send as arguments to the script
     :raise NexusScriptError: if the script execution fails
     """
-    # Import this here to avoid a circular import
-    from cachito.workers.requests import requests_session
-
     config = get_worker_config()
     auth = requests.auth.HTTPBasicAuth(config.cachito_nexus_username, config.cachito_nexus_password)
     script_url = f"{config.cachito_nexus_url.rstrip('/')}/service/rest/v1/script/{script_name}/run"
@@ -311,9 +306,6 @@ def search_components(in_nexus_hoster=True, **query_params):
     :rtype: list<dict>
     :raise CachitoError: if the search fails
     """
-    # Import this here to avoid a circular import
-    from cachito.workers.requests import requests_session
-
     config = get_worker_config()
     if in_nexus_hoster:
         username, password = get_nexus_hoster_credentials()
@@ -436,9 +428,6 @@ def upload_component(params, payload, to_nexus_hoster, additional_data=None):
         https://issues.sonatype.org/browse/NEXUS-21946 for further reference.
     :raise CachitoError: if the upload fails
     """
-    # Import this here to avoid a circular import
-    from cachito.workers.requests import requests_session
-
     config = get_worker_config()
     if to_nexus_hoster:
         username, password = get_nexus_hoster_credentials()

--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -9,7 +9,11 @@ import requests
 from cachito.common.checksum import hash_file
 from cachito.errors import CachitoError, UnknownHashAlgorithm
 from cachito.workers.config import get_worker_config
-from cachito.workers.requests import requests_auth_session, requests_session
+from cachito.workers.requests import (
+    SAFE_REQUEST_METHODS,
+    get_requests_session,
+    requests_auth_session,
+)
 
 __all__ = [
     "update_request_with_config_files",
@@ -20,6 +24,8 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 ChecksumInfo = collections.namedtuple("ChecksumInfo", "algorithm hexdigest")
+
+pkg_requests_session = get_requests_session(retry_options={"allowed_methods": SAFE_REQUEST_METHODS})
 
 
 def _get_request_url(request_id):
@@ -139,7 +145,7 @@ def download_binary_file(url, download_path, auth=None, insecure=False, chunk_si
     :raise CachitoError: If download failed
     """
     try:
-        resp = requests_session.get(url, stream=True, verify=not insecure, auth=auth)
+        resp = pkg_requests_session.get(url, stream=True, verify=not insecure, auth=auth)
         resp.raise_for_status()
     except requests.RequestException as e:
         raise CachitoError(f"Could not download {url}: {e}")

--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -9,6 +9,7 @@ import requests
 from cachito.common.checksum import hash_file
 from cachito.errors import CachitoError, UnknownHashAlgorithm
 from cachito.workers.config import get_worker_config
+from cachito.workers.requests import requests_auth_session, requests_session
 
 __all__ = [
     "update_request_with_config_files",
@@ -40,9 +41,6 @@ def update_request_with_config_files(request_id, config_files):
     :param list config_files: the list of configuration files to add to the request
     :raise CachitoError: if the request to the Cachito API fails
     """
-    # Import this here to avoid a circular import
-    from cachito.workers.requests import requests_auth_session
-
     log.info("Adding %d configuration files to the request %d", len(config_files), request_id)
     config = get_worker_config()
     request_url = _get_request_url(request_id) + "/configuration-files"
@@ -76,8 +74,6 @@ def update_request_env_vars(request_id: int, env_vars: Dict[str, Dict[str, str]]
         "kind" attributes, e.g. {"NAME": {"value": "VALUE", "kind": "KIND"}}.
     :raise CachitoError: if the request to the Cachito API fails
     """
-    from cachito.workers.requests import requests_auth_session
-
     config = get_worker_config()
     request_url = _get_request_url(request_id)
     payload = {"environment_variables": env_vars}
@@ -142,9 +138,6 @@ def download_binary_file(url, download_path, auth=None, insecure=False, chunk_si
     :param int chunk_size: Chunk size param for Response.iter_content()
     :raise CachitoError: If download failed
     """
-    # Import this here to avoid a circular import
-    from cachito.workers.requests import requests_session
-
     try:
         resp = requests_session.get(url, stream=True, verify=not insecure, auth=auth)
         resp.raise_for_status()

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -27,10 +27,10 @@ from cachito.workers.errors import NexusScriptError
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import (
     ChecksumInfo,
-    verify_checksum,
     download_binary_file,
+    pkg_requests_session,
+    verify_checksum,
 )
-from cachito.workers.requests import requests_session
 from cachito.workers.scm import Git
 
 
@@ -1533,7 +1533,7 @@ def _download_pypi_package(requirement, pip_deps_dir, pypi_proxy_url, pypi_proxy
     # See https://www.python.org/dev/peps/pep-0503/
     package_url = f"{pypi_proxy_url.rstrip('/')}/simple/{canonicalize_name(package)}/"
     try:
-        pypi_resp = requests_session.get(package_url, auth=pypi_proxy_auth)
+        pypi_resp = pkg_requests_session.get(package_url, auth=pypi_proxy_auth)
         pypi_resp.raise_for_status()
     except requests.RequestException as e:
         raise CachitoError(f"PyPI query failed: {e}")

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -30,6 +30,7 @@ from cachito.workers.pkg_managers.general import (
     verify_checksum,
     download_binary_file,
 )
+from cachito.workers.requests import requests_session
 from cachito.workers.scm import Git
 
 
@@ -1526,9 +1527,6 @@ def _download_pypi_package(requirement, pip_deps_dir, pypi_proxy_url, pypi_proxy
 
     :return: Dict with package name, version and download path
     """
-    # Import this here to avoid a circular import
-    from cachito.workers.requests import requests_session
-
     package = requirement.package
     version = requirement.version_specs[0][1]
 

--- a/cachito/workers/requests.py
+++ b/cachito/workers/requests.py
@@ -9,12 +9,28 @@ from cachito.workers.config import get_worker_config
 
 log = logging.getLogger(__name__)
 
+# The set is extended version of constant Retry.DEFAULT_ALLOWED_METHODS
+# with PATCH and POST methods included.
+ALL_REQUEST_METHODS = frozenset(
+    {"GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE"}
+)
+# The set includes only methods which don't modify state of the service.
+SAFE_REQUEST_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+DEFAULT_RETRY_OPTIONS = {
+    "total": 5,
+    "read": 5,
+    "connect": 5,
+    "backoff_factor": 1.3,
+    "status_forcelist": (500, 502, 503, 504),
+}
 
-def get_requests_session(auth=False):
+
+def get_requests_session(auth=False, retry_options={}):
     """
     Create a requests session with authentication (when enabled).
 
     :param bool auth: configure authentication on the session
+    :param dict retry_options: overwrite options for initialization of Retry instance
     :return: the configured requests session
     :rtype: requests.Session
     """
@@ -28,14 +44,15 @@ def get_requests_session(auth=False):
         elif config.cachito_auth_type == "cert":
             session.cert = config.cachito_auth_cert
 
-    retry = Retry(
-        total=5, read=5, connect=5, backoff_factor=1.3, status_forcelist=(500, 502, 503, 504)
-    )
-    adapter = requests.adapters.HTTPAdapter(max_retries=retry)
+    retry_options = {**DEFAULT_RETRY_OPTIONS, **retry_options}
+    adapter = requests.adapters.HTTPAdapter(max_retries=Retry(**retry_options))
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     return session
 
 
-requests_auth_session = get_requests_session(auth=True)
-requests_session = get_requests_session()
+# These sessions are only for connecting to the internal Cachito API
+requests_auth_session = get_requests_session(
+    auth=True, retry_options={"allowed_methods": ALL_REQUEST_METHODS}
+)
+requests_session = get_requests_session(retry_options={"allowed_methods": ALL_REQUEST_METHODS})

--- a/cachito/workers/tasks/celery.py
+++ b/cachito/workers/tasks/celery.py
@@ -10,7 +10,7 @@ from cachito.workers.celery_logging import (
     setup_task_logging,
     setup_task_logging_customization,
 )
-from cachito.workers.config import configure_celery, validate_celery_config
+from cachito.workers.config import app, validate_celery_config  # noqa: F401
 
 
 # Workaround https://github.com/celery/celery/issues/5416
@@ -21,8 +21,6 @@ if celery.version_info < (4, 3) and sys.version_info >= (3, 7):  # pragma: no co
     routes_re._pattern_type = Pattern
 
 
-app = celery.Celery()
-configure_celery(app)
 celeryd_init.connect(validate_celery_config)
 task_prerun.connect(setup_task_logging_customization)
 task_prerun.connect(setup_task_logging)

--- a/cachito/workers/tasks/utils.py
+++ b/cachito/workers/tasks/utils.py
@@ -10,6 +10,7 @@ import requests
 from cachito.errors import ValidationError, CachitoError
 from cachito.workers.celery_logging import get_function_arg_value
 from cachito.workers.config import get_worker_config
+from cachito.workers.requests import requests_auth_session, requests_session
 
 __all__ = [
     "make_base64_config_file",
@@ -242,9 +243,6 @@ def _get_request_or_fail(request_id: int, connect_error_msg: str, status_error_m
     :param status_error_msg: error message to raise if the response status is 4xx or 5xx
     :raises CachitoError: if the connection fails or the API returns an error response
     """
-    # Import this here to avoid a circular import (tasks -> requests -> tasks)
-    from cachito.workers.requests import requests_session
-
     config = get_worker_config()
     request_url = f'{config.cachito_api_url.rstrip("/")}/requests/{request_id}'
 
@@ -278,9 +276,6 @@ def _patch_request_or_fail(
     :param status_error_msg: error message to raise if the response status is 4xx or 5xx
     :raises CachitoError: if the connection fails or the API returns an error response
     """
-    # Import this here to avoid a circular import (tasks -> requests -> tasks)
-    from cachito.workers.requests import requests_auth_session
-
     config = get_worker_config()
     request_url = f'{config.cachito_api_url.rstrip("/")}/requests/{request_id}'
 

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -8,7 +8,6 @@ import pytest
 from cachito.errors import CachitoError
 from cachito.workers import nexus
 from cachito.workers.errors import NexusScriptError
-from cachito.workers.requests import requests_session
 
 
 def setup_module():
@@ -146,7 +145,7 @@ def test_get_nexus_hoster_url(mock_gwc, cachito_nexus_hoster_url, cachito_nexus_
     assert nexus._get_nexus_hoster_url() == expected
 
 
-@mock.patch.object(requests_session, "request")
+@mock.patch.object(nexus.nexus_requests_session, "request")
 @mock.patch("cachito.workers.nexus.open", mock.mock_open(read_data="println('Hello')"))
 def test_create_or_update_create(mock_request):
     mock_get = mock.Mock()
@@ -163,7 +162,7 @@ def test_create_or_update_create(mock_request):
     assert request_calls[1][0][0] == "post"
 
 
-@mock.patch.object(requests_session, "request")
+@mock.patch.object(nexus.nexus_requests_session, "request")
 @mock.patch("cachito.workers.nexus.open", mock.mock_open(read_data="println('Hello')"))
 def test_create_or_update_update(mock_request):
     mock_get = mock.Mock()
@@ -181,7 +180,7 @@ def test_create_or_update_update(mock_request):
     assert request_calls[1][0][0] == "put"
 
 
-@mock.patch.object(requests_session, "request")
+@mock.patch.object(nexus.nexus_requests_session, "request")
 @mock.patch("cachito.workers.nexus.open", mock.mock_open(read_data="println('Hello')"))
 def test_create_or_update_already_set(mock_request):
     mock_get = mock.Mock()
@@ -195,7 +194,7 @@ def test_create_or_update_already_set(mock_request):
     assert mock_request.call_args[0][0] == "get"
 
 
-@mock.patch.object(requests_session, "request")
+@mock.patch.object(nexus.nexus_requests_session, "request")
 @mock.patch("cachito.workers.nexus.open", mock.mock_open(read_data="println('Hello')"))
 def test_create_or_update_get_fails(mock_request):
     mock_get = mock.Mock()
@@ -210,7 +209,7 @@ def test_create_or_update_get_fails(mock_request):
     assert mock_request.call_args[0][0] == "get"
 
 
-@mock.patch.object(requests_session, "request")
+@mock.patch.object(nexus.nexus_requests_session, "request")
 @mock.patch("cachito.workers.nexus.open", mock.mock_open(read_data="println('Hello')"))
 def test_create_or_update_get_connection_error(mock_request):
     mock_request.side_effect = requests.ConnectionError()
@@ -223,7 +222,7 @@ def test_create_or_update_get_connection_error(mock_request):
     assert mock_request.call_args[0][0] == "get"
 
 
-@mock.patch.object(requests_session, "request")
+@mock.patch.object(nexus.nexus_requests_session, "request")
 @mock.patch("cachito.workers.nexus.open", mock.mock_open(read_data="println('Hello')"))
 def test_create_or_update_create_fails(mock_request):
     mock_get = mock.Mock()
@@ -242,7 +241,7 @@ def test_create_or_update_create_fails(mock_request):
     assert request_calls[1][0][0] == "post"
 
 
-@mock.patch.object(requests_session, "request")
+@mock.patch.object(nexus.nexus_requests_session, "request")
 @mock.patch("cachito.workers.nexus.open", mock.mock_open(read_data="println('Hello')"))
 def test_create_or_update_update_fails(mock_request):
     mock_get = mock.Mock()
@@ -281,7 +280,7 @@ def test_create_or_update_scripts(mock_cous):
     assert len(expected_scripts) == 0, error_msg
 
 
-@mock.patch.object(requests_session, "post")
+@mock.patch.object(nexus.nexus_requests_session, "post")
 def test_execute_script(mock_post):
     mock_post.return_value.ok = True
 
@@ -293,7 +292,7 @@ def test_execute_script(mock_post):
     assert mock_post.call_args[0][0].endswith("/service/rest/v1/script/js_cleanup/run")
 
 
-@mock.patch.object(requests_session, "post")
+@mock.patch.object(nexus.nexus_requests_session, "post")
 def test_execute_script_connection_error(mock_post):
     mock_post.side_effect = requests.ConnectionError
 
@@ -306,7 +305,7 @@ def test_execute_script_connection_error(mock_post):
     mock_post.assert_called_once()
 
 
-@mock.patch.object(requests_session, "post")
+@mock.patch.object(nexus.nexus_requests_session, "post")
 def test_execute_script_failed(mock_post):
     mock_post.return_value.ok = False
     mock_post.return_value.text = "some error"
@@ -472,7 +471,7 @@ def test_get_raw_component_asset_url_sanity_check(mock_get_component_info, compo
         nexus.get_raw_component_asset_url("cachito-pip-raw", "foo/bar/foobar-1.0.tar.gz")
 
 
-@mock.patch.object(requests_session, "get")
+@mock.patch.object(nexus.nexus_requests_session, "get")
 def test_search_components(mock_get, components_search_results):
     # Split up the components_search_results fixture into two pages to test pagination
     first_page = copy.deepcopy(components_search_results)
@@ -498,7 +497,7 @@ def test_search_components(mock_get, components_search_results):
 
 
 @pytest.mark.parametrize("hoster", [True, False])
-@mock.patch.object(requests_session, "get")
+@mock.patch.object(nexus.nexus_requests_session, "get")
 @mock.patch("requests.auth.HTTPBasicAuth")
 @mock.patch("cachito.workers.nexus.get_worker_config")
 def test_search_components_auth(mock_gwc, mock_auth, mock_get, components_search_results, hoster):
@@ -525,7 +524,7 @@ def test_search_components_auth(mock_gwc, mock_auth, mock_get, components_search
         mock_auth.assert_called_once_with(local_credential, local_credential)
 
 
-@mock.patch.object(requests_session, "get")
+@mock.patch.object(nexus.nexus_requests_session, "get")
 def test_search_components_connection_error(mock_get):
     mock_get.side_effect = requests.ConnectionError()
 
@@ -534,7 +533,7 @@ def test_search_components_connection_error(mock_get):
         nexus.search_components(repository="cachito-js-hosted", type="npm")
 
 
-@mock.patch.object(requests_session, "get")
+@mock.patch.object(nexus.nexus_requests_session, "get")
 def test_search_components_failed(mock_get):
     mock_get.return_value.ok = False
 
@@ -543,7 +542,7 @@ def test_search_components_failed(mock_get):
         nexus.search_components(repository="cachito-js-hosted", type="npm")
 
 
-@mock.patch.object(requests_session, "post")
+@mock.patch.object(nexus.nexus_requests_session, "post")
 @pytest.mark.parametrize("use_hoster", [True, False])
 def test_upload_asset_only_component(mock_post, use_hoster):
     mock_open = mock.mock_open(read_data=b"some tgz file")
@@ -561,7 +560,7 @@ def test_upload_asset_only_component(mock_post, use_hoster):
     assert mock_post.call_args[1]["auth"].password == "cachito"
 
 
-@mock.patch.object(requests_session, "post")
+@mock.patch.object(nexus.nexus_requests_session, "post")
 def test_upload_asset_only_component_connection_error(mock_post):
     mock_open = mock.mock_open(read_data=b"some tgz file")
     mock_post.side_effect = requests.ConnectionError()
@@ -572,7 +571,7 @@ def test_upload_asset_only_component_connection_error(mock_post):
             nexus.upload_asset_only_component("cachito-js-hosted", "npm", "/path/to/rxjs-6.5.5.tgz")
 
 
-@mock.patch.object(requests_session, "post")
+@mock.patch.object(nexus.nexus_requests_session, "post")
 def test_upload_asset_only_component_failed(mock_post):
     mock_open = mock.mock_open(read_data=b"some tgz file")
     mock_post.return_value.ok = False
@@ -590,7 +589,7 @@ def test_upload_asset_only_component_wrong_type():
         nexus.upload_asset_only_component("cachito-js-hosted", repo_type, "/path/to/rxjs-6.5.5.tgz")
 
 
-@mock.patch.object(requests_session, "post")
+@mock.patch.object(nexus.nexus_requests_session, "post")
 @pytest.mark.parametrize("use_hoster", [True, False])
 def test_upload_raw_component(mock_post, use_hoster):
     mock_open = mock.mock_open(read_data=b"some tgz file")
@@ -610,7 +609,7 @@ def test_upload_raw_component(mock_post, use_hoster):
     assert mock_post.call_args[1]["auth"].password == "cachito"
 
 
-@mock.patch.object(requests_session, "post")
+@mock.patch.object(nexus.nexus_requests_session, "post")
 def test_upload_raw_component_failed(mock_post):
     mock_open = mock.mock_open(read_data=b"some tgz file")
     mock_post.return_value.ok = False

--- a/tests/test_workers/test_pkg_managers/test_general.py
+++ b/tests/test_workers/test_pkg_managers/test_general.py
@@ -7,12 +7,13 @@ import pytest
 from cachito.errors import CachitoError
 from cachito.workers.pkg_managers.general import (
     download_binary_file,
+    pkg_requests_session,
     update_request_env_vars,
     update_request_with_config_files,
     verify_checksum,
     ChecksumInfo,
 )
-from cachito.workers.requests import requests_auth_session, requests_session
+from cachito.workers.requests import requests_auth_session
 
 
 @mock.patch.object(requests_auth_session, "post")
@@ -87,7 +88,7 @@ def test_verify_checksum_unsupported_algorithm(tmpdir):
 @pytest.mark.parametrize("auth", [None, ("user", "password")])
 @pytest.mark.parametrize("insecure", [True, False])
 @pytest.mark.parametrize("chunk_size", [1024, 2048])
-@mock.patch.object(requests_session, "get")
+@mock.patch.object(pkg_requests_session, "get")
 def test_download_binary_file(mock_get, auth, insecure, chunk_size, tmpdir):
     url = "http://example.org/example.tar.gz"
     content = b"file content"
@@ -105,7 +106,7 @@ def test_download_binary_file(mock_get, auth, insecure, chunk_size, tmpdir):
     mock_response.iter_content.assert_called_with(chunk_size=chunk_size)
 
 
-@mock.patch.object(requests_session, "get")
+@mock.patch.object(pkg_requests_session, "get")
 def test_download_binary_file_failed(mock_get):
     mock_get.side_effect = [requests.RequestException("Something went wrong")]
 

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -13,7 +13,6 @@ import requests
 from cachito.errors import CachitoError, ValidationError
 from cachito.workers.errors import NexusScriptError
 from cachito.workers.pkg_managers import pip, general
-from cachito.workers.requests import requests_session
 from tests.helper_utils import write_file_tree
 
 
@@ -2363,7 +2362,7 @@ class TestDownload:
     )
     # Package name should be normalized before querying PyPI
     @pytest.mark.parametrize("package_name", ["AioWSGI", "aiowsgi"])
-    @mock.patch.object(requests_session, "get")
+    @mock.patch.object(general.pkg_requests_session, "get")
     @mock.patch("cachito.workers.pkg_managers.pip.download_binary_file")
     def test_download_pypi_package(
         self,

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -142,11 +142,11 @@ def test_get_request_state(mock_get_request_or_fail, id, state):
     )
 
 
-@mock.patch("cachito.workers.requests.requests_auth_session")
-def test_set_request_state(mock_requests):
+@mock.patch.object(requests_auth_session, "patch")
+def test_set_request_state(mock_patch):
     utils.set_request_state(1, "complete", "Completed successfully")
     expected_payload = {"state": "complete", "state_reason": "Completed successfully"}
-    mock_requests.patch.assert_called_once_with(
+    mock_patch.assert_called_once_with(
         "http://cachito.domain.local/api/v1/requests/1", json=expected_payload, timeout=60
     )
 
@@ -159,11 +159,9 @@ def test_set_request_state_connection_failed(mock_requests_patch):
         utils.set_request_state(1, "complete", "Completed successfully")
 
 
-@mock.patch("cachito.workers.requests.requests_auth_session")
-def test_set_request_state_bad_status_code(mock_requests):
-    mock_requests.patch.return_value.raise_for_status.side_effect = [
-        requests.HTTPError("Unauthorized")
-    ]
+@mock.patch.object(requests_auth_session, "patch")
+def test_set_request_state_bad_status_code(mock_patch):
+    mock_patch.return_value.raise_for_status.side_effect = [requests.HTTPError("Unauthorized")]
     expected = 'Setting the state to "complete" on request 1 failed'
     with pytest.raises(CachitoError, match=expected):
         utils.set_request_state(1, "complete", "Completed successfully")


### PR DESCRIPTION
Separete session instances for different cases:
  - keep requests_auth_session and requests_session for internal Cachito requests
  - cachito.workers.nexus.nexus_requests_session - for Nexus requests
  - cachito.workers.pkg_managers.general.pkg_requests_session - for package managers

Add 'retry_options' parameter in get_requests_session to allow customize retrying for each case.
Specify extended set of allowed methods for retrying internal Cachito requests.
Specify limited set of allowed methonds (only safe one) for retrying requests to external services.