### PR TITLE
Disable celery heartbeats

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -34,4 +34,4 @@ ENV GIT_COMMITTER_NAME=cachito \
     GIT_AUTHOR_EMAIL=cachito@localhost
 
 EXPOSE 8080
-CMD ["celery", "-A", "cachito.workers.tasks", "worker", "--loglevel=info"]
+CMD ["celery", "-A", "cachito.workers.tasks", "worker", "--without-heartbeat", "--loglevel=info"]


### PR DESCRIPTION
By disabling the Celery's heartbeat, we intend to avoid the connection leak issue that is happening at the Rabbitmq pod.

It seems that whenever the heartbeat fails to verify the worker's connection, it [spawns a new connection ](https://github.com/celery/kombu/blob/2aeb73248b4a0bf8ad3de81a0f40733e7cd42255/kombu/connection.py#L870)that does not get closed. This will cause the connections to accumulate, increasing the memory usage constantly and eventually blocking all new connections, essentialy crashing Cachito.

It's important to notice that this heartbeat is implemented at the application level in Celery, and duplicates the goals of the [AMQP heartbeat](https://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-heartbeat) to some extent.