### PR TITLE
Improve content manifest endpoint performance

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -706,8 +706,6 @@ def get_content_manifest_by_requests():
     for request in requests:
         manifest = request.content_manifest.to_json()
         assembled_icm["image_contents"].extend(manifest["image_contents"])
-    if len(requests) == 1:
-        final_icm = assembled_icm
-    else:
-        final_icm = deep_sort_icm(assembled_icm)
-    return create_jsonify_response(final_icm)
+    if len(requests) > 1:
+        deep_sort_icm(assembled_icm)
+    return create_jsonify_response(assembled_icm)

--- a/cachito/web/content_manifest.py
+++ b/cachito/web/content_manifest.py
@@ -238,7 +238,8 @@ class ContentManifest:
         """
         icm = deepcopy(BASE_ICM)
         icm["image_contents"] = image_contents or []
-        return deep_sort_icm(icm)
+        deep_sort_icm(icm)
+        return icm
 
 
 class Package:

--- a/cachito/web/content_manifest.py
+++ b/cachito/web/content_manifest.py
@@ -3,8 +3,7 @@ import os
 import re
 import urllib.parse
 from copy import deepcopy
-from dataclasses import dataclass, field
-from typing import Optional
+from typing import List, Optional
 
 import flask
 import pkg_resources
@@ -242,7 +241,6 @@ class ContentManifest:
         return deep_sort_icm(icm)
 
 
-@dataclass(frozen=True)
 class Package:
     """
     A package within a content manifest.
@@ -250,12 +248,24 @@ class Package:
     It is used primarily to generate a package URL (purl).
     """
 
-    name: str
-    type: str
-    version: str
-    dev: bool = False
-    dependencies: list = field(default_factory=list)
-    path: Optional[str] = None
+    __slots__ = ("name", "type", "version", "dev", "dependencies", "path")
+
+    def __init__(
+        self,
+        name: str,
+        type: str,
+        version: str,
+        dev: bool = False,
+        path: Optional[str] = None,
+        dependencies: Optional[List] = None,
+    ):
+        """Initialize package data."""
+        self.name = name
+        self.type = type
+        self.version = version
+        self.dev = dev
+        self.dependencies = [] if dependencies is None else dependencies
+        self.path = path
 
     def __repr__(self):
         return (

--- a/cachito/web/utils.py
+++ b/cachito/web/utils.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from collections import OrderedDict
 
 from flask import request, url_for
 
@@ -10,8 +9,7 @@ def deep_sort_icm(orig_item):
 
     The function for sorting image content manifests
 
-    All dicts in the content manifest will be turned into OrderedDicts with alphabetically
-    sorted keys. All lists of dicts with a "purl" key will be sorted alphabetically by the
+    All lists of dicts with a "purl" key will be sorted alphabetically by the
     "purl" value. Any other objects will be left as is.
 
     :param orig_item: Original content manifest to be sorted
@@ -21,12 +19,10 @@ def deep_sort_icm(orig_item):
     if isinstance(orig_item, list):
         sorted_item = [deep_sort_icm(item) for item in orig_item]
         # If item is a list of dicts with the "purl" key, sort by the "purl" value
-        if sorted_item and isinstance(sorted_item[0], OrderedDict) and "purl" in sorted_item[0]:
+        if sorted_item and isinstance(sorted_item[0], dict) and "purl" in sorted_item[0]:
             sorted_item = sorted(sorted_item, key=lambda item: item["purl"])
     elif isinstance(orig_item, dict):
-        items = ((k, deep_sort_icm(v)) for k, v in orig_item.items())
-        # Sort items by key
-        sorted_item = OrderedDict(sorted(items, key=lambda keyval: keyval[0]))
+        sorted_item = {k: deep_sort_icm(v) for k, v in orig_item.items()}
     else:
         sorted_item = orig_item
     return sorted_item

--- a/cachito/web/utils.py
+++ b/cachito/web/utils.py
@@ -21,23 +21,20 @@ def deep_sort_icm(orig_item):
     :return: Recursively sorted dict or list according to orig_item
     :rtype: Any
     """
-    if isinstance(orig_item, dict):
-        sorted_item = {}
-        for k, v in orig_item.items():
-            if v and isinstance(v, CONTAINER_TYPES):
-                sorted_item[k] = deep_sort_icm(v)
-            else:
-                sorted_item[k] = v
-        return sorted_item
-
-    if isinstance(orig_item, list):
-        sorted_item = [deep_sort_icm(item) for item in orig_item]
+    if orig_item and isinstance(orig_item, dict):
+        keys = orig_item.keys()
+        for key in keys:
+            val = orig_item[key]
+            if val and isinstance(val, CONTAINER_TYPES):
+                deep_sort_icm(val)
+    elif orig_item and isinstance(orig_item, list):
+        for item in orig_item:
+            deep_sort_icm(item)
         # If item is a list of dicts with the "purl" key, sort by the "purl" value
-        if sorted_item and isinstance(sorted_item[0], dict) and "purl" in sorted_item[0]:
-            sorted_item.sort(key=SORT_KEY_BY_PURL)
-        return sorted_item
-
-    raise TypeError("Unknown type is included in the content manifest.")
+        if isinstance(orig_item[0], dict) and "purl" in orig_item[0]:
+            orig_item.sort(key=SORT_KEY_BY_PURL)
+    else:
+        raise TypeError("Unknown type is included in the content manifest.")
 
 
 def pagination_metadata(pagination_query, **kwargs):

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1565,7 +1565,7 @@ def test_fetch_request_content_manifest_go(
         "image_contents": [image_content],
         "metadata": {"icm_version": 1, "icm_spec": json_schema_url, "image_layer_index": -1},
     }
-    expected = deep_sort_icm(expected)
+    deep_sort_icm(expected)
 
     # mock packages.json file contents
     sample_pkg_lvl_pkg["dependencies"] = sample_pkg_deps
@@ -2083,7 +2083,8 @@ def test_get_content_manifests_by_requests(app, client, db, auth_env, tmpdir):
         else:
             assembled_icm = BASE_ICM.copy()
             assembled_icm["image_contents"] = expected_image_contents
-            assert deep_sort_icm(assembled_icm) == json.loads(resp.data)
+            deep_sort_icm(assembled_icm)
+            assert assembled_icm == json.loads(resp.data)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,7 +59,8 @@ def test_deep_sort_icm(orig_items):
             "metadata": {"icm_spec": "sample-URL", "icm_version": 1, "image_layer_index": -1},
         }
     ]
-    assert deep_sort_icm(orig_items) == expected
+    deep_sort_icm(orig_items)
+    assert orig_items == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,3 +60,24 @@ def test_deep_sort_icm(orig_items):
         }
     ]
     assert deep_sort_icm(orig_items) == expected
+
+
+@pytest.mark.parametrize(
+    "error_icm",
+    [
+        "image content manifest",
+        {
+            "image_contents": [
+                {
+                    "dependencies": [],
+                    "purl": "0sample-URL",
+                    "sources": [("purl", "0sample-URL"), ("purl", "1sample-URL")],
+                },
+            ],
+            "metadata": {"icm_spec": "sample-URL", "icm_version": 1, "image_layer_index": -1},
+        },
+    ],
+)
+def test_deep_sort_icm_raises_error_when_unknown_type_included(error_icm):
+    with pytest.raises(TypeError, match="Unknown type is included in the content manifest"):
+        deep_sort_icm(error_icm)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from collections import OrderedDict
 
 import pytest
 
@@ -31,44 +30,33 @@ from cachito.web.utils import deep_sort_icm
                         "sources": [{"purl": "1sample-URL"}, {"purl": "0sample-URL"}],
                     },
                 ],
-            }
+            },
         ],
     ],
 )
 def test_deep_sort_icm(orig_items):
     expected = [
-        OrderedDict(
-            {
-                "image_contents": [
-                    OrderedDict(
-                        {
-                            "dependencies": [],
-                            "purl": "0sample-URL",
-                            "sources": [
-                                OrderedDict({"purl": "0sample-URL"}),
-                                OrderedDict({"purl": "1sample-URL"}),
-                            ],
-                        }
-                    ),
-                    OrderedDict(
-                        {
-                            "dependencies": [
-                                OrderedDict({"purl": "0sample-URL"}),
-                                OrderedDict({"purl": "1sample-URL"}),
-                                OrderedDict({"purl": "2sample-URL"}),
-                                OrderedDict({"purl": "3sample-URL"}),
-                                OrderedDict({"purl": "4sample-URL"}),
-                                OrderedDict({"purl": "5sample-URL"}),
-                            ],
-                            "purl": "1sample-URL",
-                            "sources": [],
-                        }
-                    ),
-                ],
-                "metadata": OrderedDict(
-                    {"icm_spec": "sample-URL", "icm_version": 1, "image_layer_index": -1}
-                ),
-            }
-        ),
+        {
+            "image_contents": [
+                {
+                    "dependencies": [],
+                    "purl": "0sample-URL",
+                    "sources": [{"purl": "0sample-URL"}, {"purl": "1sample-URL"}],
+                },
+                {
+                    "dependencies": [
+                        {"purl": "0sample-URL"},
+                        {"purl": "1sample-URL"},
+                        {"purl": "2sample-URL"},
+                        {"purl": "3sample-URL"},
+                        {"purl": "4sample-URL"},
+                        {"purl": "5sample-URL"},
+                    ],
+                    "purl": "1sample-URL",
+                    "sources": [],
+                },
+            ],
+            "metadata": {"icm_spec": "sample-URL", "icm_version": 1, "image_layer_index": -1},
+        }
     ]
     assert deep_sort_icm(orig_items) == expected


### PR DESCRIPTION
All the performance measurement is based on a request's packages data generated from:

* Repository: https://github.com/stackrox/rox.git
* Reference: 73de8f2f5f4490ab303e892c11e2cedf008b7ff5
* Package manager: gomod

Some basic data:

* 317 packages and 50245 dependencies included in the packages data.
* Each of them is a Python dict object.
* The file size of the packages data is 5.4M
* 1341300 deep_sort_icm function calls.

Every commit in this PR as detail information about each improvement.

As a result, based on the packages data,

* Less memory is used to generate the `content_manifest.Package` objects.
* Less memory is used by the function `deep_sort_icm`.
* Lots of function calls, e.g. `deep_sort_icm` and `isinstance`, are avoided.

Overall, about 52.6 MiB memory is saved in the deep_sort_icm function call inside generate_icm, from 133.0 MiB down to 80.4 MiB.

There is still room to improve the memory usage and even make the content manifest generation much faster.

One major thought is to remove the `deep_sort_icm` function and sort the `dependencies` and `sources` just after they are collected, and sort the final `image_contents` at once. It looks like we don't need a such general function to sort a potential huge dict object containing the content manifest, as the schema of the content manifest is known and certainty. It is probably good to implement it along with the refactor of the content manifest generation.