### PR TITLE
Fix Yarn integration test data

### DIFF
--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -756,7 +756,7 @@ yarn_cached_deps:
   ssh_main_repo: "git@github.com:cachito-testing/cachito-yarn-with-deps.git"
   ssh_dep_repo: "git@github.com:cachito-testing/cachito-yarn-without-deps.git"
   # dummy dependency to test change in package.json
-  test_dependency: '"assertion-error": "1.1.0"'
+  test_dependency: '"assertion-error": "^1.1.0"'
   pkg_managers: [ "yarn" ]
   # Parts of the Cachito response to check
   response_expectations:


### PR DESCRIPTION
CLOUDBLD-3914

New code changes require a corresponding test_dependency addition to
yarn.lock

Signed-off-by: Daniel Cho <dacho@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
