### PR TITLE
Fix "... unexpected checksum value" error message in log

### DIFF
--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -119,7 +119,6 @@ def verify_checksum(file_path: str, checksum_info: ChecksumInfo, chunk_size: int
         hasher = hash_file(file_path, chunk_size, checksum_info.algorithm)
     except UnknownHashAlgorithm as exc:
         msg = f"Cannot perform checksum on the file {filename}, {exc}"
-        log.exception(msg)
         raise CachitoError(msg)
 
     computed_hexdigest = hasher.hexdigest()
@@ -129,7 +128,6 @@ def verify_checksum(file_path: str, checksum_info: ChecksumInfo, chunk_size: int
             f"The file {filename} has an unexpected checksum value, "
             f"expected {checksum_info.hexdigest} but computed {computed_hexdigest}"
         )
-        log.error(msg)
         raise CachitoError(msg)
 
 

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -464,7 +464,11 @@ def upload_non_registry_dependency(
         )
         dep_archive = os.path.join(temp_dir, stdout.strip())
         if checksum_info:
-            verify_checksum(dep_archive, checksum_info)
+            try:
+                verify_checksum(dep_archive, checksum_info)
+            except CachitoError as e:
+                log.error("%s", e)
+                raise
 
         package_json_rel_path = find_package_json(dep_archive)
         if not package_json_rel_path:

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1855,7 +1855,7 @@ def _verify_hash(download_path, hashes):
             log.info(f"Checksum of {download_path.name} matches: {algorithm}:{digest}")
             return
         except CachitoError as e:
-            log.error("%s", e)
+            log.warning("%s", e)
 
     msg = f"Failed to verify checksum of {download_path.name} against any of the provided hashes"
     raise CachitoError(msg)


### PR DESCRIPTION
CLOUDBLD-7718

Pip package manager verifies each hash until finds the correct one.
Such behaviour cause a log pollution by irrelevant error messages.

The patch removes any logging from the generic verify_checksum function
and delegate it to a calling function. Also it writes warning instead of
error to the log in pip._verify_checksum.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
