### PR TITLE
Upgrade Golang version to 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ Offline Installations   | ✓     | x   | x   | x    |
 
 Tool   | Version |
 ---    | ---     |
-Go     | 1.16.8  |
+Go     | 1.17    |
 Npm    | 8.0.0   |
 Node   | 16.11.0 |
 Pip    | 21.2.3  |

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -18,7 +18,11 @@ RUN dnf -y install \
     python3-pip \
     python3-setuptools \
     strace \
+    https://kojipkgs.fedoraproject.org//packages/golang/1.17/2.fc36/noarch/golang-src-1.17-2.fc36.noarch.rpm \
+    https://kojipkgs.fedoraproject.org//packages/golang/1.17/2.fc36/x86_64/golang-1.17-2.fc36.x86_64.rpm \
+    https://kojipkgs.fedoraproject.org//packages/golang/1.17/2.fc36/x86_64/golang-bin-1.17-2.fc36.x86_64.rpm \
     && dnf clean all
+
 COPY . .
 
 # All the requirements except pyarn should already be installed


### PR DESCRIPTION
This PR upgrades the Golang version in the worker images using RPMs from Fedora 36, since this version was scrapped from Fedora 35.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
