### PR TITLE
Fixes gomod cached dependencies test to work with Go 1.16

### DIFF
--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -161,6 +161,18 @@ gomod_cached_deps:
         replaces: null
         type: "gomod"
         version: "DEP_VERSION"
+      - name: "golang.org/x/text"
+        replaces: null
+        type: "gomod"
+        version: "v0.0.0-20170915032832-14c0d48ead0c"
+      - name: "rsc.io/quote"
+        replaces: null
+        type: "gomod"
+        version: "v1.5.2"
+      - name: "rsc.io/sampler"
+        replaces: null
+        type: "gomod"
+        version: "v1.3.0"
       name: "github.com/cachito-testing/cachito-gomod-with-deps"
       type: "gomod"
       version: "MAIN_VERSION"
@@ -185,6 +197,18 @@ gomod_cached_deps:
       replaces: null
       type: "gomod"
       version: "DEP_VERSION"
+    - name: "golang.org/x/text"
+      replaces: null
+      type: "gomod"
+      version: "v0.0.0-20170915032832-14c0d48ead0c"
+    - name: "rsc.io/quote"
+      replaces: null
+      type: "gomod"
+      version: "v1.5.2"
+    - name: "rsc.io/sampler"
+      replaces: null
+      type: "gomod"
+      version: "v1.3.0"
   # Expected files
   expected_files: []
   # Expected content manifest data
@@ -197,6 +221,9 @@ gomod_cached_deps:
     - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
     source_purls:
     - "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-without-deps@DEP_VERSION"
+    - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
 # Test npm with cached dependencies
 npm_cached_deps:
   # Use local version of repos.

--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -413,8 +413,7 @@ def update_main_repo(env_data, repo_dir, tmpdir, new_dep_commits, dep_repo):
 
     gomod:
         * get a pseudo-version for dependency commit
-        * replace a `require` string with old dependency
-          with new one in the go.mod file
+        * add a new dependency in the go.mod file
         * return replacement rules based on commit and pseudo-version
 
     npm & yarn:
@@ -457,13 +456,7 @@ def update_main_repo(env_data, repo_dir, tmpdir, new_dep_commits, dep_repo):
     elif env_data["pkg_managers"] == ["gomod"]:
         dep_version = get_pseudo_version(dep_repo, new_dep_commits[0])
 
-        with open(os.path.join(repo_dir, "go.mod"), "r") as f:
-            base_gomod_file = [
-                line for line in f.read().split("\n") if not line.startswith("require")
-            ]
-        with open(os.path.join(repo_dir, "go.mod"), "w+") as f:
-            for line in base_gomod_file:
-                f.write(f"{line}\n")
+        with open(os.path.join(repo_dir, "go.mod"), "a") as f:
             go_dep = env_data["https_dep_repo"][len("https://") :]
             if go_dep.endswith(".git"):
                 go_dep = go_dep[: -len(".git")]


### PR DESCRIPTION
The test used to remove a dependency which was still being referenced in the test repo code, and this causes it to break when using Go 1.16.

See: https://blog.golang.org/go116-module-changes#TOC_3.