### PR TITLE
docs: pip: Add a warning note referencing pybuild-deps as a project

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -160,6 +160,11 @@ There are two implications which may not be immediately obvious for build requir
    (recursively)
 2. you need to repeat the above for _all_ your recursive runtime dependencies
 
+> :warning: NOTE that the information that follows on finding build dependencies is deprecated and
+> is only listed for historical records as this project is planned to be sunset and archived in the
+> near future. **Please use [pybuild-deps](https://github.com/hermetoproject/pybuild-deps) and follow
+> the instructions there instead.**
+
 You can use the [pip_find_builddeps.py](../bin/pip_find_builddeps.py) script to find all the build
 dependencies you will need. Here is how you would use it:
 


### PR DESCRIPTION
The current way of dealing with pip's build dependencies should be handled by the pybuild-deps project hosted under the Hermeto github organization going forward. Make this clear in the docs for the time being until we officially sunset the cachito project.

Resolves https://github.com/containerbuildsystem/cachito/issues/1071

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
