### PR TITLE
CI: fix coveralls

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -36,7 +36,8 @@ jobs:
         COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
       run: |
-        pip3 install --upgrade pip
+        sudo apt install python3-testresources
+        pip3 install --upgrade pip==20.0.2
         pip3 install --upgrade setuptools
         pip3 install --upgrade coveralls
         coveralls --service=github
@@ -48,7 +49,8 @@ jobs:
     steps:
       - name: Finished
         run: |
-          pip3 install --upgrade pip
+          sudo apt install python3-testresources
+          pip3 install --upgrade pip==20.0.2
           pip3 install --upgrade setuptools
           pip3 install --upgrade coveralls
           coveralls --finish --service=github

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -40,7 +40,7 @@ jobs:
         pip3 install --upgrade pip==20.0.2
         pip3 install --upgrade setuptools
         pip3 install --upgrade coveralls
-        coveralls --service=github
+        /home/runner/.local/bin/coveralls --service=github
 
   coveralls-finish:
     name: Finish coveralls-python
@@ -53,7 +53,7 @@ jobs:
           pip3 install --upgrade pip==20.0.2
           pip3 install --upgrade setuptools
           pip3 install --upgrade coveralls
-          coveralls --finish --service=github
+          /home/runner/.local/bin/coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
There is a dependencies conflict about version of pip, until this is
resolved older version of pip must be used

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
