### PR TITLE
Ignore versions in package containing verification

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -539,7 +539,8 @@ def _fail_unless_allowed(module_name: str, package_name: str, allowed_patterns: 
     * package_name is a submodule of module_name
     * package_name replacement is allowed according to allowed_patterns
     """
-    is_submodule = contains_package(module_name, package_name)
+    versionless_module_name = MODULE_VERSION_RE.sub("", module_name)
+    is_submodule = contains_package(versionless_module_name, package_name)
     if not is_submodule and not any(fnmatch.fnmatch(package_name, pat) for pat in allowed_patterns):
         raise CachitoError(
             f"The module {module_name} is not allowed to replace {package_name} with a local "

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -753,6 +753,9 @@ def test_vet_local_deps_parent_dir(path):
         ("example/module", "example/package", ["*/*"], None),
         ("example/module", "example/package", ["*"], None),
         ("example/module", "example/module/submodule", [], None),
+        ("example/module/v1", "example/module/submodule", [], None),
+        ("example/module/v1", "example/module/submodule/v2", [], None),
+        ("example/module", "example/module/submodule/v1", [], None),
         (
             "example/module",
             "example/package",
@@ -794,6 +797,12 @@ def test_vet_local_deps_parent_dir(path):
             "example/package",
             ["*/example/package"],
             "The module example/module is not allowed to replace example/package",
+        ),
+        (
+            "example/module/v",
+            "example/module/submodule",
+            [],
+            "The module example/module/v is not allowed to replace example/module/submodule",
         ),
     ],
 )


### PR DESCRIPTION
We need to return True when we check that a package
example.com/foo/v1 contains a subpackage
example.com/foo/bar. Therefore we need to use only
versionless names of packages.
Packages can have only major versions (for more
information see: research.swtch.com/vgo-import).

CLOUDBLD-8076

Signed-off-by: Elina Akhmanova <eakhmano@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
