### PR TITLE
Implement integration test for gomod-vendor-check

### DIFF
--- a/tests/integration/test_data/gomod_vendor_check.yaml
+++ b/tests/integration/test_data/gomod_vendor_check.yaml
@@ -1,0 +1,188 @@
+# gomod package with gomod-vendor-check flag
+# repo: The URL for the upstream git repository
+# ref: A git reference at the given git repository
+# flags: A list of strings with Cachito flags
+# expected_files: Expected source files <relative_path>: <file_URL>
+# expected_deps_files: Expected dependencies files (empty)
+# response_expectations: Parts of the Cachito response to check
+# content_manifest: PURLs for image contents part
+wrong_vendor:
+  repo: https://github.com/cachito-testing/gomod-vendor-check-fail.git
+  ref:  8553df6498705b2b36614320ca0c65bc24a1d9e6
+  flags: ["gomod-vendor-check"]
+  pkg_managers: ["gomod"]
+empty_vendor:
+  repo: https://github.com/cachito-testing/gomod-vendor-check-empty-vendor.git
+  ref:  9989e210ac2993196e22d0a23fe18ce460012058
+  flags: ["gomod-vendor-check"]
+  pkg_managers: ["gomod"]
+correct_vendor:
+  repo: https://github.com/cachito-testing/gomod-vendor-check-pass.git
+  ref:  0543a5034b687df174c6b12b7b6b9c04770a856f
+  flags: ["gomod-vendor-check"]
+  pkg_managers: ["gomod"]
+  response_expectations:
+    dependencies:
+      - name: golang.org/x/text/internal/tag
+        replaces: null
+        type: go-package
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: golang.org/x/text/language
+        replaces: null
+        type: go-package
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: rsc.io/quote
+        replaces: null
+        type: go-package
+        version: v1.5.2
+      - name: rsc.io/sampler
+        replaces: null
+        type: go-package
+        version: v1.3.0
+      - name: golang.org/x/text
+        replaces: null
+        type: gomod
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: rsc.io/quote
+        replaces: null
+        type: gomod
+        version: v1.5.2
+      - name: rsc.io/sampler
+        replaces: null
+        type: gomod
+        version: v1.3.0
+    packages:
+      - dependencies:
+        - name: golang.org/x/text/internal/tag
+          replaces: null
+          type: go-package
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: golang.org/x/text/language
+          replaces: null
+          type: go-package
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: rsc.io/quote
+          replaces: null
+          type: go-package
+          version: v1.5.2
+        - name: rsc.io/sampler
+          replaces: null
+          type: go-package
+          version: v1.3.0
+        name: github.com/cachito-testing/gomod-vendor-check-pass
+        type: go-package
+        version: v0.0.0-20210802173203-0543a5034b68
+      - dependencies:
+        - name: golang.org/x/text
+          replaces: null
+          type: gomod
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: rsc.io/quote
+          replaces: null
+          type: gomod
+          version: v1.5.2
+        - name: rsc.io/sampler
+          replaces: null
+          type: gomod
+          version: v1.3.0
+        name: github.com/cachito-testing/gomod-vendor-check-pass
+        type: gomod
+        version: v0.0.0-20210802173203-0543a5034b68
+  expected_files:
+    app: https://github.com/cachito-testing/gomod-vendor-check-pass/tarball/0543a5034b687df174c6b12b7b6b9c04770a856f
+  content_manifest:
+  - purl: "pkg:golang/github.com%2Fcachito-testing%2Fgomod-vendor-check-pass@v0.0.0-20210802173203-0543a5034b68"
+    dep_purls:
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+    source_purls:
+    - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+no_vendor:
+  repo: https://github.com/cachito-testing/gomod-vendor-check-no-vendor.git
+  ref: 7ba383d5592910edbf7f287d4b5a00c5ababf751
+  flags: ["gomod-vendor-check"]
+  pkg_managers: ["gomod"]
+  response_expectations:
+    dependencies:
+      - name: golang.org/x/text/internal/tag
+        replaces: null
+        type: go-package
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: golang.org/x/text/language
+        replaces: null
+        type: go-package
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: rsc.io/quote
+        replaces: null
+        type: go-package
+        version: v1.5.2
+      - name: rsc.io/sampler
+        replaces: null
+        type: go-package
+        version: v1.3.0
+      - name: golang.org/x/text
+        replaces: null
+        type: gomod
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: rsc.io/quote
+        replaces: null
+        type: gomod
+        version: v1.5.2
+      - name: rsc.io/sampler
+        replaces: null
+        type: gomod
+        version: v1.3.0
+    packages:
+      - dependencies:
+        - name: golang.org/x/text/internal/tag
+          replaces: null
+          type: go-package
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: golang.org/x/text/language
+          replaces: null
+          type: go-package
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: rsc.io/quote
+          replaces: null
+          type: go-package
+          version: v1.5.2
+        - name: rsc.io/sampler
+          replaces: null
+          type: go-package
+          version: v1.3.0
+        name: github.com/cachito-testing/gomod-vendor-check-pass
+        type: go-package
+        version: v0.0.0-20210802184302-7ba383d55929
+      - dependencies:
+        - name: golang.org/x/text
+          replaces: null
+          type: gomod
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: rsc.io/quote
+          replaces: null
+          type: gomod
+          version: v1.5.2
+        - name: rsc.io/sampler
+          replaces: null
+          type: gomod
+          version: v1.3.0
+        name: github.com/cachito-testing/gomod-vendor-check-pass
+        type: gomod
+        version: v0.0.0-20210802184302-7ba383d55929
+  expected_files:
+    app: https://github.com/cachito-testing/gomod-vendor-check-pass/tarball/0543a5034b687df174c6b12b7b6b9c04770a856f
+  content_manifest:
+  - purl: "pkg:golang/github.com%2Fcachito-testing%2Fgomod-vendor-check-pass@v0.0.0-20210802184302-7ba383d55929"
+    dep_purls:
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+    source_purls:
+    - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"

--- a/tests/integration/test_gomod_packages.py
+++ b/tests/integration/test_gomod_packages.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import pytest
+
 from . import utils
 
 
@@ -32,3 +34,34 @@ def test_gomod_vendor_without_flag(test_env):
         )
     else:
         utils.assert_properly_completed_response(completed_response)
+
+
+@pytest.mark.parametrize("env_name", [("wrong_vendor"), ("empty_vendor")])
+def test_gomod_vendor_check_fail(env_name, test_env):
+    """
+    Validate failing of gomod vendor request with gomod-vendor-check flag and inconsistent vendor.
+
+    Checks:
+    * The request fails with expected error message
+    """
+    env_data = utils.load_test_data("gomod_vendor_check.yaml")[env_name]
+    client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
+    initial_response = client.create_new_request(
+        payload={
+            "repo": env_data["repo"],
+            "ref": env_data["ref"],
+            "flags": env_data["flags"],
+            "pkg_managers": env_data["pkg_managers"],
+        },
+    )
+    completed_response = client.wait_for_complete_request(initial_response)
+    assert completed_response.status == 200
+    assert completed_response.data["state"] == "failed"
+    error_msg = (
+        "The content of the vendor directory is not consistent with go.mod. "
+        "Run `go mod vendor` locally to fix this problem. See the logs for more details."
+    )
+    assert error_msg in completed_response.data["state_reason"], (
+        f"#{completed_response.id}: Request failed correctly, but with unexpected message: "
+        f"{completed_response.data['state_reason']}. Expected message was: {error_msg}"
+    )

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -16,6 +16,8 @@ from . import utils
         ("gomod_packages", "vendored_with_flag"),
         ("gomod_packages", "implicit_gomod"),
         ("gomod_packages", "missing_gomod"),
+        ("gomod_vendor_check", "correct_vendor"),
+        ("gomod_vendor_check", "no_vendor"),
         ("npm_packages", "without_deps"),
         ("npm_packages", "with_deps"),
         ("yarn_packages", "without_deps"),


### PR DESCRIPTION
CLOUDBLD-5578

Add test function which fails with inconsistent vendor or empty vendor.
Add test data for consistent vendor and no vendor.

Signed-off-by: Daniel Cho <dacho@redhat.com>