### PR TITLE
Fix Request.created JSON representation

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -378,7 +378,7 @@ class Request(db.Model):
             env_vars_json[env_var.name] = env_var.value
         rv = {
             "id": self.id,
-            "created": self.created.isoformat(),
+            "created": None if self.created is None else self.created.isoformat(),
             "repo": self.repo,
             "ref": self.ref,
             "pkg_managers": pkg_managers,


### PR DESCRIPTION
CLOUDBLD-6469

Current code calls isoformat() on Request.created, even when it is None
from database migration. Add a check to prevent calling isoformat() on
None

Signed-off-by: Daniel Cho <dacho@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
