### PR TITLE
Revert "Disable celery heartbeats"

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -34,4 +34,4 @@ ENV GIT_COMMITTER_NAME=cachito \
     GIT_AUTHOR_EMAIL=cachito@localhost
 
 EXPOSE 8080
-CMD ["celery", "-A", "cachito.workers.tasks", "worker", "--without-heartbeat", "--loglevel=info"]
+CMD ["celery", "-A", "cachito.workers.tasks", "worker", "--loglevel=info"]


### PR DESCRIPTION
This reverts commit 49c19fd.

This change was intended to mitigate the connection leak caused by Kombu when connection failures happen.

We decided it's no longer useful to pursue this path.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
