### PR TITLE
Enhance error message when a requirement file does not exist.

### DIFF
--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1992,9 +1992,12 @@ def _download_from_requirement_files(request_id, files):
     :return: Info about downloaded packages; see download_dependencies return docs for further
         reference
     :rtype: list[dict]
+    :raises CachitoError: If requirement file does not exist
     """
     requirements = []
     for req_file in files:
+        if not os.path.exists(req_file):
+            raise CachitoError(f"Following requirement file has an invalid path: {req_file}")
         requirements.extend(download_dependencies(request_id, PipRequirementsFile(req_file)))
     return requirements
 

--- a/tests/integration/test_pip_packages.py
+++ b/tests/integration/test_pip_packages.py
@@ -27,3 +27,32 @@ def test_failing_pip_local_path(test_env):
         f"#{completed_response.id}: Request failed correctly, but with unexpected message: "
         f"{completed_response.data['state_reason']}. Expected message was: {error_msg}"
     )
+
+
+def test_failing_pip_invalid_req_path(test_env):
+    """
+    Validate failing of the pip package request with a non-existent requirement file path.
+
+    Process:
+    Send new request to the Cachito API
+    Send request to check status of existing request
+
+    Checks:
+    * Check that the request fails with expected error
+    """
+    env_data = utils.load_test_data("pip_packages.yaml")["local_path"]
+    client = utils.Client(test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"))
+    invalid_path = "foo.txt"
+    initial_response = client.create_new_request(
+        payload={
+            "repo": env_data["repo"],
+            "ref": env_data["ref"],
+            "pkg_managers": ["pip"],
+            "packages": {"pip": [{"requirements_files": [invalid_path]}]},
+        }
+    )
+    completed_response = client.wait_for_complete_request(initial_response)
+    assert completed_response.status == 200
+    assert completed_response.data["state"] == "failed"
+    error_msg = "Following requirement file has an invalid path: "
+    assert all(msg in completed_response.data["state_reason"] for msg in [error_msg, invalid_path])

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -3555,6 +3555,28 @@ def test_resolve_pip_incompatible(mock_metadata, tmp_path):
         pip.resolve_pip(tmp_path, request)
 
 
+@mock.patch("cachito.workers.pkg_managers.pip.get_pip_metadata")
+def test_resolve_pip_invalid_req_file_path(mock_metadata, tmp_path):
+    mock_metadata.return_value = ("foo", "1.0")
+    request = {"id": 1}
+    invalid_path = "/foo/bar.txt"
+    expected_error = f"Following requirement file has an invalid path: {invalid_path}"
+    requirement_files = [invalid_path]
+    with pytest.raises(CachitoError, match=expected_error):
+        pip.resolve_pip(tmp_path, request, requirement_files, None)
+
+
+@mock.patch("cachito.workers.pkg_managers.pip.get_pip_metadata")
+def test_resolve_pip_invalid_bld_req_file_path(mock_metadata, tmp_path):
+    mock_metadata.return_value = ("foo", "1.0")
+    request = {"id": 1}
+    invalid_path = "/foo/bar.txt"
+    expected_error = f"Following requirement file has an invalid path: {invalid_path}"
+    build_requirement_files = [invalid_path]
+    with pytest.raises(CachitoError, match=expected_error):
+        pip.resolve_pip(tmp_path, request, None, build_requirement_files)
+
+
 @pytest.mark.parametrize("custom_requirements", [True, False])
 @mock.patch("cachito.workers.pkg_managers.pip.upload_pypi_package")
 @mock.patch("cachito.workers.pkg_managers.pip.get_pip_metadata")


### PR DESCRIPTION
CLOUDBLD-3026

Signed-off-by: Sumin Cho <sucho@redhat.com>

### Problem
When users would provide an invalid path into the **requirements.txt** file, the Cachito request would provide an obscure error message, "_An unknown error occurred_". 

### Solution
In **cachito/workers/pkg_managers/pip.py**, I added a block of code in the function `resolve_pip` that checks each value in `requirement_files` and `build_requirement_files` to see if each file path exists in the repository. If it does not, the function raises an error with a specific message stating that the file path is not valid. In turn, the Cachito request should contain an enhanced error message for its `state_reason`.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
