### PR TITLE
Changes logs to help monitor the empty packages bug

### DIFF
--- a/cachito/common/packages_data.py
+++ b/cachito/common/packages_data.py
@@ -163,16 +163,18 @@ class PackagesData:
         self._clear_nfs_cache(file_name)
 
         if not os.path.exists(file_name):
-            log.warning("No data is loaded from non-existing file %s.", file_name)
+            log.warning("Skipping the loading of non-existing file %s.", file_name)
             return
 
         with open(file_name, "r", encoding="utf-8") as f:
             data = json.load(f)
-            log.info("Loaded file %s: %s", file_name, data)
             packages = data.get("packages")
             if packages is None:
-                log.warning("Packages data file does not include key 'packages'.")
+                log.warning("Packages data file %s does not include key 'packages'.", file_name)
                 return
+
+            log.info("Loaded file %s, found %i packages.", file_name, len(packages))
+
             for p in packages:
                 self.add_package(p, p.get("path", os.curdir), p["dependencies"])
 

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -131,7 +131,22 @@ def get_request(request_id):
     :rtype: flask.Response
     :raise NotFound: if the request is not found
     """
-    return flask.jsonify(Request.query.get_or_404(request_id).to_json())
+    json = Request.query.get_or_404(request_id).to_json()
+
+    if json["state"] == RequestStateMapping.complete.name:
+        package_count = len(json["packages"])
+        dependency_count = len(json["dependencies"])
+
+        flask.current_app.logger.info(
+            "Returning data for request %i. Found %i packages and %i dependencies. "
+            "The following package managers were used: %s.",
+            request_id,
+            package_count,
+            dependency_count,
+            json["pkg_managers"],
+        )
+
+    return flask.jsonify(json)
 
 
 @api_v1.route("/requests/<int:request_id>/configuration-files", methods=["GET"])


### PR DESCRIPTION
- Make the packages file loading logs less verbose, so they don't overload the log processing.
- Adjust several messages content to make them more readable/informative.
- Adds new log to /request/{id} endpoint, so we can monitor all responses given.

CLOUDBLD-6599