### PR TITLE
Fix empty packages data bug

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -358,7 +358,8 @@ def create_request():
             tasks.fetch_yarn_source.si(request.id, yarn_package_configs).on_error(error_callback)
         )
 
-    chain_tasks.append(tasks.finalize_request.si(request.id).on_error(error_callback))
+    chain_tasks.append(tasks.process_fetched_sources.si(request.id).on_error(error_callback))
+    chain_tasks.append(tasks.finalize_request.s(request.id).on_error(error_callback))
 
     try:
         chain(chain_tasks).delay()

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -29,6 +29,7 @@ __all__ = [
     "finalize_request",
     "get_request",
     "save_bundle_archive_checksum",
+    "process_fetched_sources",
 ]
 log = logging.getLogger(__name__)
 
@@ -169,13 +170,25 @@ def save_bundle_archive_checksum(request_id: int) -> None:
     bundle_dir.bundle_archive_checksum.write_text(checksum, encoding="utf-8")
 
 
-@app.task(priority=10)
+@app.task
 @runs_if_request_in_progress
-def finalize_request(request_id):
-    """Execute tasks to finalize the request creation."""
+def process_fetched_sources(request_id):
+    """Generate files for request and updates the request with packages/dependencies counts."""
     request = get_request(request_id)
     create_bundle_archive(request_id, request.get("flags", []))
     save_bundle_archive_checksum(request_id)
     data = aggregate_packages_data(request_id, request["pkg_managers"])
-    set_packages_and_deps_counts(request_id, len(data.packages), len(data.all_dependencies))
+
+    packages_count = len(data.packages)
+    dependencies_count = len(data.all_dependencies)
+
+    set_packages_and_deps_counts(request_id, packages_count, dependencies_count)
+
+    return packages_count, dependencies_count
+
+
+@app.task(priority=10)
+@runs_if_request_in_progress
+def finalize_request(counts, request_id):
+    """Execute tasks to finalize the request creation."""
     set_request_state(request_id, "complete", "Completed successfully")

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -34,6 +34,7 @@ from cachito.workers.tasks import (
     fetch_pip_source,
     fetch_yarn_source,
     finalize_request,
+    process_fetched_sources,
 )
 
 RE_INVALID_PACKAGES_VALUE = (
@@ -176,7 +177,8 @@ def test_create_and_fetch_request(
         )
     if "yarn" in expected_pkg_managers:
         expected.append(fetch_yarn_source.si(created_request["id"], []).on_error(error_callback))
-    expected.append(finalize_request.si(created_request["id"]).on_error(error_callback))
+    expected.append(process_fetched_sources.si(created_request["id"]).on_error(error_callback))
+    expected.append(finalize_request.s(created_request["id"]).on_error(error_callback))
     mock_chain.assert_called_once_with(expected)
 
     request_id = created_request["id"]
@@ -217,7 +219,8 @@ def test_create_request_with_gomod_package_configs(
             False,
         ).on_error(error_callback),
         fetch_gomod_source.si(1, [], package_value["gomod"]).on_error(error_callback),
-        finalize_request.si(1).on_error(error_callback),
+        process_fetched_sources.si(1).on_error(error_callback),
+        finalize_request.s(1).on_error(error_callback),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -246,7 +249,8 @@ def test_create_request_with_npm_package_configs(
             False,
         ).on_error(error_callback),
         fetch_npm_source.si(1, package_value["npm"]).on_error(error_callback),
-        finalize_request.si(1).on_error(error_callback),
+        process_fetched_sources.si(1).on_error(error_callback),
+        finalize_request.s(1).on_error(error_callback),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -285,7 +289,8 @@ def test_create_request_with_pip_package_configs(mock_chain, app, auth_env, clie
             False,
         ).on_error(error_callback),
         fetch_pip_source.si(1, package_value["pip"]).on_error(error_callback),
-        finalize_request.si(1).on_error(error_callback),
+        process_fetched_sources.si(1).on_error(error_callback),
+        finalize_request.s(1).on_error(error_callback),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -314,7 +319,8 @@ def test_create_request_with_yarn_package_configs(
             False,
         ).on_error(error_callback),
         fetch_yarn_source.si(1, package_value["yarn"]).on_error(error_callback),
-        finalize_request.si(1).on_error(error_callback),
+        process_fetched_sources.si(1).on_error(error_callback),
+        finalize_request.s(1).on_error(error_callback),
     ]
     mock_chain.assert_called_once_with(expected)
 
@@ -365,7 +371,8 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
                 False,
             ).on_error(error_callback),
             fetch_gomod_source.si(1, [], []).on_error(error_callback),
-            finalize_request.si(1).on_error(error_callback),
+            process_fetched_sources.si(1).on_error(error_callback),
+            finalize_request.s(1).on_error(error_callback),
         ]
     )
 

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -250,9 +250,7 @@ def test_aggregate_packages_data(
 @mock.patch("cachito.workers.tasks.general.aggregate_packages_data")
 @mock.patch("cachito.workers.tasks.general.set_packages_and_deps_counts")
 @mock.patch("cachito.workers.tasks.general.save_bundle_archive_checksum")
-@mock.patch("cachito.workers.tasks.general.set_request_state")
-def test_finalize_request(
-    mock_set_state,
+def test_process_fetched_sources(
     mock_save_bundle_archive_checksum,
     mock_set_counts,
     mock_aggregate_data,
@@ -270,13 +268,21 @@ def test_finalize_request(
 
     mock_aggregate_data.return_value = mock.Mock(packages=[pkg], all_dependencies=[pkg, pkg])
 
-    tasks.finalize_request(42)
+    tasks.process_fetched_sources(42)
 
     mock_get_request.assert_called_once_with(42)
     mock_create_archive.assert_called_once_with(42, ["some-flag"])
     mock_save_bundle_archive_checksum.assert_called_once_with(42)
     mock_aggregate_data.assert_called_once_with(42, ["pip"])
     mock_set_counts.assert_called_once_with(42, 1, 2)
+
+
+@mock.patch("cachito.workers.tasks.general.set_request_state")
+def test_finalize_request(
+    mock_set_state,
+    task_passes_state_check,
+):
+    tasks.finalize_request((1, 2), 42)
     mock_set_state.assert_called_once_with(42, "complete", "Completed successfully")
 
 


### PR DESCRIPTION
This PR introduces two mechanisms to solve the bug of Cachito not properly loading the packages file for a request:

1. Adds a check that will not allow a request to be completed unless the worker is able to query the API and successfully compare the number of packages and dependencies. This will avoid propagating any Cachito failure to Brew builds.
2. Forces the NFS to clear it's cache by listing all the packages file's parent directory contents. This is the only workaround currently found to have the cache cleared.    

Diagram showing the solution:
![image](https://user-images.githubusercontent.com/4075353/128347077-18a3b538-8db2-47fb-b9db-993bc6bcd38c.png)

CLOUDBLD-6599