### PR TITLE
Increase open file limit for Nexus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,12 @@ services:
       - ./tmp/nexus-data:/nexus-data:z
     ports:
       - 8082:8081
+    # Nexus needs more open files, else it will throw errors.  The Cachito integration tests expose the problem,
+    # a java.io.exception of too many open files will be thrown.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 
   cachito-api:
     build:


### PR DESCRIPTION
Fixes an error due to file limits within the Nexus container when running locally during dev & testing.