### PR TITLE
Request state single source of truth in json generation method

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -340,8 +340,9 @@ class Request(db.Model):
         return content_manifest.ContentManifest(self, packages)
 
     def _is_complete(self):
-        if self.state:
-            return self.state.state_name == RequestStateMapping.complete.name
+        if len(self.states) > 0:
+            latest_state = self.states[-1]
+            return latest_state.state_name == RequestStateMapping.complete.name
 
         return False
 


### PR DESCRIPTION
The `to_json` method on the Request model class currently uses two different relationships to determine a request's current state:

- state: based on a foreign key placed on the `request` table.
- states: based on a foreign key placed on the `request_state` table.

This behavior seems to cause a bug when the request is patched to the `complete` state while the `to_json` method is being processed. Each relationship attribute returns a different state, making the packages file to not be loaded and the request JSON appear with a `complete` state:

![image](https://user-images.githubusercontent.com/4075353/128729011-a5764eb0-accc-4004-9100-cf370d895cf3.png)

The fix currently only affects the "verbose" JSON generation, so we should probably remove this dual relationship later on.