### PR TITLE
Allow go submodule replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,10 @@ Custom configuration for the Celery workers are listed below:
   by local paths, e.g. `replace github.com/org/some-module => ./staging/src/some-module`. This is a
   dictionary where keys are module names and values are lists of packages that the corresponding module
   is allowed to replace. The packages may contain wildcards supported by Python's `fnmatch`, e.g.
-  `github.com/org/*` (this will allow all packages starting with `github.com/org/`).
+  `github.com/org/*` (this will allow all packages starting with `github.com/org/`). A submodule allowed
+  to be replaced by a local module by default (e.g. `<this-module>/submodule => ./local-module`),where a
+  submodule is an internal module (placed in non-root directory) in a multi-module hierarchy (read more about
+  [multi-module repositories](https://github.com/golang/go/wiki/Modules#faqs--multi-module-repositories)).
 * `cachito_request_file_logs_dir` - the directory to write the request specific log files. If `None`, per
   request log files are not created. This defaults to `None`.
 * `cachito_request_file_logs_format` - the format for the log messages of the request specific log files.
@@ -761,7 +764,8 @@ packages use `go-package`. Packages can be matched to their parent modules based
 names always start with the module name. In the `dependencies` section of a Go package, Cachito
 will list only the packages that were imported by that package (a.k.a. package level deps). In the
 `dependencies` section of a Go module, Cachito will list all the modules specified as dependencies
-in `go.mod`.
+in `go.mod`. Submodules allowed to be replaced by a local module by default, no entry required
+in the `cachito_gomod_file_deps_allowlist` config variable.
 
 In the Content Manifests shipped at the `/api/v1/requests/<id>/content-manifest` API endpoint, all
 top-level purls and the purls of all `dependencies` refer to Go packages. The purls for the parent

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -14,7 +14,7 @@ from cachito.errors import CachitoError, ValidationError
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers import gomod
 from cachito.workers.pkg_managers.gomod import (
-    _fail_unless_allowlisted,
+    _fail_unless_allowed,
     _get_allowed_local_deps,
     _merge_bundle_dirs,
     _merge_files,
@@ -651,7 +651,7 @@ def test_merge_files(file_1_content, file_2_content, result_file_content):
         assert_directories_equal(dir_2, dir_3)
 
 
-@mock.patch("cachito.workers.pkg_managers.gomod._fail_unless_allowlisted")
+@mock.patch("cachito.workers.pkg_managers.gomod._fail_unless_allowed")
 def test_vet_local_deps(mock_fail_allowlist):
     dependencies = [
         {"name": "foo", "version": "./local/foo"},
@@ -707,6 +707,7 @@ def test_vet_local_deps_parent_dir(path):
         ("example/module", "example/package", ["*/package"], None),
         ("example/module", "example/package", ["*/*"], None),
         ("example/module", "example/package", ["*"], None),
+        ("example/module", "example/module/submodule", [], None),
         (
             "example/module",
             "example/package",
@@ -751,12 +752,12 @@ def test_vet_local_deps_parent_dir(path):
         ),
     ],
 )
-def test_fail_unless_allowlisted(module_name, package_name, allowed_patterns, expect_error):
+def test_fail_unless_allowed(module_name, package_name, allowed_patterns, expect_error):
     if expect_error:
         with pytest.raises(CachitoError, match=re.escape(expect_error)):
-            _fail_unless_allowlisted(module_name, package_name, allowed_patterns)
+            _fail_unless_allowed(module_name, package_name, allowed_patterns)
     else:
-        _fail_unless_allowlisted(module_name, package_name, allowed_patterns)
+        _fail_unless_allowed(module_name, package_name, allowed_patterns)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Always allow go sobmodules as
local dependencies (even without
a replacement rule).

CLOUDBLD-5554

Signed-off-by: Elina Akhmanova <eakhmano@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
