### PR TITLE
Add more logs to the packages files check

### DIFF
--- a/cachito/common/packages_data.py
+++ b/cachito/common/packages_data.py
@@ -168,6 +168,7 @@ class PackagesData:
 
         with open(file_name, "r", encoding="utf-8") as f:
             data = json.load(f)
+            log.info("Loaded file %s: %s", file_name, data)
             packages = data.get("packages")
             if packages is None:
                 log.warning("Packages data file does not include key 'packages'.")

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -195,14 +195,16 @@ def _check_packages_data_on_api(
     actual_packages_count = len(request.get("packages", []))
     actual_dependencies_count = len(request.get("dependencies", []))
 
+    log.info(
+        f"Checking the packages file contents for request {request_id}. "
+        f"Expected {packages_count} packages, got {actual_packages_count}. "
+        f"Expected {dependencies_count} dependencies, got {actual_dependencies_count}."
+    )
+
     if actual_packages_count == packages_count and actual_dependencies_count == dependencies_count:
         return
 
-    raise CachitoError(
-        f"Error checking packages data for request {request_id}. "
-        f"Expected {packages_count} packages, got {actual_packages_count}. "
-        f"Expected {dependencies_count} dependencies, got {actual_dependencies_count}. "
-    )
+    raise CachitoError(f"Error checking packages data for request {request_id}.")
 
 
 @app.task(priority=10)

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -295,11 +295,7 @@ def test_finalize_request(
         "dependencies": [pkg, pkg],
     }
 
-    error_message = (
-        f"Error checking packages data for request {request_id}. "
-        f"Expected {expected_counts[0]} packages, got 1. "
-        f"Expected {expected_counts[1]} dependencies, got 2. "
-    )
+    error_message = f"Error checking packages data for request {request_id}."
 
     with raise_error and pytest.raises(CachitoError, match=error_message) or nullcontext():
         mock_get_request_packages_and_dependencies.return_value = packages_data


### PR DESCRIPTION
CLOUDBLD-6599

- Adds log that shows the packages file content every time it gets loaded
- Adds log that shows the integrity check that is made while a request is being finalized