### PR TITLE
Prometheus-flask-exporter for metrics on https requests.

### DIFF
--- a/cachito/web/app.py
+++ b/cachito/web/app.py
@@ -17,6 +17,7 @@ from cachito.web.auth import load_user_from_request, user_loader
 from cachito.web.config import validate_cachito_config
 from cachito.web.docs import docs
 from cachito.web.errors import json_error
+from cachito.web.metrics import init_metrics
 
 
 def healthcheck():
@@ -109,6 +110,8 @@ def create_app(config_obj=None):
     app.register_error_handler(CachitoError, json_error)
     app.register_error_handler(ValidationError, json_error)
     app.register_error_handler(ContentManifestError, json_error)
+
+    init_metrics(app)
 
     return app
 

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -26,6 +26,13 @@ class Config(object):
     CACHITO_USER_REPRESENTATIVES: List[str] = []
     CACHITO_WORKER_USERNAMES: List[str] = []
 
+    # Temp dir used by the Prometheus Flask Exporter to coalesce the metrics from the threads
+    if "PROMETHEUS_MULTIPROC_DIR" not in os.environ.keys():
+        PROMETHEUS_METRICS_TEMP_DIR = tempfile.gettempdir()
+        os.environ["PROMETHEUS_MULTIPROC_DIR"] = PROMETHEUS_METRICS_TEMP_DIR
+    else:
+        PROMETHEUS_METRICS_TEMP_DIR = os.environ["PROMETHEUS_MULTIPROC_DIR"]
+
 
 class ProductionConfig(Config):
     """The production Cachito Flask configuration."""
@@ -89,6 +96,7 @@ def validate_cachito_config(config, cli=False):
         "CACHITO_LOG_FORMAT",
         "CACHITO_BUNDLES_DIR",
         "SQLALCHEMY_DATABASE_URI",
+        "PROMETHEUS_METRICS_TEMP_DIR",
     ):
         if config_var == "CACHITO_BUNDLES_DIR":
             if cli:

--- a/cachito/web/metrics.py
+++ b/cachito/web/metrics.py
@@ -1,0 +1,25 @@
+import os
+
+from prometheus_client import multiprocess
+from prometheus_client.core import CollectorRegistry
+from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
+
+
+def init_metrics(app):
+    """
+    Initialize the Prometheus Flask Exporter.
+
+    :return: a Prometheus Flash Metrics object
+    :rtype: PrometheusMetrics
+    """
+    registry = CollectorRegistry()
+
+    multiproc_temp_dir = app.config["PROMETHEUS_METRICS_TEMP_DIR"]
+
+    if not os.path.isdir(multiproc_temp_dir):
+        os.makedirs(multiproc_temp_dir)
+    multiprocess.MultiProcessCollector(registry, path=multiproc_temp_dir)
+    metrics = GunicornInternalPrometheusMetrics.for_app_factory(
+        group_by="endpoint", defaults_prefix="cachito_flask"
+    )
+    metrics.init_app(app)

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -29,5 +29,8 @@ ENV REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 # Disable gitpython check for the git executable, cachito-api doesn't use git
 ENV GIT_PYTHON_REFRESH=quiet
 
+# Environment variable used by the Prometheus Flask exporter.
+ENV DEBUG_METRICS=false
+
 EXPOSE 8080
 CMD ["/usr/sbin/httpd", "-DFOREGROUND"]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -205,6 +205,7 @@ flask==2.0.1 \
     #   flask-login
     #   flask-migrate
     #   flask-sqlalchemy
+    #   prometheus-flask-exporter
 flask-login==0.5.0 \
     --hash=sha256:6d33aef15b5bcead780acc339464aae8a6e28f13c90d8b1cf9de8b549d1c0b4b \
     --hash=sha256:7451b5001e17837ba58945aead261ba425fdf7b4f0448777e597ddab39f4fba0
@@ -373,6 +374,15 @@ ply==3.11 \
     # via
     #   -r requirements.txt
     #   pyarn
+prometheus-client==0.11.0 \
+    --hash=sha256:3a8baade6cb80bcfe43297e33e7623f3118d660d41387593758e2fb1ea173a86 \
+    --hash=sha256:b014bc76815eb1399da8ce5fc84b7717a3e63652b0c0f8804092c9363acab1b2
+    # via
+    #   -r requirements-web.txt
+    #   prometheus-flask-exporter
+prometheus-flask-exporter==0.18.2 \
+    --hash=sha256:fc487e385d95cb5efd045d6a315c4ecf68c42661e7bfde0526af75ed3c4f8c1b
+    # via -r requirements-web.txt
 prompt-toolkit==3.0.16 \
     --hash=sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974 \
     --hash=sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd

--- a/requirements-web.in
+++ b/requirements-web.in
@@ -4,3 +4,4 @@ Flask-Migrate
 Flask-SQLAlchemy
 psycopg2-binary
 SQLAlchemy<1.5
+prometheus-flask-exporter

--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -20,6 +20,7 @@ flask==2.0.1 \
     #   flask-login
     #   flask-migrate
     #   flask-sqlalchemy
+    #   prometheus-flask-exporter
 flask-login==0.5.0 \
     --hash=sha256:6d33aef15b5bcead780acc339464aae8a6e28f13c90d8b1cf9de8b549d1c0b4b \
     --hash=sha256:7451b5001e17837ba58945aead261ba425fdf7b4f0448777e597ddab39f4fba0
@@ -129,6 +130,13 @@ markupsafe==2.0.1 \
     # via
     #   jinja2
     #   mako
+prometheus-client==0.11.0 \
+    --hash=sha256:3a8baade6cb80bcfe43297e33e7623f3118d660d41387593758e2fb1ea173a86 \
+    --hash=sha256:b014bc76815eb1399da8ce5fc84b7717a3e63652b0c0f8804092c9363acab1b2
+    # via prometheus-flask-exporter
+prometheus-flask-exporter==0.18.2 \
+    --hash=sha256:fc487e385d95cb5efd045d6a315c4ecf68c42661e7bfde0526af75ed3c4f8c1b
+    # via -r requirements-web.in
 psycopg2-binary==2.9.1 \
     --hash=sha256:0b7dae87f0b729922e06f85f667de7bf16455d411971b2043bbd9577af9d1975 \
     --hash=sha256:0f2e04bd2a2ab54fa44ee67fe2d002bb90cee1c0f1cc0ebc3148af7b02034cbd \

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
             "Flask-Migrate",
             "Flask-SQLAlchemy",
             "psycopg2-binary",
+            "prometheus-flask-exporter",
         ],
     },
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -11,15 +11,23 @@ deps =
     -rrequirements-test.txt
 whitelist_externals =
     make
+    mkdir
+    rm
 passenv = TOX_ENV_DIR
 setenv =
 	CACHITO_TESTING=true
+    PROMETHEUS_MULTIPROC_TEMP_DIR={envtmpdir}/prometheus_metrics
+
 usedevelop = true
+
 commands =
     py.test -vvv \
         --ignore tests/integration \
         --cov-config .coveragerc --cov=cachito --cov-report term \
         --cov-report xml --cov-report html {posargs}
+
+commands_post =
+    rm -rf {envtmpdir}/prometheus_metrics
 
 [testenv:black]
 # a bug in python3.9 is causing occasional failures: https://bugs.python.org/issue43498,


### PR DESCRIPTION
Implement a prometheus exporter for Cachito.  Accessible on /metrics endpoint.  Attached is sample output.

[metrics.txt](https://github.com/release-engineering/cachito/files/6803582/metrics.txt)
