### PR TITLE
CI: Don't run pytest in verbose mode

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ setenv =
 usedevelop = true
 
 commands =
-    py.test -vvv \
+    py.test \
         --ignore tests/integration \
         --cov-config .coveragerc --cov=cachito --cov-report term \
         --cov-report xml --cov-report html {posargs}


### PR DESCRIPTION
Life is too short to spend it by scrolling through CI log

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
