### PR TITLE
Add ignore error flag for the go mod list command

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -256,7 +256,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
 
         log.info("Retrieving the list of package level dependencies")
         package_info = _load_list_deps(
-            run_gomod_cmd(["go", "list", "-deps", "-json", "./..."], run_params)
+            run_gomod_cmd(["go", "list", "-e", "-deps", "-json", "./..."], run_params)
         )
 
         packages = []


### PR DESCRIPTION
Due to some behavioral changes introduced in Go 1.16, the `go mod list -deps` command would give errors in some specific requests. 

This flag is meant to allow the use of Go 1.16 without breaking the builds that currently pass.