### PR TITLE
GH workflow: allow manual trigger for workflow

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs: {}
 
 jobs:
   tests:


### PR DESCRIPTION
This will enable abilitiy to run workflow from GH web

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
