### PR TITLE
Remove unused tables in local docker-compose environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       pip3 uninstall -y cachito &&
       python3 setup.py develop --no-deps &&
       cachito wait-for-db &&
-      cachito db upgrade &&
+      cachito db upgrade -x delete_data=True &&
       flask run --reload --host 0.0.0.0 --port 8080
     environment:
       FLASK_ENV: development


### PR DESCRIPTION
The change made in #581 dropped several unused tables from the DB. But the docker-compose file was not adjusted accordingly, causing these tables to still exist in the local environment.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
