### PR TITLE
Fix Request database model

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -286,7 +286,7 @@ class Request(db.Model):
     """A Cachito user request."""
 
     id = db.Column(db.Integer, primary_key=True)
-    created = db.Column(db.DateTime(), nullable=False, index=True, default=sqlalchemy.func.now())
+    created = db.Column(db.DateTime(), nullable=True, index=True, default=sqlalchemy.func.now())
     repo = db.Column(db.String, nullable=False, index=True)
     ref = db.Column(db.String, nullable=False, index=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"))


### PR DESCRIPTION
Model for Request table had a wrong
"created" column, but a migration
(976b7ef3ec86_add_created_field.py)
had a correct one. We need to bring
a consistency and keep nullable=True
for both occurrences.

CLOUDBLD-6469

Signed-off-by: Elina Akhmanova <eakhmano@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
