### PR TITLE
Adds endpoints that lists packages file contents

### DIFF
--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -534,6 +534,59 @@ paths:
                 error:
                   type: string
                   example: The logs for the Cachito request 1 no longer exist
+  "/requests/{id}/packages":
+    get:
+      description: Return the packages and dependencies for a request
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the Cachito request
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Lists packages and dependencies
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dependencies:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PackageWithReplaces"
+                  packages:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: "#/components/schemas/Package"
+                        - type: object
+                          properties:
+                            dependencies:
+                              type: array
+                              items:
+                                $ref: "#/components/schemas/PackageWithReplaces"
+        "404":
+          description: The request does not exist or the packages file is not present
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "The packages file is not present for request"
+        "500":
+          description: Request is at invalid state. The packages file is not present.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Invalid state: packages file was not found."
   "/content-manifest":
     get:
       description: Return the content manifest of the specified requests


### PR DESCRIPTION
This endpoint is intented to be used by the worker process while finalizing a request. The reason for this is that the current `/api/v1/requests/{id}` endpoint does not try to load the packages file unless the request is at the `completed` state.

We thought it would be best to keep it this way because there would be no impact to the current way the API is working, avoiding adding any performance issues (the NFS cache will need to be force cleaned before every loading of the file).

This PR is the first step to have a complete solution that will flush the cache before loading the packages file and check its integrity before the request is marked as `completed`. Here's a diagram showing the full solution:

![image](https://user-images.githubusercontent.com/4075353/128179165-8402aafb-14df-45b3-a997-e2ac404cc71b.png)

CLOUDBLD-6599