### PR TITLE
Fix integration tests for cached dependecies

### DIFF
--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -137,6 +137,18 @@ gomod_cached_deps:
   response_expectations:
     packages:
     - dependencies:
+      - name: "bytes"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "errors"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "fmt"
+        replaces: null
+        type: "go-package"
+        version: null
       - name: "golang.org/x/text/internal/tag"
         replaces: null
         type: "go-package"
@@ -145,6 +157,90 @@ gomod_cached_deps:
         replaces: null
         type: "go-package"
         version: "v0.0.0-20170915032832-14c0d48ead0c"
+      - name: "internal/abi"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/bytealg"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/cpu"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/fmtsort"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/goexperiment"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/itoa"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/oserror"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/poll"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/race"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/reflectlite"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/syscall/execenv"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/syscall/unix"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/testlog"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "internal/unsafeheader"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "io"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "io/fs"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "math"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "math/bits"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "os"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "path"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "reflect"
+        replaces: null
+        type: "go-package"
+        version: null
       - name: "rsc.io/quote"
         replaces: null
         type: "go-package"
@@ -153,6 +249,62 @@ gomod_cached_deps:
         replaces: null
         type: "go-package"
         version: "v1.3.0"
+      - name: "runtime"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "runtime/internal/atomic"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "runtime/internal/math"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "runtime/internal/sys"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "sort"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "strconv"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "strings"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "sync"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "sync/atomic"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "syscall"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "time"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "unicode"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "unicode/utf8"
+        replaces: null
+        type: "go-package"
+        version: null
+      - name: "unsafe"
+        replaces: null
+        type: "go-package"
+        version: null
       name: "github.com/cachito-testing/cachito-gomod-with-deps"
       type: "go-package"
       version: "MAIN_VERSION"
@@ -177,6 +329,18 @@ gomod_cached_deps:
       type: "gomod"
       version: "MAIN_VERSION"
     dependencies:
+    - name: "bytes"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "errors"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "fmt"
+      replaces: null
+      type: "go-package"
+      version: null
     - name: "golang.org/x/text/internal/tag"
       replaces: null
       type: "go-package"
@@ -185,6 +349,90 @@ gomod_cached_deps:
       replaces: null
       type: "go-package"
       version: "v0.0.0-20170915032832-14c0d48ead0c"
+    - name: "internal/abi"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/bytealg"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/cpu"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/fmtsort"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/goexperiment"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/itoa"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/oserror"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/poll"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/race"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/reflectlite"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/syscall/execenv"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/syscall/unix"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/testlog"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "internal/unsafeheader"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "io"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "io/fs"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "math"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "math/bits"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "os"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "path"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "reflect"
+      replaces: null
+      type: "go-package"
+      version: null
     - name: "rsc.io/quote"
       replaces: null
       type: "go-package"
@@ -193,6 +441,62 @@ gomod_cached_deps:
       replaces: null
       type: "go-package"
       version: "v1.3.0"
+    - name: "runtime"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "runtime/internal/atomic"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "runtime/internal/math"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "runtime/internal/sys"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "sort"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "strconv"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "strings"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "sync"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "sync/atomic"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "syscall"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "time"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "unicode"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "unicode/utf8"
+      replaces: null
+      type: "go-package"
+      version: null
+    - name: "unsafe"
+      replaces: null
+      type: "go-package"
+      version: null
     - name: "github.com/cachito-testing/cachito-gomod-without-deps"
       replaces: null
       type: "gomod"
@@ -215,10 +519,48 @@ gomod_cached_deps:
   content_manifest:
     purl: "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-with-deps@MAIN_VERSION"
     dep_purls:
+    - "pkg:golang/bytes"
+    - "pkg:golang/errors"
+    - "pkg:golang/fmt"
     - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/internal%2Fabi"
+    - "pkg:golang/internal%2Fbytealg"
+    - "pkg:golang/internal%2Fcpu"
+    - "pkg:golang/internal%2Ffmtsort"
+    - "pkg:golang/internal%2Fgoexperiment"
+    - "pkg:golang/internal%2Fitoa"
+    - "pkg:golang/internal%2Foserror"
+    - "pkg:golang/internal%2Fpoll"
+    - "pkg:golang/internal%2Frace"
+    - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsyscall%2Fexecenv"
+    - "pkg:golang/internal%2Fsyscall%2Funix"
+    - "pkg:golang/internal%2Ftestlog"
+    - "pkg:golang/internal%2Funsafeheader"
+    - "pkg:golang/io"
+    - "pkg:golang/io%2Ffs"
+    - "pkg:golang/math"
+    - "pkg:golang/math%2Fbits"
+    - "pkg:golang/os"
+    - "pkg:golang/path"
+    - "pkg:golang/reflect"
     - "pkg:golang/rsc.io%2Fquote@v1.5.2"
     - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+    - "pkg:golang/runtime"
+    - "pkg:golang/runtime%2Finternal%2Fatomic"
+    - "pkg:golang/runtime%2Finternal%2Fmath"
+    - "pkg:golang/runtime%2Finternal%2Fsys"
+    - "pkg:golang/sort"
+    - "pkg:golang/strconv"
+    - "pkg:golang/strings"
+    - "pkg:golang/sync"
+    - "pkg:golang/sync%2Fatomic"
+    - "pkg:golang/syscall"
+    - "pkg:golang/time"
+    - "pkg:golang/unicode"
+    - "pkg:golang/unicode%2Futf8"
+    - "pkg:golang/unsafe"
     source_purls:
     - "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-without-deps@DEP_VERSION"
     - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"

--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -352,6 +352,8 @@ def replace_by_rules(orig_str, replace_rules):
     :return: string with replaced values
     :rtype: str
     """
+    if orig_str is None:
+        return None
     res_string = orig_str
     for s, r in replace_rules.items():
         if s in res_string:


### PR DESCRIPTION
CLOUDBLD-7841

Include stdlib dependencies for gomod to the corresponding fixtures.
Check dependency version for null.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
