### PR TITLE
Checks the packages file before finalizing a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,13 @@ Custom configuration for the Celery workers are listed below:
   `value` must be a string which specifies the value of the environment variable. The `kind` must
   also be a string which specifies the type of value, either `"path"` or `"literal"`. Check
   `cachito/workers/config.py::Config` for the default value of this configuration.
+* `cachito_finalize_request_packages_check_interval` - when finalizing a request, a worker will
+  query the API pods and check their response to make sure the packages and dependencies were
+  properly loaded. In case there's a failure, the worker will retry the check. This property
+  sets the interval between checks, in seconds.
+* `cachito_finalize_request_packages_check_max_attempts` - similar to
+  `cachito_finalize_request_packages_check_interval`, but defines the number of attemps for the
+  packages file check. Setting the value to 0 will disable the check completely.
 * `cachito_gomod_ignore_missing_gomod_file` - if `True` and the request specifies the `gomod`
   package manager but there is no `go.mod` file present in the repository, Cachito will skip
   the `gomod` package manager for the request. If `False`, the request will fail if the `go.mod`

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -324,7 +324,8 @@ def create_request():
             tasks.fetch_yarn_source.si(request.id, yarn_package_configs).on_error(error_callback)
         )
 
-    chain_tasks.append(tasks.finalize_request.si(request.id).on_error(error_callback))
+    chain_tasks.append(tasks.process_fetched_sources.si(request.id).on_error(error_callback))
+    chain_tasks.append(tasks.finalize_request.s(request.id).on_error(error_callback))
 
     try:
         chain(chain_tasks).delay()

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -348,11 +348,8 @@ class Request(db.Model):
     def _get_packages_data(self):
         packages_data = PackagesData()
 
-        if self._is_complete():
-            bundle_dir = RequestBundleDir(
-                self.id, root=flask.current_app.config["CACHITO_BUNDLES_DIR"]
-            )
-            packages_data.load(bundle_dir.packages_data)
+        bundle_dir = RequestBundleDir(self.id, root=flask.current_app.config["CACHITO_BUNDLES_DIR"])
+        packages_data.load(bundle_dir.packages_data)
 
         return packages_data
 

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -31,6 +31,8 @@ class Config(object):
             "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": {"value": "true", "kind": "literal"},
         },
     }
+    cachito_finalize_request_packages_check_interval = 1.0
+    cachito_finalize_request_packages_check_max_attempts = 10
     cachito_deps_patch_batch_size = 50
     cachito_gomod_ignore_missing_gomod_file = True
     cachito_gomod_strict_vendor = False
@@ -141,6 +143,8 @@ class TestingConfig(DevelopmentConfig):
             "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": {"value": "true", "kind": "literal"},
         },
     }
+    cachito_finalize_request_packages_check_interval = 0.1
+    cachito_finalize_request_packages_check_max_attempts = 3
     cachito_npm_file_deps_allowlist = {"han_solo": ["millennium-falcon"]}
     cachito_request_file_logs_dir = None
 

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import tarfile
+import time
 from pathlib import Path
 from typing import Any, Callable, List, Optional
 
@@ -11,6 +12,7 @@ import requests
 from cachito.common.checksum import hash_file
 from cachito.common.packages_data import PackagesData
 from cachito.errors import CachitoError, ValidationError
+from cachito.workers.config import get_worker_config
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.scm import Git
 from cachito.workers.tasks.celery import app
@@ -29,7 +31,7 @@ __all__ = [
     "finalize_request",
     "get_request",
     "save_bundle_archive_checksum",
-    "process_fetched_sources"
+    "process_fetched_sources",
 ]
 log = logging.getLogger(__name__)
 
@@ -173,10 +175,7 @@ def save_bundle_archive_checksum(request_id: int) -> None:
 @app.task(priority=10)
 @runs_if_request_in_progress
 def process_fetched_sources(request_id):
-    """
-    Writes the bundle archive, packages file and checksum file.
-    It also updates the request with the number of packages and dependencies fetched.
-    """
+    """Generate files for request and updates the request with packages/dependencies counts."""
     request = get_request(request_id)
     create_bundle_archive(request_id, request.get("flags", []))
     save_bundle_archive_checksum(request_id)
@@ -190,8 +189,60 @@ def process_fetched_sources(request_id):
     return packages_count, dependencies_count
 
 
+def _check_packages_data_on_api(
+    request_id: int, packages_count: int, dependencies_count: int
+) -> bool:
+    request = get_request(request_id)
+    actual_packages_count = len(request.get("packages", []))
+    actual_dependencies_count = len(request.get("dependencies", []))
+
+    if actual_packages_count == packages_count and actual_dependencies_count == dependencies_count:
+        return True
+
+    if actual_packages_count != 0 or actual_dependencies_count != 0:
+        log.warning(
+            "Mismatch in the number of expected packages while checking the written data."
+            f"Expected {packages_count} packages, got {actual_packages_count}."
+            f"Expected {dependencies_count} dependencies, got {actual_dependencies_count}."
+        )
+
+    return False
+
+
+def _wait_until_packages_file_is_available(
+    request_id: int, packages_count: int, dependencies_count: int
+) -> None:
+    config = get_worker_config()
+    interval = config.cachito_finalize_request_packages_check_interval
+    max_attempts = config.cachito_finalize_request_packages_check_max_attempts
+    log_message = "Checking if the packages file was properly loaded"
+
+    if max_attempts == 0:
+        return
+
+    attempts = 0
+    check_passed = False
+
+    while not check_passed and attempts < max_attempts:
+        if attempts > 0:
+            time.sleep(interval)
+            log.warning("%s (attempt %i).", log_message, attempts + 1)
+        else:
+            log.info(log_message)
+
+        check_passed = _check_packages_data_on_api(request_id, packages_count, dependencies_count)
+        attempts += 1
+
+    if not check_passed:
+        raise CachitoError("Packages file could not be loaded.")
+
+
 @app.task(priority=10)
 @runs_if_request_in_progress
 def finalize_request(counts, request_id):
-    """Execute tasks to finalize the request creation."""
+    """Check if the packages file can be read by the API and set the request state to complete."""
+    packages_count = counts[0]
+    dependencies_count = counts[1]
+
+    _wait_until_packages_file_is_available(request_id, packages_count, dependencies_count)
     set_request_state(request_id, "complete", "Completed successfully")

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -33,6 +33,7 @@ from cachito.workers.tasks import (
     fetch_npm_source,
     fetch_pip_source,
     fetch_yarn_source,
+    process_fetched_sources,
     finalize_request,
 )
 
@@ -176,7 +177,8 @@ def test_create_and_fetch_request(
         )
     if "yarn" in expected_pkg_managers:
         expected.append(fetch_yarn_source.si(created_request["id"], []).on_error(error_callback))
-    expected.append(finalize_request.si(created_request["id"]).on_error(error_callback))
+    expected.append(process_fetched_sources.si(created_request["id"]).on_error(error_callback))
+    expected.append(finalize_request.s(created_request["id"]).on_error(error_callback))
     mock_chain.assert_called_once_with(expected)
 
     request_id = created_request["id"]
@@ -217,7 +219,8 @@ def test_create_request_with_gomod_package_configs(
             False,
         ).on_error(error_callback),
         fetch_gomod_source.si(1, [], package_value["gomod"]).on_error(error_callback),
-        finalize_request.si(1).on_error(error_callback),
+        process_fetched_sources.si(1).on_error(error_callback),
+        finalize_request.s(1).on_error(error_callback),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -246,7 +249,8 @@ def test_create_request_with_npm_package_configs(
             False,
         ).on_error(error_callback),
         fetch_npm_source.si(1, package_value["npm"]).on_error(error_callback),
-        finalize_request.si(1).on_error(error_callback),
+        process_fetched_sources.si(1).on_error(error_callback),
+        finalize_request.s(1).on_error(error_callback),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -285,7 +289,8 @@ def test_create_request_with_pip_package_configs(mock_chain, app, auth_env, clie
             False,
         ).on_error(error_callback),
         fetch_pip_source.si(1, package_value["pip"]).on_error(error_callback),
-        finalize_request.si(1).on_error(error_callback),
+        process_fetched_sources.si(1).on_error(error_callback),
+        finalize_request.s(1).on_error(error_callback),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -314,7 +319,8 @@ def test_create_request_with_yarn_package_configs(
             False,
         ).on_error(error_callback),
         fetch_yarn_source.si(1, package_value["yarn"]).on_error(error_callback),
-        finalize_request.si(1).on_error(error_callback),
+        process_fetched_sources.si(1).on_error(error_callback),
+        finalize_request.s(1).on_error(error_callback),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -365,7 +371,8 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
                 False,
             ).on_error(error_callback),
             fetch_gomod_source.si(1, [], []).on_error(error_callback),
-            finalize_request.si(1).on_error(error_callback),
+            process_fetched_sources.si(1).on_error(error_callback),
+            finalize_request.s(1).on_error(error_callback),
         ]
     )
 

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -33,8 +33,8 @@ from cachito.workers.tasks import (
     fetch_npm_source,
     fetch_pip_source,
     fetch_yarn_source,
-    process_fetched_sources,
     finalize_request,
+    process_fetched_sources,
 )
 
 RE_INVALID_PACKAGES_VALUE = (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Optional
-from unittest import mock
 
 import pytest
 
-from cachito.web.models import PackageManager, Request, RequestStateMapping
+from cachito.web.models import PackageManager
 
 
 @pytest.mark.parametrize(
@@ -17,38 +16,3 @@ def test_package_manager_get_by_name(name, expected, app, db, auth_env):
         assert expected == pkg_manager
     else:
         assert expected == pkg_manager.name
-
-
-class TestRequest:
-    def _create_request_object(self):
-        request = Request()
-        request.repo = "a_repo"
-        request.ref = "a_ref"
-        request.user_id = 1
-        request.submitted_by_id = 1
-        request.packages_count = 1
-        request.dependencies_count = 1
-
-        return request
-
-    @pytest.mark.parametrize(
-        "state, call_count",
-        [
-            [RequestStateMapping.in_progress.name, 0],
-            [RequestStateMapping.complete.name, 2],
-            [RequestStateMapping.failed.name, 0],
-            [RequestStateMapping.stale.name, 0],
-        ],
-    )
-    @mock.patch("cachito.common.packages_data.PackagesData.load")
-    def test_package_data_is_only_accessed_when_request_is_complete(
-        self, load_mock, state, call_count, app, auth_env
-    ):
-        request = self._create_request_object()
-        request.add_state(state, "Reason")
-
-        with app.test_request_context(environ_base=auth_env):
-            request.to_json()
-            request.content_manifest.to_json()
-
-        assert load_mock.call_count == call_count

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -250,9 +250,7 @@ def test_aggregate_packages_data(
 @mock.patch("cachito.workers.tasks.general.aggregate_packages_data")
 @mock.patch("cachito.workers.tasks.general.set_packages_and_deps_counts")
 @mock.patch("cachito.workers.tasks.general.save_bundle_archive_checksum")
-@mock.patch("cachito.workers.tasks.general.set_request_state")
-def test_finalize_request(
-    mock_set_state,
+def test_process_fetched_sources(
     mock_save_bundle_archive_checksum,
     mock_set_counts,
     mock_aggregate_data,
@@ -270,13 +268,21 @@ def test_finalize_request(
 
     mock_aggregate_data.return_value = mock.Mock(packages=[pkg], all_dependencies=[pkg, pkg])
 
-    tasks.finalize_request(42)
+    tasks.process_fetched_sources(42)
 
     mock_get_request.assert_called_once_with(42)
     mock_create_archive.assert_called_once_with(42, ["some-flag"])
     mock_save_bundle_archive_checksum.assert_called_once_with(42)
     mock_aggregate_data.assert_called_once_with(42, ["pip"])
     mock_set_counts.assert_called_once_with(42, 1, 2)
+
+
+@mock.patch("cachito.workers.tasks.general.set_request_state")
+def test_finalize_request(
+    mock_set_state,
+    task_passes_state_check,
+):
+    tasks.finalize_request((1, 2), 42)
     mock_set_state.assert_called_once_with(42, "complete", "Completed successfully")
 
 


### PR DESCRIPTION
This PR makes three changes:
- Allows the API to read the packages file regardless of the request's state (reverting a change done in a previous PR)
- Creates a new task that will be responsible for writing all files related to the request and setting the pkgs/deps count
- Adds a mechanism to verify it the packages file can be properly read by an API pod before the request is moved to the completed state. 

The reason for the task split is because the retry did not work when the file write and the check were part of the same task. We suspect the flush of the file to the NFS is only made when the task process is finished.

The check itself is done by querying the API from the worker pod that is processing the request and comparing its response with the number of packages and dependencies that were just written. We also made so that if this check fails, it will be retried considering a configured interval and number of attempts.

Here's a simplified diagram that shows how a request processing will be once this PR is merged:

![image](https://user-images.githubusercontent.com/4075353/127800219-27a0c8e1-25ca-421f-a3c7-1e01cc949ddc.png)

CLOUDBLD-6599