### PR TITLE
Change log level for failures when uploading to Nexus

### DIFF
--- a/cachito/workers/nexus.py
+++ b/cachito/workers/nexus.py
@@ -384,7 +384,7 @@ def upload_asset_only_component(repo_name, repo_type, component_path, to_nexus_h
     try:
         upload_component(params, payload, to_nexus_hoster)
     except CachitoError:
-        log.exception("Failed to upload %r to the %r Nexus repository", component_path, repo_type)
+        log.warning("Failed to upload %r to the %r Nexus repository", component_path, repo_type)
         raise
 
 
@@ -457,7 +457,7 @@ def upload_component(params, payload, to_nexus_hoster, additional_data=None):
         raise CachitoError("Could not connect to the Nexus instance to upload a component")
 
     if not rv.ok:
-        log.error(
+        log.warning(
             "Failed to upload a component with the status code %d and the text: %s",
             rv.status_code,
             rv.text,


### PR DESCRIPTION
CLOUDBLD-7717

Failures do not have impact on the success of the request since Cachito
is able to recover from it.

Signed-off-by: ejegrova <ejegrova@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
