### PR TITLE
Checks packages file before finalizing a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,13 @@ Custom configuration for the Celery workers are listed below:
   `value` must be a string which specifies the value of the environment variable. The `kind` must
   also be a string which specifies the type of value, either `"path"` or `"literal"`. Check
   `cachito/workers/config.py::Config` for the default value of this configuration.
+* `cachito_finalize_request_packages_check_interval` - when finalizing a request, a worker will
+  query the API pods and check their response to make sure the packages and dependencies were
+  properly loaded. In case there's a failure, the worker will retry the check. This property
+  sets the interval between checks, in seconds.
+* `cachito_finalize_request_packages_check_max_attempts` - similar to
+  `cachito_finalize_request_packages_check_interval`, but defines the number of attemps for the
+  packages file check. Setting the value to 0 will disable the check completely.
 * `cachito_gomod_ignore_missing_gomod_file` - if `True` and the request specifies the `gomod`
   package manager but there is no `go.mod` file present in the repository, Cachito will skip
   the `gomod` package manager for the request. If `False`, the request will fail if the `go.mod`

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -348,11 +348,8 @@ class Request(db.Model):
     def _get_packages_data(self):
         packages_data = PackagesData()
 
-        if self._is_complete():
-            bundle_dir = RequestBundleDir(
-                self.id, root=flask.current_app.config["CACHITO_BUNDLES_DIR"]
-            )
-            packages_data.load(bundle_dir.packages_data)
+        bundle_dir = RequestBundleDir(self.id, root=flask.current_app.config["CACHITO_BUNDLES_DIR"])
+        packages_data.load(bundle_dir.packages_data)
 
         return packages_data
 

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -31,6 +31,8 @@ class Config(object):
             "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": {"value": "true", "kind": "literal"},
         },
     }
+    cachito_finalize_request_packages_check_interval = 1.0
+    cachito_finalize_request_packages_check_max_attempts = 10
     cachito_deps_patch_batch_size = 50
     cachito_gomod_ignore_missing_gomod_file = True
     cachito_gomod_strict_vendor = False
@@ -141,6 +143,8 @@ class TestingConfig(DevelopmentConfig):
             "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": {"value": "true", "kind": "literal"},
         },
     }
+    cachito_finalize_request_packages_check_interval = 0.1
+    cachito_finalize_request_packages_check_max_attempts = 3
     cachito_npm_file_deps_allowlist = {"han_solo": ["millennium-falcon"]}
     cachito_request_file_logs_dir = None
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Optional
-from unittest import mock
 
 import pytest
 
-from cachito.web.models import PackageManager, Request, RequestStateMapping
+from cachito.web.models import PackageManager
 
 
 @pytest.mark.parametrize(
@@ -17,38 +16,3 @@ def test_package_manager_get_by_name(name, expected, app, db, auth_env):
         assert expected == pkg_manager
     else:
         assert expected == pkg_manager.name
-
-
-class TestRequest:
-    def _create_request_object(self):
-        request = Request()
-        request.repo = "a_repo"
-        request.ref = "a_ref"
-        request.user_id = 1
-        request.submitted_by_id = 1
-        request.packages_count = 1
-        request.dependencies_count = 1
-
-        return request
-
-    @pytest.mark.parametrize(
-        "state, call_count",
-        [
-            [RequestStateMapping.in_progress.name, 0],
-            [RequestStateMapping.complete.name, 2],
-            [RequestStateMapping.failed.name, 0],
-            [RequestStateMapping.stale.name, 0],
-        ],
-    )
-    @mock.patch("cachito.common.packages_data.PackagesData.load")
-    def test_package_data_is_only_accessed_when_request_is_complete(
-        self, load_mock, state, call_count, app, auth_env
-    ):
-        request = self._create_request_object()
-        request.add_state(state, "Reason")
-
-        with app.test_request_context(environ_base=auth_env):
-            request.to_json()
-            request.content_manifest.to_json()
-
-        assert load_mock.call_count == call_count


### PR DESCRIPTION
This PR adds a mechanism to verify it the packages file could be properly read by an API pod before the request is moved to the `completed` state. This is done by querying the API from the worker pod that is processing the request and comparing its response with the number of packages and dependencies that were just written.

We also made so that if this check fails, it will be retried considering a configured interval and number of attempts.

![image](https://user-images.githubusercontent.com/4075353/127701296-9874c55f-6084-4e2b-a516-29b8050e1641.png)

CLOUDBLD-6599