### PR TITLE
Metric for requests in progress. First custom prometheus metric

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -19,6 +19,7 @@ from cachito.common.utils import b64encode
 from cachito.errors import CachitoError, ValidationError
 from cachito.web import db
 from cachito.web.content_manifest import BASE_ICM
+from cachito.web.metrics import cachito_metrics
 from cachito.web.models import (
     ConfigFileBase64,
     EnvironmentVariable,
@@ -300,6 +301,8 @@ def create_request():
     db.session.add(request)
     db.session.commit()
 
+    cachito_metrics["gauge_state"].labels(state=request.state.state_name).inc()
+
     if current_user.is_authenticated:
         flask.current_app.logger.info(
             "The user %s submitted request %d", current_user.username, request.id
@@ -383,7 +386,9 @@ def create_request():
             "Failed to schedule the task for request %d. Failing the request.", request.id
         )
         error = "Failed to schedule the task to the workers. Please try again."
+        cachito_metrics["gauge_state"].labels(state=request.state.state_name).dec()
         request.add_state("failed", error)
+        cachito_metrics["gauge_state"].labels(state=request.state.state_name).inc()
         db.session.commit()
         raise CachitoError(error)
 
@@ -465,6 +470,8 @@ def patch_request(request_id):
     cleanup_nexus = []
     delete_logs = False
     if "state" in payload and "state_reason" in payload:
+        cachito_metrics["gauge_state"].labels(state=payload["state"]).inc()
+        cachito_metrics["gauge_state"].labels(state=request.state.state_name).dec()
         new_state = payload["state"]
         delete_bundle = new_state == "stale" and request.state.state_name != "failed"
         if new_state in ("stale", "failed"):

--- a/cachito/web/metrics.py
+++ b/cachito/web/metrics.py
@@ -1,9 +1,11 @@
 import os
 import socket
 
-from prometheus_client import multiprocess
+from prometheus_client import Gauge, multiprocess
 from prometheus_client.core import CollectorRegistry
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
+
+cachito_metrics = {}
 
 
 def init_metrics(app):
@@ -24,3 +26,8 @@ def init_metrics(app):
         default_labels={"host": hostname}, group_by="endpoint", defaults_prefix="cachito_flask"
     )
     metrics.init_app(app)
+    gauge_state = Gauge("requests", "Requests in each state", ["state"])
+
+    cachito_metrics["gauge_state"] = gauge_state
+
+    return metrics


### PR DESCRIPTION
Simple metric for requests in progress.  A sum() function in prometheus will fix the accounting issue of one API node  incrementing for a particular request and another node doing a decrementing as it moves between states.  