### PR TITLE
Fix logging level for API endpoints

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -221,7 +221,7 @@ def download_archive(request_id):
         flask.current_app.logger.error(msg.format(bundle_dir.bundle_archive_file))
         raise InternalServerError(msg.format(bundle_dir.bundle_archive_file.name))
 
-    flask.current_app.logger.debug(
+    flask.current_app.logger.info(
         "Sending the bundle at %s for request %d", bundle_dir.bundle_archive_file, request_id
     )
     resp = flask.send_file(
@@ -337,7 +337,7 @@ def create_request():
         db.session.commit()
         raise CachitoError(error)
 
-    flask.current_app.logger.debug("Successfully scheduled request %d", request.id)
+    flask.current_app.logger.info("Successfully scheduled request %d", request.id)
     return flask.jsonify(request.to_json()), 201
 
 
@@ -465,7 +465,7 @@ def patch_request(request_id):
             )
 
     if delete_bundle_temp and bundle_dir.exists():
-        flask.current_app.logger.debug(
+        flask.current_app.logger.info(
             "Deleting the temporary files used to create the bundle at %s", bundle_dir
         )
         try:


### PR DESCRIPTION
Changes several logs from "debug" to "info", so they can be seen on pod logs and log aggregations services. Those logs are useful to trace the state of a request and help the troubleshooting of issues.

For instance, we have the following log showing that a new request was received by the API:

```
[Fri Jul 23 09:49:35.000511 2021] [wsgi:error] [pid 10:tid 49] [remote 172.54.16.1:34032] [2021-07-23 09:49:35 cachito.web.app INFO api_v1.create_request] The user UID=osbs,emailAddress=osbs@redhat.com,CN=osbs,O=Red Hat\\, Inc.,L=Raleigh,ST=North Carolina,C=US submitted request 96118
```

And the log that happens on the end of the function, once the request is successfully created and posted to RabbitMQ, is currently not being shown because of its `debug` level: 

```
flask.current_app.logger.debug("Successfully scheduled request %d", request.id)
```

Signed-off-by: Bruno Pimentel <bpimente@redhat.com>