### PR TITLE
Change passenv variable in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -89,4 +89,4 @@ commands =
     pytest -rA -vvvv \
         --confcutdir=tests/integration \
         {posargs:tests/integration}
-passenv = KRB5CCNAME REQUESTS_CA_BUNDLE KRB5_CLIENT_KTNAME CACHITO_TEST_CERT CACHITO_TEST_KEY JOB_NAME
+passenv = KRB5CCNAME, REQUESTS_CA_BUNDLE, KRB5_CLIENT_KTNAME, CACHITO_TEST_CERT, CACHITO_TEST_KEY, JOB_NAME


### PR DESCRIPTION
Tox introduced breaking feauture in v4. We have to use comma as value separator instead of whitespace.
https://tox.wiki/en/4.0.3/faq.html#tox-4-changed-ini-rules

Signed-off-by: ejegrova <ejegrova@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
