### PR TITLE
Log api/v1/status/short endpoint errors

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -61,6 +61,7 @@ def get_status_short():
         status(short=True)
         retval = {"ok": True}
     except CachitoError as e:
+        flask.current_app.logger.error(e)
         retval = {"ok": False, "reason": str(e)}
 
     return flask.jsonify(retval), 200 if retval["ok"] else 503


### PR DESCRIPTION
Since the CachitoError is caught in this endpoint, its details are hidden from the logs, and need to be explicitly printed. 

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
