### PR TITLE
[Draft] Allow to use git+ssh protocol to fetch application sources

### DIFF
--- a/cachito/workers/tasks/celery.py
+++ b/cachito/workers/tasks/celery.py
@@ -10,7 +10,8 @@ from cachito.workers.celery_logging import (
     setup_task_logging,
     setup_task_logging_customization,
 )
-from cachito.workers.config import app, validate_celery_config  # noqa: F401
+from cachito.workers.config import app  # noqa: F401
+from cachito.workers.config import populate_ssh_known_hosts, validate_celery_config
 
 # Workaround https://github.com/celery/celery/issues/5416
 if celery.version_info < (4, 3) and sys.version_info >= (3, 7):  # pragma: no cover
@@ -22,6 +23,7 @@ if celery.version_info < (4, 3) and sys.version_info >= (3, 7):  # pragma: no co
 
 
 celeryd_init.connect(validate_celery_config)
+celeryd_init.connect(populate_ssh_known_hosts)
 task_prerun.connect(setup_task_logging_customization)
 task_prerun.connect(setup_task_logging)
 task_postrun.connect(cleanup_task_logging_customization)


### PR DESCRIPTION
CLOUDBLD-8038

Extend ~/.ssh/known_hosts with hosts specified by cachito_git_ssh_known_hosts config option.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
