### PR TITLE
Loads package data only when a request is complete

### DIFF
--- a/cachito/common/packages_data.py
+++ b/cachito/common/packages_data.py
@@ -145,8 +145,9 @@ class PackagesData:
         :type file_name: str or pathlib.Path
         """
         if not os.path.exists(file_name):
-            log.debug("No data is loaded from non-existing file %s.", file_name)
+            log.warning("No data is loaded from non-existing file %s.", file_name)
             return
+
         with open(file_name, "r", encoding="utf-8") as f:
             data = json.load(f)
             packages = data.get("packages")

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -340,11 +340,20 @@ class Request(db.Model):
 
         return content_manifest.ContentManifest(self, packages)
 
-    def _get_packages_data(self):
-        bundle_dir = RequestBundleDir(self.id, root=flask.current_app.config["CACHITO_BUNDLES_DIR"])
+    def _is_complete(self):
+        if self.state:
+            return self.state.state_name == RequestStateMapping.complete.name
 
+        return False
+
+    def _get_packages_data(self):
         packages_data = PackagesData()
-        packages_data.load(bundle_dir.packages_data)
+
+        if self._is_complete():
+            bundle_dir = RequestBundleDir(
+                self.id, root=flask.current_app.config["CACHITO_BUNDLES_DIR"]
+            )
+            packages_data.load(bundle_dir.packages_data)
 
         return packages_data
 

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -406,6 +406,8 @@ def test_fetch_paginated_requests(
             request = Request.from_json(data)
             request.packages_count = 0
             request.dependencies_count = 0
+            request.add_state(RequestStateMapping.complete.name, "Completed")
+
             db.session.add(request)
     db.session.commit()
 
@@ -446,7 +448,7 @@ def test_fetch_paginated_requests(
     assert response["meta"]["per_page"] == 10
 
     # per_page and page parameters are honored
-    rv = client.get("/api/v1/requests?page=3&per_page=5&verbose=True&state=in_progress")
+    rv = client.get("/api/v1/requests?page=3&per_page=5&verbose=True&state=complete")
     assert rv.status_code == 200
     response = rv.json
     fetched_requests = response["items"]
@@ -459,7 +461,7 @@ def test_fetch_paginated_requests(
         assert f"page={page_num}" in pagination_metadata[page]
         assert "per_page=5" in pagination_metadata[page]
         assert "verbose=True" in pagination_metadata[page]
-        assert "state=in_progress" in pagination_metadata[page]
+        assert "state=complete" in pagination_metadata[page]
     assert pagination_metadata["total"] == sample_requests_count
     assert fetched_requests[0]["dependencies"] == pkg_info["dependencies"]
     assert fetched_requests[0]["packages"] == packages_data["packages"]

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ exclude = venv,.git,.tox,dist,*egg,cachito/web/migrations,.env
 ignore = D100,D104,D105,W503,E203
 per-file-ignores =
     # Ignore missing docstrings in the tests and migrations
-    tests/*:D103
+    tests/*:D101,D102,D103
     cachito/web/migrations/*:D103
 
 [testenv:integration]


### PR DESCRIPTION
CLOUDBLD-6452

The purpose of this PR is essentially to avoid looking for the file containing the packages/dependencies data when it is not supposed to be there (any state different from `complete`). This scenario is derived from the work of changing the storage method of this data from the database to JSON files.

The main issue that took us to this implementation is the failure of the integration tests running on OCP, which were somehow impacted by the many calls to the API made in a short period of time.