### PR TITLE
Use exponential backoff for gomod retries

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -32,7 +32,7 @@ class Config(object):
         },
     }
     cachito_deps_patch_batch_size = 50
-    cachito_gomod_download_max_tries = 3
+    cachito_gomod_download_max_tries = 5
     cachito_gomod_ignore_missing_gomod_file = True
     cachito_gomod_strict_vendor = False
     cachito_log_level = "INFO"


### PR DESCRIPTION
The go commands download dependencies into a temporary cache directory.
The directory is reused between retries, which means that, when retried,
the command can just pick up where it left off. Three attempts with
constant backoff might not be enough to give Athens a chance to recover.
Increase the default max tries to 5 and use exponential backoff instead.

By default, Cachito will wait for 1s -> 2s -> 4s -> 8s before retrying.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>