### PR TITLE
Print tool version information in worker logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,18 @@ Offline Installations   | ✓     | x   | x   | x    |
   they could find ways to do an offline install for any package manager, but only `gomod` supports
   this out of the box (i.e. the user does not need to change their workflow).
 
+### Actual Tool Versions
+
+Tool   | Version |
+---    | ---     |
+Go     | 1.15.12 |
+npm    | 6.14.13 |
+node   | 14.17.0 |
+pip    | 20.2.2  |
+Python | 3.9.5   |
+git    | 2.31.1  |
+Yarn   | 1.x     |
+
 ### gomod
 
 The gomod package manager works by parsing the `go.mod` file present in the source repository to

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -4,6 +4,7 @@ import os
 
 from cachito.common.packages_data import PackagesData
 from cachito.errors import CachitoError
+from cachito.workers import run_cmd
 from cachito.workers.config import get_worker_config
 from cachito.workers.pkg_managers.general import update_request_env_vars
 from cachito.workers.pkg_managers.gomod import resolve_gomod, path_to_subpackage
@@ -54,6 +55,9 @@ def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
     :param list package_configs: the list of optional package configurations submitted by the user
     :raises CachitoError: if the dependencies could not be retrieved
     """
+    version_output = run_cmd(["go", "version"], {})
+    log.info(f"Go version: {version_output.strip()}")
+
     config = get_worker_config()
     if package_configs is None:
         package_configs = []

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from cachito.common.packages_data import PackagesData
 from cachito.errors import CachitoError
-from cachito.workers import nexus
+from cachito.workers import nexus, run_cmd
 from cachito.workers.config import get_worker_config, validate_npm_config
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import (
@@ -101,6 +101,11 @@ def fetch_npm_source(request_id, package_configs=None):
     :param list package_configs: the list of optional package configurations submitted by the user
     :raise CachitoError: if the task fails
     """
+    version_output = run_cmd(["npm", "--version"], {})
+    log.info(f"npm version: {version_output.strip()}")
+    version_output = run_cmd(["node", "--version"], {})
+    log.info(f"Node.js version: {version_output.strip()}")
+
     if package_configs is None:
         package_configs = []
 

--- a/cachito/workers/tasks/pip.py
+++ b/cachito/workers/tasks/pip.py
@@ -5,7 +5,7 @@ import os
 
 from cachito.common.packages_data import PackagesData
 from cachito.errors import CachitoError
-from cachito.workers import nexus
+from cachito.workers import nexus, run_cmd
 from cachito.workers.config import get_worker_config, validate_pip_config
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import (
@@ -57,6 +57,9 @@ def fetch_pip_source(request_id, package_configs=None):
     :param int request_id: the Cachito request ID this is for
     :param list package_configs: the list of optional package configurations submitted by the user
     """
+    version_output = run_cmd(["pip", "--version"], {})
+    log.info(f"pip version: {version_output.strip()}")
+
     validate_pip_config()
     bundle_dir: RequestBundleDir = RequestBundleDir(request_id)
 

--- a/cachito/workers/tasks/yarn.py
+++ b/cachito/workers/tasks/yarn.py
@@ -8,7 +8,7 @@ import pyarn.lockfile
 
 from cachito.common.packages_data import PackagesData
 from cachito.errors import CachitoError
-from cachito.workers import nexus
+from cachito.workers import nexus, run_cmd
 from cachito.workers.config import get_worker_config, validate_yarn_config
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import (
@@ -95,6 +95,9 @@ def fetch_yarn_source(request_id: int, package_configs: List[dict] = None):
     :param list package_configs: the list of optional package configurations submitted by the user
     :raise CachitoError: if the task fails
     """
+    version_output = run_cmd(["node", "--version"], {})
+    log.info(f"Node.js version: {version_output.strip()}")
+
     if package_configs is None:
         package_configs = []
 


### PR DESCRIPTION
CLOUDBLD-3369

Return version for the following tools: go, pip, npm and Node.js (for npm and Yarn package managers).