### PR TITLE
Fix date type check for /request-metrics/summary endpoint

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from collections import OrderedDict
 from copy import deepcopy
-from datetime import date, datetime, time
+from datetime import date, datetime
 from typing import Any, Dict, Union
 
 import flask
@@ -35,7 +35,7 @@ from cachito.web.models import (
     is_request_ref_valid,
 )
 from cachito.web.status import status
-from cachito.web.utils import deep_sort_icm, pagination_metadata, str_to_bool
+from cachito.web.utils import deep_sort_icm, normalize_end_date, pagination_metadata, str_to_bool
 from cachito.workers import tasks
 
 api_v1 = flask.Blueprint("api_v1", __name__)
@@ -744,6 +744,8 @@ class RequestMetricsArgs(pydantic.BaseModel):
     finished_from: Union[datetime, date, None]
     finished_to: Union[datetime, date, None]
 
+    _normalize_end_date = pydantic.validator("finished_to", allow_reuse=True)(normalize_end_date)
+
 
 @api_v1.route("/request-metrics", methods=["GET"])
 def get_request_metrics():
@@ -751,13 +753,10 @@ def get_request_metrics():
     max_per_page = flask.current_app.config["CACHITO_MAX_PER_PAGE"]
     args = RequestMetricsArgs(**flask.request.args)
     query = RequestState.get_final_states_query().order_by(RequestState.request_id.desc())
-    finished_to = args.finished_to
-    if type(finished_to) is date:
-        finished_to = datetime.combine(finished_to, time.max)
     if args.finished_from:
         query = query.filter(RequestState.updated >= args.finished_from)
-    if finished_to:
-        query = query.filter(RequestState.updated <= finished_to)
+    if args.finished_to:
+        query = query.filter(RequestState.updated <= args.finished_to)
 
     pagination_query = query.paginate(max_per_page=max_per_page)
     return flask.jsonify(
@@ -784,18 +783,17 @@ class RequestMetricsSummaryArgs(pydantic.BaseModel):
     finished_from: Union[datetime, date]
     finished_to: Union[datetime, date]
 
+    _normalize_end_date = pydantic.validator("finished_to", allow_reuse=True)(normalize_end_date)
+
 
 @api_v1.route("/request-metrics/summary", methods=["GET"])
 def get_request_metrics_summary():
     """Return a summary about completed requests for a given period of time."""
     args = RequestMetricsSummaryArgs(**flask.request.args)
-    finished_to = args.finished_to
-    if isinstance(finished_to, date):
-        finished_to = datetime.combine(finished_to, time.max)
     requests = (
         RequestState.get_final_states_query()
         .filter(RequestState.updated >= args.finished_from)
-        .filter(RequestState.updated <= finished_to)
+        .filter(RequestState.updated <= args.finished_to)
     ).subquery()
 
     states_summary = dict.fromkeys(["complete", "failed"], 0)

--- a/cachito/web/utils.py
+++ b/cachito/web/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from datetime import date, datetime, time
 from operator import itemgetter
+from typing import Union
 
 from flask import request, url_for
 
@@ -98,3 +100,17 @@ def str_to_bool(item):
         return item.lower() in ("true", "1")
     else:
         return False
+
+
+def normalize_end_date(value: Union[datetime, date, None]):
+    """
+    Convert date value to the end of the day datetime.
+
+    The function doesn't touch values of any other input types.
+    Example:
+        Input value: date(2021, 10, 21)
+        Output value: datetime(2021, 10, 21, 23, 59, 59, 999999)
+    """
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return datetime.combine(value, time.max)
+    return value

--- a/tests/integration/test_request_metrics.py
+++ b/tests/integration/test_request_metrics.py
@@ -56,3 +56,11 @@ def test_get_request_metrics_summary(api_client):
     assert summary["duration_avg"] > 0
     assert summary["time_in_queue_avg"] > 0
     assert summary["time_in_queue_95"] > 0
+
+    # Check empty datetime range
+    resp = api_client.fetch_request_metrics_summary(
+        finished_from=finished_from, finished_to=finished_from,
+    )
+    assert resp.status_code == 200
+    summary = resp.json()
+    assert summary["total"] == 0


### PR DESCRIPTION
Add validator for 'finished_to' query parameter which allows to determine date values
and convert them into values that correspond to the end of the day.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
