### PR TITLE
Pass download dir to download_dependencies directly

### DIFF
--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -6,6 +6,7 @@ import os
 
 from cachito.errors import CachitoError, ValidationError
 from cachito.workers.config import get_worker_config
+from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general_js import (
     JSDependency,
     download_dependencies,
@@ -297,8 +298,10 @@ def resolve_npm(app_source_path, request, skip_deps=None):
     # By downloading the dependencies, it stores the tarballs in the bundle and also stages the
     # content in the npm repository for the request
     proxy_repo_url = get_npm_proxy_repo_url(request["id"])
+    bundle_dir = RequestBundleDir(request["id"])
+    bundle_dir.npm_deps_dir.mkdir(exist_ok=True)
     package_and_deps_info["downloaded_deps"] = download_dependencies(
-        request["id"], package_and_deps_info["deps"], proxy_repo_url, skip_deps
+        bundle_dir.npm_deps_dir, package_and_deps_info["deps"], proxy_repo_url, skip_deps,
     )
 
     # Remove all the "bundled" keys since that is an implementation detail that should not be

--- a/cachito/workers/pkg_managers/yarn.py
+++ b/cachito/workers/pkg_managers/yarn.py
@@ -10,6 +10,7 @@ import pyarn.lockfile
 
 from cachito.errors import CachitoError
 from cachito.workers.config import get_worker_config
+from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general_js import (
     JSDependency,
     convert_hex_sha_to_npm,
@@ -418,8 +419,10 @@ def resolve_yarn(app_source_path, request, skip_deps=None):
     # By downloading the dependencies, it stores the tarballs in the bundle and also stages the
     # content in the yarn repository for the request
     proxy_repo_url = get_yarn_proxy_repo_url(request["id"])
+    bundle_dir = RequestBundleDir(request["id"])
+    bundle_dir.yarn_deps_dir.mkdir(exist_ok=True)
     package_and_deps_info["downloaded_deps"] = download_dependencies(
-        request["id"],
+        bundle_dir.yarn_deps_dir,
         package_and_deps_info["deps"],
         proxy_repo_url,
         skip_deps=skip_deps,

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 
 from cachito.errors import CachitoError
+from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers import general_js, npm
 
 
@@ -571,7 +572,18 @@ def test_get_package_and_deps_dep_replacements(package_lock_deps, package_and_de
 @mock.patch("cachito.workers.pkg_managers.npm.os.path.exists")
 @mock.patch("cachito.workers.pkg_managers.npm.get_package_and_deps")
 @mock.patch("cachito.workers.pkg_managers.npm.download_dependencies")
-def test_resolve_npm(mock_dd, mock_gpad, mock_exists, shrink_wrap, package_lock, package_and_deps):
+@mock.patch("cachito.workers.config.get_worker_config")
+def test_resolve_npm(
+    get_worker_config,
+    mock_dd,
+    mock_gpad,
+    mock_exists,
+    shrink_wrap,
+    package_lock,
+    package_and_deps,
+    tmpdir,
+):
+    get_worker_config.return_value = mock.Mock(cachito_bundles_dir=str(tmpdir))
     package_json = True
     mock_dd.return_value = {
         "@angular-devkit/architect@0.803.26",
@@ -615,7 +627,7 @@ def test_resolve_npm(mock_dd, mock_gpad, mock_exists, shrink_wrap, package_lock,
     mock_gpad.assert_called_once_with(package_json_path, lock_file_path)
     # We can't verify the actual correct deps value was passed in since the deps that were passed
     # in were mutated and mock does not keep a deepcopy of the function arguments.
-    mock_dd.assert_called_once_with(1, mock.ANY, mock.ANY, mock.ANY)
+    mock_dd.assert_called_once_with(RequestBundleDir(1).npm_deps_dir, mock.ANY, mock.ANY, mock.ANY)
 
 
 @mock.patch("cachito.workers.pkg_managers.npm.os.path.exists")

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from cachito.errors import CachitoError
+from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers import yarn
 from cachito.workers.pkg_managers.general_js import JSDependency
 
@@ -592,7 +593,9 @@ def test_replace_deps_in_yarn_lock_dependencies():
 @mock.patch("cachito.workers.pkg_managers.yarn._set_proxy_resolved_urls")
 @mock.patch("cachito.workers.pkg_managers.yarn._replace_deps_in_package_json")
 @mock.patch("cachito.workers.pkg_managers.yarn._replace_deps_in_yarn_lock")
+@mock.patch("cachito.workers.config.get_worker_config")
 def test_resolve_yarn(
+    get_worker_config,
     mock_replace_yarnlock,
     mock_replace_packjson,
     mock_set_proxy_urls,
@@ -602,7 +605,9 @@ def test_resolve_yarn(
     mock_get_package_and_deps,
     have_nexus_replacements,
     any_urls_in_yarn_lock,
+    tmpdir,
 ):
+    get_worker_config.return_value = mock.Mock(cachito_bundles_dir=str(tmpdir))
     n_pop_calls = 0
 
     def dict_pop_mocker():
@@ -656,7 +661,11 @@ def test_resolve_yarn(
     )
     mock_get_repo_url.assert_called_once_with(1)
     mock_download_deps.assert_called_once_with(
-        1, mock_deps, mock_get_repo_url.return_value, skip_deps={"foobar"}, pkg_manager="yarn"
+        RequestBundleDir(1).yarn_deps_dir,
+        mock_deps,
+        mock_get_repo_url.return_value,
+        skip_deps={"foobar"},
+        pkg_manager="yarn",
     )
     assert n_pop_calls == len(mock_deps) * 2
 


### PR DESCRIPTION
Function download_dependencies is used by npm and yarn resolve tasks
only. It should make no sense to pass a request id and construct the
download directory by the function itself.

Argument pkg_manager was used for creating npm or yarn specific download
dir and validating its value to ensure function is called correctly by
npm or yarn task. In fact, the ValueError due to an invalid pkg_manager
will never be raised at the runtime, instead it should be a programming
error if happens. Therefore, the corresponding change is to use an
assertion to ensure the correctness of the passed-in value.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>