### PR TITLE
Fix packages_data module logging

### DIFF
--- a/cachito/common/paths.py
+++ b/cachito/common/paths.py
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import logging
 import os
 import shutil
 from pathlib import Path
 from typing import Any
-
-log = logging.getLogger(__name__)
 
 # Subclassing from type(Path()) is a workaround because pathlib does not
 # support subclass from Path directly. This base type will be the correct type

--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -12,7 +12,7 @@ class Config(object):
     """The base Cachito Flask configuration."""
 
     # Additional loggers to set to the level defined in CACHITO_LOG_LEVEL
-    CACHITO_ADDITIONAL_LOGGERS: List[str] = []
+    CACHITO_ADDITIONAL_LOGGERS: List[str] = ["cachito.common.packages_data"]
     CACHITO_DEFAULT_PACKAGE_MANAGERS: List[str] = ["gomod"]
     # This sets the level of the "flask.app" logger, which is accessed from current_app.logger
     CACHITO_LOG_LEVEL = "INFO"


### PR DESCRIPTION
This config makes the logs from the `cachito/common/packages_data.py` module appear when it is being used by Flask.

Note that other modules within this package will need the same configuration if we add logs to them in the future.